### PR TITLE
Align service dependencies and redact health config

### DIFF
--- a/apps/racemanager/service/config.py
+++ b/apps/racemanager/service/config.py
@@ -22,6 +22,8 @@ class Settings:
         race_db_name: Optional[str] = None,
         laps_collection: Optional[str] = None,
         websocket_public_url: Optional[str] = None,
+        http_host: Optional[str] = None,
+        http_port: Optional[int] = None,
     ) -> None:
         self.atlas_uri = atlas_uri or os.getenv(
             "ATLAS_URI", "mongodb://localhost:27017"
@@ -31,14 +33,21 @@ class Settings:
             "LAPS_COLLECTION", "laps_live"
         )
         self.websocket_public_url = websocket_public_url or os.getenv("WS_PUBLIC_URL")
+        self.http_host = http_host or os.getenv("HTTP_HOST", "0.0.0.0")
+        self.http_port = http_port or int(os.getenv("HTTP_PORT", "4000"))
 
-    def dict(self) -> dict[str, Optional[str]]:
-        return {
+    def dict(self, *, include_sensitive: bool = True) -> dict[str, Optional[str | int]]:
+        config = {
             "atlas_uri": self.atlas_uri,
             "race_db_name": self.race_db_name,
             "laps_collection": self.laps_collection,
             "websocket_public_url": self.websocket_public_url,
+            "http_host": self.http_host,
+            "http_port": self.http_port,
         }
+        if not include_sensitive:
+            config["atlas_uri"] = "<redacted>"
+        return config
 
 
 @lru_cache(maxsize=1)

--- a/apps/racemanager/service/main.py
+++ b/apps/racemanager/service/main.py
@@ -42,7 +42,9 @@ repo_provider = RepoProvider()
 
 @app.get("/health")
 def health(settings: Annotated[Settings, Depends(get_settings)]) -> JSONResponse:
-    return JSONResponse({"status": "ok", "config": settings.dict()})
+    return JSONResponse(
+        {"status": "ok", "config": settings.dict(include_sensitive=False)}
+    )
 
 
 @app.post("/ingest/lap", response_model=LapResponse)

--- a/apps/racemanager/service/requirements.txt
+++ b/apps/racemanager/service/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.115.6
-uvicorn==0.32.1
+fastapi==0.99.1
+uvicorn==0.23.2
 pydantic==1.10.19
 pymongo==4.10.1


### PR DESCRIPTION
## Summary
- align race manager service dependencies so FastAPI and Pydantic versions are compatible
- redact Atlas connection details from the health endpoint response to avoid leaking secrets

## Testing
- make test (fails: colcon not installed)
- pre-commit run --files apps/racemanager/service/requirements.txt apps/racemanager/service/config.py apps/racemanager/service/main.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c89a50c883239672e3b447a24fc7)