### PR TITLE
Handle lap timestamp serialization in bridge

### DIFF
--- a/apps/racemanager/bridge/bridge.py
+++ b/apps/racemanager/bridge/bridge.py
@@ -41,6 +41,7 @@ class LapEvent:
         base = asdict(self)
         for key in ["onTrack", "directionOk", "minLapTimeOk"]:
             base.pop(key)
+        base["timestamp"] = self.timestamp.isoformat()
         base["validity"] = validity
         return base
 


### PR DESCRIPTION
## Summary
- serialize lap event timestamps to ISO strings before constructing the HTTP payload to avoid JSON encoding errors

## Testing
- make test (fails: colcon not installed)
- pre-commit run --files apps/racemanager/bridge/bridge.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fefd5c0c8323a447730275e0e46d)