### PR TITLE
Docs/tooling: switch to ROS 2 Kilted Kaiju source-build workflow, expand Race Manager docs, and add run_racemanager.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 - Simulation at scale (Isaac Sim, Gym)
 
 ## Architecture
-- **ROS 2 Iron** baseline
+- **ROS 2 Kilted Kaiju** baseline (source-build workflow)
 - NVIDIA Isaac Sim ≥ 2023.x
-- OAK-D depth vision, MoveIt 2 (Iron)
+- OAK-D depth vision, MoveIt 2 (Kilted)
 - FaceRig + QuirkPolicy
 - Safety systems in hardware + software
 
@@ -26,10 +26,9 @@
 ## Quick start
 **Codespaces is CPU-only**; for docs/CI. Use local GPU or GPU VM for Isaac Sim.
 
-Install ROS 2 Iron and source the environment:
+Install ROS 2 Kilted Kaiju from source and source your workspace overlay:
 ```bash
-# follow https://docs.ros.org/en/iron/Installation.html
-source /opt/ros/iron/setup.bash
+# after building your ROS 2 + j5 workspace from source
 source ~/j5/ros_ws/install/setup.bash
 
 ```
@@ -45,7 +44,7 @@ Launch the robot:
 ros2 launch j5_bringup bringup.launch.py
 ```
 If `ros2` or bringup packages are not found, verify:
-- You're running **Ubuntu 22.04** (required for ROS 2 Iron).
+- You're running a ROS 2 Kilted-supported Linux distro.
 - All packages are built for ROS 2 (mixing ROS 1 can break discovery).
 - Your environment includes the workspace:
   ```bash
@@ -55,8 +54,484 @@ If `ros2` or bringup packages are not found, verify:
   ```
 Re-run the `source` commands above after any changes.
 
+If `ros2` is still missing, your source build likely did not finish. Rebuild the workspace (`colcon build`) and source `.../ros_ws/install/setup.bash` in every shell before launching.
+
+#### Source-build troubleshooting (`catkin_pkg`, `ament_cmake`, wrong Python)
+If your `colcon build` fails with errors like:
+- `ModuleNotFoundError: No module named 'catkin_pkg'`
+- `Could not find a package configuration file provided by "ament_cmake"`
+- `execute_process(.../venv/bin/python3 ... package_xml_2_cmake.py ...)`
+
+then one (or more) of these is happening:
+1. ROS is building with an app virtualenv Python instead of system Python.
+2. `catkin_pkg` is missing from system Python.
+3. Your J5 workspace is building without the ROS 2 underlay sourced (so `ament_cmake` is unknown).
+
+Recommended fix sequence:
+
+Known-good command for both underlay and overlay builds:
+```bash
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+```
+
+If you occasionally see:
+```
+CMake Warning: Manually-specified variables were not used by the project:
+  Python3_EXECUTABLE
+```
+that warning can be benign for packages that do not query Python at configure-time. Treat it as actionable only when a traceback still shows the wrong interpreter (for example `.../venv/bin/python3`).
+
+```bash
+# 1) use a fresh shell, and ensure no app venv is active
+deactivate 2>/dev/null || true
+unset VIRTUAL_ENV
+unset PYTHONPATH
+
+# 2) clear stale overlay/underlay prefixes from previous failed builds
+unset AMENT_PREFIX_PATH
+unset CMAKE_PREFIX_PATH
+unset COLCON_CURRENT_PREFIX
+
+# 3) force system python for colcon/cmake python hooks
+export COLCON_PYTHON_EXECUTABLE=/usr/bin/python3
+export Python3_EXECUTABLE=/usr/bin/python3
+
+# 4) install required ROS python dependency
+sudo apt update
+sudo apt install -y python3-catkin-pkg
+
+# 5) source your ROS 2 core underlay (built from source)
+# example path - adjust if your ros2 source workspace is elsewhere
+source ~/ros2_kilted/install/setup.bash
+
+# 6) rebuild j5 workspace as overlay
+cd ~/j5/ros_ws
+rm -rf build install log
+colcon build --symlink-install
+source install/setup.bash
+```
+
+If you are testing Clang, keep in mind this only changes compilers; it does not fix missing underlay packages:
+```bash
+export CC=clang
+export CXX=clang++
+colcon build --cmake-force-configure
+```
+
+
+Based on your diagnostics, Python is now correct (`/usr/bin/python3`) and `catkin_pkg` imports successfully, so the remaining blocker is likely an incomplete ROS 2 underlay (no `ament_cmake` in the sourced prefixes).
+
+Also, warnings about missing paths in `AMENT_PREFIX_PATH`/`CMAKE_PREFIX_PATH` mean stale environment values from previous overlays are still set; clear them before building the underlay.
+
+Use this underlay bootstrap flow in `~/ros2_kilted`:
+```bash
+cd ~/ros2_kilted
+# ensure command spelling is symlink, not simlink
+colcon build --symlink-install --packages-up-to ament_cmake
+source install/setup.bash
+
+# then finish the full underlay build
+colcon build --symlink-install
+source install/setup.bash
+
+# verify ament_cmake is now discoverable
+echo $CMAKE_PREFIX_PATH | tr ':' '\n' | rg ament_cmake || true
+```
+
+Then rebuild the J5 overlay:
+```bash
+cd ~/j5/ros_ws
+rm -rf build install log
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
+
+Because CMake caches the interpreter path, if you ever configured in a venv you must clean the ROS underlay build cache before retrying:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
+If it still fails, capture these diagnostics from the same shell:
+```bash
+which python3
+python3 -c "import sys; print(sys.executable)"
+python3 -c "import catkin_pkg; print(catkin_pkg.__file__)"
+echo $COLCON_PYTHON_EXECUTABLE
+echo $PYTHONPATH
+echo $AMENT_PREFIX_PATH
+echo $CMAKE_PREFIX_PATH
+echo $COLCON_CURRENT_PREFIX
+```
+
+#### Build failure: `rmw_zenoh_cpp` (zenoh + `std::optional` template error)
+If your build fails in `rmw_zenoh_cpp` with errors like:
+- `std::optional<zenoh::CancellationToken>`
+- `explicitly-defaulted copy constructor ... requires it to be non-const`
+
+this is usually a **toolchain/vendor compatibility issue** in the zenoh RMW path, not a core J5 package issue.
+
+For now, unless you specifically need zenoh middleware, continue with one of these:
+
+```bash
+# Option A: skip zenoh RMW package while building ROS 2 source workspace
+colcon build --symlink-install --packages-skip rmw_zenoh_cpp
+
+# Option B: build only the RMW you intend to run (example: Fast DDS)
+colcon build --symlink-install --packages-select rmw_fastrtps_cpp
+```
+
+After build, pin middleware explicitly in runtime shells:
+```bash
+export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+# or: export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+
+If sourcing fails with a message like:
+```
+not found: ".../install/rmw_zenoh_cpp/share/rmw_zenoh_cpp/local_setup.bash"
+```
+it means your `install/` tree still contains stale environment hooks from a prior failed build.
+
+Use this recovery flow in the ROS 2 underlay workspace:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-skip rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+
+# use setup.bash for normal shell setup
+source install/setup.bash
+command -v ros2
+```
+
+Use `install/setup.bash` for regular use. `install/local_setup.bash` is intended for layering on top of an existing environment and is less forgiving when the install tree is inconsistent.
+After underlay builds, source `install/setup.bash` before checking `ros2`; using only `local_setup.bash` may not populate your PATH as expected in broken/partial environments.
+
+If you do need zenoh, treat it as a separate follow-up: test compiler/version combinations and/or newer zenoh vendor revisions in a clean workspace.
+
+#### Interpreting `colcon` summary with many stderr lines
+If you see a summary like:
+- `1 package failed: rmw_zenoh_cpp`
+- several packages `aborted`
+- many packages with `stderr output`
+
+this is usually not “many independent failures.” In your case:
+- `rmw_zenoh_cpp` is the root failure,
+- downstream packages (for example `fastdds`, `sensor_msgs`, `tf2_msgs`) may abort because the build graph was interrupted,
+- many `ament_*` packages emit non-fatal warnings to stderr during checks.
+
+
+If `rmw_implementation` fails while skipping zenoh with errors about missing `rmw_zenoh_cpp/package.sh`, use dependency-based skipping instead of skipping only one package:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-skip-by-dep rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+`--packages-skip-by-dep` excludes packages that depend on zenoh (including `rmw_implementation` in this failure mode), which prevents dangling references in the generated setup files.
+
+To continue without zenoh and unblock the rest of the workspace:
+```bash
+cd ~/ros2_kilted
+colcon build --symlink-install   --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
+Then rebuild your J5 overlay:
+```bash
+cd ~/j5/ros_ws
+colcon build --symlink-install   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
+Optional (to see all failures in one pass):
+```bash
+colcon build --symlink-install --continue-on-error
+```
+
+
+If `rmw_zenoh_cpp` fails with a C++ error around:
+- `std::optional<zenoh::CancellationToken>`
+- GCC 13 `optional` copy-constructor notes
+
+this matches the known zenoh/rmw compatibility issue on some toolchains (especially aarch64 + newer libstdc++). Prefer skipping zenoh for now:
+
+To avoid spending ~40+ minutes building zenoh vendor only to fail later in `rmw_zenoh_cpp`, apply the skip flag on the **first** full build attempt:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-skip rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+```
+
+After build, set runtime middleware explicitly away from zenoh:
+```bash
+export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+# or: export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-skip rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
+`vcs` / `rosdep` `pkg_resources is deprecated` warnings are informational; they are not the root failure in this trace.
+
+If core interface packages (e.g. `geometry_msgs`, `example_interfaces`) abort after `rmw_zenoh_cpp` fails, treat this as fallout from the first failure and rebuild underlay clean with zenoh skipped-by-dependency:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-skip rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
+If many packages remain "not processed", re-run once after cleanup (same command) to complete the graph.
+
+Even if `zenoh_cpp_vendor` finished successfully, a subsequent `rmw_zenoh_cpp` compile failure with the GCC13 `std::optional<zenoh::CancellationToken>` signature is still the primary blocker.
+
+When summary looks like:
+- `1 package failed: rmw_zenoh_cpp`
+- `fastdds`/`geometry_msgs` aborted
+- only a few packages not processed
+
+use this exact recovery loop:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-skip rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+
+# run once more to process packages that were previously not processed
+colcon build --symlink-install \
+  --packages-skip rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+
+source install/setup.bash
+```
+
+
+#### Interpreting warnings after a successful J5 overlay build
+If your build ends with `Summary: 9 packages finished` and only `stderr output` warnings (no failed packages), this is generally healthy.
+
+From your reported output:
+- Missing-path warnings in `AMENT_PREFIX_PATH` / `CMAKE_PREFIX_PATH` at build start are typically stale values from prior shells.
+- `CATKIN_INSTALL_INTO_PREFIX_ROOT` / `CATKIN_SYMLINK_INSTALL` "not used" warnings are usually benign when packages are pure CMake/ament and do not consume catkin-specific vars.
+- `setuptools ... Unbuilt egg for pytest-repeat` is a common distro Python warning and not a hard build failure.
+
+Recommended cleanup before builds:
+```bash
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+```
+
+Quick success criteria:
+- No `Failed <<< ...` lines
+- `Summary:` reports all targeted packages finished
+- `source ~/j5/ros_ws/install/setup.bash && command -v ros2` works
+
+
+If `command -v ros2` is still empty after `source ~/j5/ros_ws/install/setup.bash`, your overlay was sourced without a ROS 2 underlay in that shell.
+Source both, in order:
+```bash
+source ~/ros2_kilted/install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+command -v ros2
+```
+
+If `command -v ros2` is still empty even after sourcing underlay + overlay, the ROS underlay likely does not contain the `ros2` CLI yet (for example, `ros2cli` package not built/installed), or your install tree is using isolated layout where `install/bin/` may not exist.
+
+Check directly:
+```bash
+find ~/ros2_kilted/install -type f -path "*/bin/ros2" | head -n 1
+```
+
+If this command returns nothing, your underlay did not build/install `ros2cli`.
+Confirm the package exists in source and rebuild CLI targets:
+```bash
+cd ~/ros2_kilted
+colcon list | rg '^ros2cli\b'
+
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp \
+  --packages-skip-by-dep rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+If `colcon list | rg '^ros2cli\b'` prints nothing, your source checkout is incomplete; re-import the official ROS 2 kilted `.repos` file and rebuild.
+If that command *does* print `ros2cli` but `find ... '*/bin/ros2'` is still empty, then ros2cli exists in source but was not installed successfully.
+Using `--packages-select` for `ros2cli` can fail in partially-built workspaces because required dependencies are not built.
+Build with `--packages-up-to` from a clean workspace instead:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp \
+  --packages-skip-by-dep rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+find ~/ros2_kilted/install -type f -path '*/ros2cli*/bin/ros2' -o -path '*/bin/ros2' | head -n 5
+source install/setup.bash
+command -v ros2
+```
+
+Then re-source your overlay:
+```bash
+source ~/j5/ros_ws/install/setup.bash
+command -v ros2
+```
+
+If a `ros2` binary exists in the install tree but `command -v ros2` is still empty, inspect and repair PATH in that shell:
+```bash
+echo "$PATH"
+ROS2_BIN="$(find ~/ros2_kilted/install -type f -path '*/bin/ros2' | head -n 1)"
+export PATH="$(dirname "$ROS2_BIN"):$PATH"
+command -v ros2
+```
+
+Also verify setup scripts are not exiting early:
+```bash
+set -x
+source ~/ros2_kilted/install/setup.bash
+set +x
+```
+
+#### rosdep: `Cannot locate rosdep definition for [ament_python]`
+If `rosdep install` reports unresolved `ament_python` for J5 overlay packages:
+
+```text
+j5_voice: Cannot locate rosdep definition for [ament_python]
+j5_bringup: Cannot locate rosdep definition for [ament_python]
+```
+
+use this sequence (note `--from-paths`, not `--from`):
+```bash
+sudo rosdep init 2>/dev/null || true
+rosdep update
+
+# source underlay first so core ROS packages are present in environment
+source ~/ros2_kilted/install/setup.bash
+
+cd ~/j5/ros_ws
+rosdep install --from-paths src --ignore-src -r -y --rosdistro kilted --skip-keys "ament_python"
+```
+
+Why this works:
+- `ament_python` is provided by ROS underlay packages, not a system apt key in many source-build setups.
+- `--skip-keys "ament_python"` prevents rosdep from trying to resolve it as an OS package.
+
+The `pkg_resources is deprecated` warning from `/usr/bin/rosdep` is informational and not the failure cause.
+
+#### `AMENT_PREFIX_PATH` / `CMAKE_PREFIX_PATH` are empty or unset
+This is not automatically a failure. In a fresh shell before sourcing ROS setup files, these variables are often empty.
+
+Use this minimal sanity flow:
+```bash
+# fresh shell
+echo "$AMENT_PREFIX_PATH"
+echo "$CMAKE_PREFIX_PATH"
+
+# source underlay first, then overlay
+source ~/ros2_kilted/install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+
+# now re-check
+command -v ros2
+echo "$AMENT_PREFIX_PATH"
+echo "$CMAKE_PREFIX_PATH"
+```
+
+If they are still empty after sourcing:
+1. Underlay `install/` may be incomplete.
+2. `setup.bash` may not exist at the path you sourced.
+3. Shell may be running in a restricted/non-bash context.
+
+For reliable source builds on constrained SBCs (Pi), use this pattern:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install   --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
 ### Development
 Run `make lint` to format and `make test` to run tests.
+
+
+
+### Working over SSH (multiple shells)
+Yes — the simplest approach is to open multiple SSH sessions (multiple terminal windows/tabs) to the same host.
+
+Recommended split:
+- Shell 1: backend (`uvicorn` or launcher script).
+- Shell 2: frontend (`npm run dev`) if running manually.
+- Shell 3: ROS 2 bridge/tests (`bridge.py`, `ros2 topic pub`, logs).
+
+If you prefer one SSH login, use `tmux` and split panes/windows.
+
+
+### SSH-only network changes (finding Pi IP on a new network)
+If your Pi is headless and only reachable by SSH, avoid relying on password-login as your recovery plan.
+Keep key-based SSH enabled and use one or more of these approaches:
+
+1. **Use a stable hostname + mDNS**
+   - Set hostname once (example): `sudo hostnamectl set-hostname racetime-pi`
+   - Connect with: `ssh <user>@racetime-pi.local` (works on most home LANs with mDNS).
+
+2. **Reserve DHCP lease in router**
+   - In your router UI, bind the Pi MAC address to a fixed IP.
+   - Then SSH always uses that fixed IP.
+
+3. **Check IP from active SSH session before moving networks**
+   - `hostname -I`
+   - `ip -4 addr show`
+
+4. **Reconfigure Wi-Fi/network from SSH with NetworkManager (`nmcli`)**
+   ```bash
+   nmcli dev wifi list
+   nmcli dev wifi connect "<SSID>" password "<PASSWORD>"
+   nmcli con show --active
+   ip -4 addr show
+   ```
+
+5. **Last-resort emergency access**
+   - Keep a serial console/HDMI fallback if possible for first-boot or bad network configs.
+   - Prefer this over permanently enabling password SSH auth.
+
+If you must temporarily enable password auth for recovery, revert it immediately after access is restored:
+- Set `PasswordAuthentication no` in `/etc/ssh/sshd_config`, then `sudo systemctl reload ssh`.
+
+### Headless Raspberry Pi launch (backend + frontend + bridge)
+Use the helper script from repo root:
+
+```bash
+# standalone mode (no ROS 2 on host yet)
+./scripts/run_racemanager.sh --mode standalone --host 0.0.0.0 --pi-ip <pi-lan-ip>
+
+# ROS 2 mode (expects a completed source build + install/setup.bash)
+./scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip>
+```
+
+From another device on your network, open `http://<pi-lan-ip>:3000`.
 
 
 ## Roadmap
@@ -72,7 +547,7 @@ This section describes a **minimum viable hardware + software setup** for runnin
 ### 1) Shopping list (simplest practical build)
 
 #### Core compute + IO
-- Mini PC with Ubuntu 22.04 (Intel N100/N200 class or better, 8 GB RAM, 256 GB SSD).
+- Mini PC with Ubuntu 24.04 or newer (Intel N100/N200 class or better, 8 GB RAM, 256 GB SSD).
 - 12 V / 5 A power supply for the mini PC (or OEM PSU).
 - USB 3.0 hub (powered) for stable camera + peripheral connectivity.
 

--- a/apps/racemanager/README.md
+++ b/apps/racemanager/README.md
@@ -69,6 +69,46 @@ Expose per-car aggregates that the UI can bind to existing proof-of-concept fiel
 - **ROS-side testing without hardware**: feed recorded lap messages through the bridge (bag replay) and confirm the UI updates instantly.
 - **Perception regression testing**: point the bridge replay runner to a prerecorded MP4; forward the resulting laps with `source="replay"`/`replayId` so the service/UI can compare them against live runs.
 
+### MP4 replay ingestion on Raspberry Pi 5 (copy/paste commands)
+
+1. Copy an MP4 from another machine to the Pi:
+   ```bash
+   scp /path/to/session_2026-02-25.mp4 racetime@<pi5-ip>:~/j5/replays/
+   ```
+
+2. Or sync a whole replay folder from another machine:
+   ```bash
+   rsync -avP /path/to/replay_folder/ racetime@<pi5-ip>:~/j5/replays/
+   ```
+
+3. Or copy from a USB stick plugged into the Pi:
+   ```bash
+   mkdir -p ~/usb ~/j5/replays
+   sudo mount /dev/sda1 ~/usb
+   cp ~/usb/session_2026-02-25.mp4 ~/j5/replays/
+   sudo umount ~/usb
+   ```
+
+4. Run your lap extractor against the MP4 and emit JSON lines (one lap per line):
+   ```bash
+   python /path/to/your_lap_extractor.py \
+     --video ~/j5/replays/session_2026-02-25.mp4 \
+     --race-id demo-race \
+     --replay-id pi5-session-2026-02-25 \
+     > /tmp/replay_laps.jsonl
+   ```
+
+5. Ingest replay laps into the Race Manager service via the bridge:
+   ```bash
+   cat /tmp/replay_laps.jsonl | python apps/racemanager/bridge/bridge.py --mode stdin --service-url http://localhost:4000
+   ```
+
+6. Optional quick smoke test without a real extractor (single replay lap):
+   ```bash
+   printf '%s\n' '{"raceId":"demo-race","carId":"car-7","sessionLap":1,"lapTimeMs":70234,"trackDistanceM":350.0,"source":"replay","replayId":"pi5-manual-test","validity":{"onTrack":true,"directionOk":true,"minLapTimeOk":true}}' \
+   | python apps/racemanager/bridge/bridge.py --mode stdin --service-url http://localhost:4000
+   ```
+
 ## Pushing the `race-manager` branch to GitHub
 If the branch was recreated locally and you need to publish it to your GitHub fork or the upstream origin, do the following from the repo root:
 
@@ -107,16 +147,22 @@ single mini PC with only a USB camera and add ROS later.
    curl http://localhost:4000/races/demo-race/leaderboard
    ```
 
-### ROS 2 mode (when available)
-1. Source ROS 2:
+### ROS 2 mode (source-build workflow)
+1. Build and source your ROS 2 workspace from source:
    ```bash
-   source /opt/ros/iron/setup.bash
+   cd ~/j5/ros_ws
+   colcon build --symlink-install
+   source ~/j5/ros_ws/install/setup.bash
    ```
-2. Run bridge subscriber:
+2. Verify CLI exists in this shell:
+   ```bash
+   command -v ros2
+   ```
+3. Run bridge subscriber:
    ```bash
    python apps/racemanager/bridge/bridge.py --mode ros2 --topic /race/lap_event
    ```
-3. Publish JSON lap event on topic for smoke test:
+4. Publish JSON lap event on topic for smoke test:
    ```bash
    ros2 topic pub /race/lap_event std_msgs/msg/String '{data: "{\"raceId\":\"demo-race\",\"carId\":\"car-7\",\"sessionLap\":1,\"lapTimeMs\":70000,\"trackDistanceM\":350.0,\"validity\":{\"onTrack\":true,\"directionOk\":true,\"minLapTimeOk\":true}}"}' --once
    ```
@@ -126,3 +172,157 @@ single mini PC with only a USB camera and add ROS later.
 - Service broadcasts:
   - `type="lap"` after each ingest
   - `type="leaderboard"` with recalculated standings
+
+
+## One-command launcher (headless/server friendly)
+
+Use `scripts/run_racemanager.sh` from the repo root to start backend + frontend and
+(optionally) the bridge in standalone/demo or ROS 2 mode.
+
+Examples:
+
+```bash
+# Standalone mode (no ROS 2), reachable from other devices
+./scripts/run_racemanager.sh --mode standalone --host 0.0.0.0 --pi-ip 192.168.1.50
+
+# ROS 2 mode (sources your workspace install/setup.bash)
+./scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip 192.168.1.50
+```
+
+The script prints browser URLs for local and LAN access (for example,
+`http://192.168.1.50:3000`) and sets:
+- `NEXT_PUBLIC_API_BASE=http://<pi-ip>:4000`
+- `NEXT_PUBLIC_WS_URL=ws://<pi-ip>:4000/ws`
+
+If ROS 2 is not installed system-wide, that is OK for this workflow. Build ROS 2 + dependencies from source, source your workspace `install/setup.bash`, then retry `--mode ros2`.
+
+
+### SSH and multiple shells
+- Yes, you can SSH in multiple times (multiple terminal windows/tabs).
+- Alternative: use `tmux` in one SSH session and split panes for service/UI/bridge logs.
+
+
+### ROS 2 build gotcha: app virtualenv, underlay, and `ament_cmake`
+If `colcon build` reports `No module named 'catkin_pkg'` or cannot find `ament_cmake`, use a fresh shell and run:
+
+Known-good build command:
+```bash
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+```
+
+If CMake warns that `Python3_EXECUTABLE` was not used, that warning is often benign for packages that do not use Python in configure steps. Focus on whether failures still reference `.../venv/bin/python3`.
+
+```bash
+deactivate 2>/dev/null || true
+unset VIRTUAL_ENV
+unset PYTHONPATH
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX
+export COLCON_PYTHON_EXECUTABLE=/usr/bin/python3
+export Python3_EXECUTABLE=/usr/bin/python3
+sudo apt update && sudo apt install -y python3-catkin-pkg
+
+# rebuild/source ROS 2 core underlay with explicit system python
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+
+# then build j5 overlay
+cd ~/j5/ros_ws
+rm -rf build install log
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
+`CC`/`CXX` (Clang) only selects the compiler; it does not replace missing underlay setup or missing Python deps.
+
+
+If diagnostics already show `/usr/bin/python3` and `catkin_pkg` works, but `ament_cmake` is still missing, your ROS 2 underlay build is incomplete. Bootstrap it first:
+
+```bash
+cd ~/ros2_kilted
+colcon build --symlink-install --packages-up-to ament_cmake
+source install/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+Then rebuild `~/j5/ros_ws` as the overlay.
+
+
+If you see warnings about missing paths in `AMENT_PREFIX_PATH` / `CMAKE_PREFIX_PATH`, those are stale values from a previous environment; clear them before running `colcon` as shown above.
+
+
+### Headless Pi on a new network (SSH-only)
+- Prefer SSH keys + hostname/mDNS (`<hostname>.local`) or DHCP reservation instead of re-enabling password auth long-term.
+- From any active SSH shell, get current address with `hostname -I` or `ip -4 addr show`.
+- To switch Wi-Fi over SSH (NetworkManager):
+  ```bash
+  nmcli dev wifi list
+  nmcli dev wifi connect "<SSID>" password "<PASSWORD>"
+  nmcli con show --active
+  ip -4 addr show
+  ```
+- If you temporarily turn on password login for recovery, disable it again immediately after restoring key-based access.
+
+
+If ROS underlay sourcing fails due to missing `rmw_zenoh_cpp` local setup scripts, rebuild `~/ros2_kilted` from clean (`rm -rf build install log`) with `--packages-skip rmw_zenoh_cpp`, then source `~/ros2_kilted/install/setup.bash` (not `local_setup.bash`) before launching in `--mode ros2`.
+
+
+If ROS underlay builds fail at `rmw_implementation` after skipping zenoh, rebuild with dependency-based skipping: `colcon build --symlink-install --packages-skip-by-dep rmw_zenoh_cpp --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3`, then source `~/ros2_kilted/install/setup.bash` and verify `command -v ros2`.
+
+
+If your J5 overlay build finishes all packages and only shows `stderr output` warnings (unused `CATKIN_*` vars, `pytest-repeat` egg warning), treat it as non-fatal unless there are actual `Failed <<<` entries.
+
+
+If `command -v ros2` is empty after sourcing `~/j5/ros_ws/install/setup.bash`, source your ROS underlay first (`source ~/ros2_kilted/install/setup.bash`), then source the J5 overlay again.
+
+
+If `command -v ros2` is still empty after sourcing underlay then overlay, verify underlay CLI binary exists (for example: `find ~/ros2_kilted/install -type f -path "*/bin/ros2" | head -n 1`). If missing, rebuild underlay with at least `ros2cli` before launching `--mode ros2`.
+
+
+If overlay rosdep install fails with `Cannot locate rosdep definition for [ament_python]`, source underlay first and run: `rosdep install --from-paths src --ignore-src -r -y --rosdistro kilted --skip-keys "ament_python"`.
+
+
+If a `ros2` binary exists under `~/ros2_kilted/install` (for example `*/bin/ros2`) but `command -v ros2` stays empty, prepend PATH manually before launching `--mode ros2`: `ROS2_BIN="$(find ~/ros2_kilted/install -type f -path '*/bin/ros2' | head -n 1)" && export PATH="$(dirname "$ROS2_BIN"):$PATH"`.
+
+
+If no `ros2` binary is found under `~/ros2_kilted/install`, verify underlay sources include `ros2cli` (`colcon list | rg '^ros2cli\b'`) and rebuild CLI targets before launching `--mode ros2`.
+
+
+If `colcon list | rg '^ros2cli\b'` returns `ros2cli` but no `ros2` binary appears under `~/ros2_kilted/install`, rebuild from clean using dependency-aware targets (`rm -rf build install log && colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp --packages-skip rmw_zenoh_cpp --packages-skip-by-dep rmw_zenoh_cpp`) before `--mode ros2`.
+
+
+If ROS underlay summary shows `rmw_zenoh_cpp` failed and core interfaces (`example_interfaces`, `geometry_msgs`) aborted, clean and rebuild underlay with `--packages-skip rmw_zenoh_cpp`, then source underlay again before `--mode ros2`.
+
+
+If `rmw_zenoh_cpp` fails with GCC 13 `std::optional<zenoh::CancellationToken>` errors, skip the zenoh RMW package for underlay builds and proceed with Fast DDS/CycloneDDS middleware for `--mode ros2` workflows.
+
+
+If `zenoh_cpp_vendor` builds but `rmw_zenoh_cpp` fails (GCC13 optional signature), skip the zenoh RMW package and rerun the same underlay build command once so previously not-processed packages complete before `--mode ros2`.
+
+
+To avoid long zenoh vendor compile time on affected toolchains, use `--packages-skip rmw_zenoh_cpp` from the first underlay build and export `RMW_IMPLEMENTATION=rmw_fastrtps_cpp` (or `rmw_cyclonedds_cpp`) before ROS-mode runs.
+
+
+If `AMENT_PREFIX_PATH` / `CMAKE_PREFIX_PATH` are empty, check them again only after sourcing underlay then overlay; empty values in a fresh shell are expected.
+
+
+### Copy-paste quick recovery (ROS 2 mode)
+```bash
+# 1) rebuild underlay (skip zenoh dependency chain)
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install   --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+
+# 2) rebuild J5 overlay
+cd ~/j5/ros_ws
+rm -rf build install log
+colcon build --symlink-install   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+
+# 3) verify ROS CLI and run launcher
+command -v ros2
+./scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip>
+```

--- a/apps/racemanager/ui/README.md
+++ b/apps/racemanager/ui/README.md
@@ -16,3 +16,12 @@ npm run dev
 ```
 
 Then open http://localhost:3000. Environment variables can be provided in a `.env.local` file.
+
+
+For headless servers (e.g., Raspberry Pi), bind dev server to all interfaces:
+
+```bash
+npm run dev -- --hostname 0.0.0.0 --port 3000
+```
+
+Then open `http://<pi-ip>:3000` from another device on the same network.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Getting started
 - For ROS 2 build steps, see below.
 
 ROS 2 on Windows (PowerShell)
-1) Ensure ROS 2 (Humble/Iron) is installed and added to your environment. In PowerShell:
+1) Ensure ROS 2 Kilted Kaiju is installed and added to your environment. In PowerShell:
    - `$env:ChocolateyInstall` should be set if you used Chocolatey.
    - Run the shortcut "ROS 2 <distro> > ROS 2 Developer PowerShell" or dot‑source the setup script.
 2) Build
@@ -24,3 +24,858 @@ ROS 2 on Windows (PowerShell)
    - `.\install\local_setup.ps1`
 3) Run demos
    - Placeholder until packages are implemented.
+
+
+ROS 2 source-build troubleshooting (Linux)
+
+### Run this first in a fresh shell
+```bash
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+export COLCON_PYTHON_EXECUTABLE=/usr/bin/python3
+export Python3_EXECUTABLE=/usr/bin/python3
+echo "$AMENT_PREFIX_PATH"
+echo "$CMAKE_PREFIX_PATH"
+echo "$COLCON_CURRENT_PREFIX"
+```
+
+### Fix `No module named catkin_pkg`
+```bash
+sudo apt update
+sudo apt install -y python3-catkin-pkg
+```
+
+### Build ROS 2 underlay (default command)
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+### If `ament_cmake` is missing, bootstrap it first
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --packages-up-to ament_cmake --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+```
+
+### If `rmw_zenoh_cpp` fails (GCC13 / zenoh optional-copy errors)
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+command -v ros2
+```
+
+### If `local_setup.bash` or `rmw_implementation` reports missing `rmw_zenoh_cpp/package.sh`
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --packages-skip-by-dep rmw_zenoh_cpp --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+### If `ros2` is missing after sourcing overlay
+```bash
+source ~/ros2_kilted/install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+command -v ros2
+```
+
+### If `command -v ros2` is still empty, rebuild CLI packages
+```bash
+cd ~/ros2_kilted
+colcon list | rg '^ros2cli\b'
+find ~/ros2_kilted/install -type f -path '*/bin/ros2' | head -n 5
+
+rm -rf build install log
+colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp --packages-skip rmw_zenoh_cpp --packages-skip-by-dep rmw_zenoh_cpp --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+If `ros2cli` fails with missing `install/rmw_zenoh_cpp/.../package.sh`, that means a skipped package is still being referenced by a dependent; use both `--packages-skip rmw_zenoh_cpp --packages-skip-by-dep rmw_zenoh_cpp` for ros2cli recovery so the failing package and its dependents are excluded.
+
+### If rosdep fails with `Cannot locate rosdep definition for [ament_python]`
+```bash
+sudo rosdep init 2>/dev/null || true
+rosdep update
+source ~/ros2_kilted/install/setup.bash
+cd ~/j5/ros_ws
+rosdep install --from-paths src --ignore-src -r -y --rosdistro kilted --skip-keys "ament_python"
+```
+
+### Optional PATH repair when `ros2` exists but is not on PATH
+```bash
+ROS2_BIN="$(find ~/ros2_kilted/install -type f -path '*/bin/ros2' | head -n 1)"
+export PATH="$(dirname "$ROS2_BIN"):$PATH"
+command -v ros2
+```
+
+### Quick log triage commands
+```bash
+rg 'Failed <<<' ~/ros2_kilted/log/latest_build/*
+rg 'Aborted <<<' ~/ros2_kilted/log/latest_build/*
+rg 'stderr output' ~/ros2_kilted/log/latest_build/*
+```
+
+
+## Copy-paste recovery sequences (Linux)
+
+### 1) Fresh shell + source order check
+```bash
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+source ~/ros2_kilted/install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+command -v ros2
+echo "$AMENT_PREFIX_PATH"
+echo "$CMAKE_PREFIX_PATH"
+```
+
+### 1b) Build-local ROS 2 path check (no system `/opt` fallback)
+```bash
+if ! command -v ros2 >/dev/null 2>&1; then
+  [ -f ~/ros2_kilted/install/setup.bash ] && source ~/ros2_kilted/install/setup.bash
+  [ -f ~/j5/ros_ws/install/setup.bash ] && source ~/j5/ros_ws/install/setup.bash
+fi
+command -v ros2 || true
+echo "$AMENT_PREFIX_PATH"
+echo "$CMAKE_PREFIX_PATH"
+echo "$COLCON_CURRENT_PREFIX"
+```
+
+Use the command above for source-build workflows; do not rely on `/opt/ros/...` or `~/alive/...` paths in this runbook.
+
+### 2) Build underlay while skipping zenoh dependency chain
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install   --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+```
+
+### 3) If ros2 CLI is still missing
+```bash
+cd ~/ros2_kilted
+colcon list | rg '^ros2cli\b'
+find ~/ros2_kilted/install -type f -path '*/bin/ros2' | head -n 5
+
+rm -rf build install log
+colcon build --symlink-install   --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp   --packages-skip rmw_zenoh_cpp   --packages-skip-by-dep rmw_zenoh_cpp   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+### 4) rosdep for J5 overlay (source-build context)
+```bash
+sudo rosdep init 2>/dev/null || true
+rosdep update
+source ~/ros2_kilted/install/setup.bash
+cd ~/j5/ros_ws
+rosdep install --from-paths src --ignore-src -r -y --rosdistro kilted --skip-keys "ament_python"
+```
+
+
+## ARM Ubuntu 24.04 source-build verification plan (step-by-step)
+
+Use this as a strict checklist on a fresh Pi 5 / ARM64 server install. Do not move to the next step until the current step's verification command succeeds.
+
+### Step 0: Host sanity (OS, arch, toolchain)
+```bash
+uname -a
+dpkg --print-architecture
+cat /etc/os-release
+python3 --version
+gcc --version
+g++ --version
+cmake --version
+```
+
+Expected:
+- `aarch64` / `arm64`
+- Ubuntu `24.04`
+- Python 3.12.x
+- GCC/G++ available
+
+### Step 1: Install base build + ROS tooling prerequisites
+```bash
+sudo apt update
+sudo apt install -y \
+  build-essential \
+  cmake \
+  git \
+  curl \
+  wget \
+  gnupg2 \
+  lsb-release \
+  locales \
+  software-properties-common \
+  python3-pip \
+  python3-venv \
+  python3-colcon-common-extensions \
+  python3-rosdep \
+  python3-vcstool \
+  python3-rosinstall-generator \
+  python3-catkin-pkg \
+  python3-empy \
+  python3-numpy \
+  python3-setuptools \
+  python3-pytest \
+  python3-pytest-repeat \
+  libasio-dev \
+  libtinyxml2-dev
+```
+
+Verify:
+```bash
+command -v colcon
+command -v vcs
+command -v rosdep
+python3 -c "import catkin_pkg, em, numpy, setuptools; print('python deps ok')"
+```
+
+### Step 2: Initialize rosdep metadata
+```bash
+sudo rosdep init 2>/dev/null || true
+rosdep update
+```
+
+Verify:
+```bash
+rosdep db > /tmp/rosdep-db.txt
+sed -n '1,8p' /tmp/rosdep-db.txt
+```
+
+### Step 3: Create clean ROS 2 source workspace
+```bash
+mkdir -p ~/ros2_kilted/src
+cd ~/ros2_kilted
+curl -L https://raw.githubusercontent.com/ros2/ros2/kilted/ros2.repos -o ros2.repos
+vcs import src < ros2.repos
+```
+
+Verify:
+```bash
+cd ~/ros2_kilted
+colcon list | rg '^ros2cli\b|^rclcpp\b|^ament_cmake\b' -n
+```
+
+### Step 4: Install source workspace system dependencies
+```bash
+cd ~/ros2_kilted
+rosdep install --from-paths src --ignore-src -r -y --rosdistro kilted
+```
+
+If one key is unresolved, verify and continue:
+```bash
+rosdep check --from-paths src --ignore-src --rosdistro kilted || true
+```
+
+Important: `rosdep install/check` only validates **system** dependencies. It does **not** build ROS packages and does not create `install/.../bin/ros2`.
+
+### Step 5: Clean environment before building
+```bash
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+export COLCON_PYTHON_EXECUTABLE=/usr/bin/python3
+export Python3_EXECUTABLE=/usr/bin/python3
+```
+
+Verify:
+```bash
+echo "$AMENT_PREFIX_PATH"
+echo "$CMAKE_PREFIX_PATH"
+echo "$COLCON_CURRENT_PREFIX"
+python3 -c "import sys; print(sys.executable)"
+```
+
+### Step 6: Build ROS 2 underlay (first attempt)
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+```
+
+If your log shows `Starting >>> rmw_zenoh_cpp` and then the GCC13 `std::optional<zenoh::CancellationToken>` error, the command above is working as expected and your compiler is not generally broken; this is the known zenoh/rmw incompatibility path on some ARM toolchains.
+
+If your command line does **not** include `--packages-skip rmw_zenoh_cpp`, colcon will still build `rmw_zenoh_cpp`.
+
+If this fails in `rmw_zenoh_cpp`, `rmw_test_fixture_implementation`, **or** `zenoh_security_tools`, use explicit skip package list:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools rmw_implementation \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+```
+
+Verify:
+```bash
+source ~/ros2_kilted/install/setup.bash
+command -v ros2
+find ~/ros2_kilted/install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+ros2 --help | head -n 5
+```
+
+If `command -v ros2` is empty but `find ... '*/ros2cli*/bin/ros2'` returns a path, run the binary directly to prove install success and then fix shell PATH/sourcing:
+```bash
+ROS2_BIN="$(find ~/ros2_kilted/install -type f -path '*/ros2cli*/bin/ros2' | head -n 1)"
+"$ROS2_BIN" --help | head -n 5
+export PATH="$(dirname "$ROS2_BIN"):$PATH"
+command -v ros2
+```
+
+If some packages were `Aborted` or `not processed`, immediately rerun the same command once more to complete packages that were blocked by the first failure:
+```bash
+cd ~/ros2_kilted
+colcon build --symlink-install \
+  --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools rmw_implementation \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+```
+
+If Summary shows `0 packages failed` but you skipped core runtime packages (for example `ros2cli`, `rclpy`, `rcl`, `pluginlib`), run a follow-up build that restores those packages and only excludes the zenoh dependency chain:
+```bash
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp \
+  --packages-skip-by-dep rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+Do not keep `ros2cli` in `--packages-skip` for final recovery builds; that prevents the `ros2` command from being installed.
+
+For ros2cli recovery runs, keep both flags together: `--packages-skip rmw_zenoh_cpp` skips the failing package itself, and `--packages-skip-by-dep rmw_zenoh_cpp` skips dependents that still reference it.
+
+If build Summary shows many `stderr output` packages but **no `Failed <<<` lines**, treat the build as successful and continue:
+```bash
+cd ~/ros2_kilted
+source install/setup.bash
+command -v ros2
+ros2 --help | head -n 5
+```
+
+For outputs like `Summary: 132 packages finished ... 33 packages had stderr output` with no failed package line, proceed to underlay sanity checks (this is not a build failure):
+```bash
+cd ~/ros2_kilted
+source install/setup.bash
+command -v ros2
+ros2 pkg list | rg '^ros2cli$|^rclcpp$' -n
+```
+
+If the summary matches the pattern above and `fastdds` / `rmw_fastrtps_*` finished, treat underlay build as complete and move to overlay build:
+```bash
+cd ~/j5/ros_ws
+source ~/ros2_kilted/install/setup.bash
+rosdep install --from-paths src --ignore-src -r -y --rosdistro kilted --skip-keys "ament_python"
+rm -rf build install log
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+If `source install/setup.bash` succeeds but `command -v ros2` is still empty, run this exact triage block:
+```bash
+cd ~/ros2_kilted
+colcon list | rg '^ros2cli\b'
+find install -type f -path '*/bin/ros2' | head -n 10
+echo "$AMENT_PREFIX_PATH"
+echo "$CMAKE_PREFIX_PATH"
+echo "$COLCON_CURRENT_PREFIX"
+```
+
+Interpretation for this triage block:
+- `colcon list | rg '^ros2cli\b'` only proves `ros2cli` exists in `src/`; it does **not** prove it was built/installed.
+- If `find install -type f -path '*/bin/ros2'` prints nothing, the CLI binary is not installed yet.
+- If `AMENT_PREFIX_PATH` / `CMAKE_PREFIX_PATH` already contain many overlay paths (for example `~/j5/ros_ws/install/...`) while building underlay, clear them before rebuilding underlay.
+- Repeated `WARNING:colcon.colcon_ros.prefix_path.ament:The path '.../install/<pkg>' ... doesn't exist`, `WARNING:colcon.colcon_ros.prefix_path.catkin:The path '.../install/<pkg>' ... doesn't exist`, or bare `AMENT_PREFIX_PATH doesn't exist` output all indicate stale prefix-path entries in the current shell.
+- This usually happens when `install/` was deleted (`rm -rf build install log`) in the same shell that previously sourced `install/setup.bash`.
+- Stale prefix entries can pollute dependency discovery and cause follow-on `ament_python` failures (for example while building `ros2cli`).
+
+To detect stale prefix entries quickly:
+```bash
+for var in AMENT_PREFIX_PATH CMAKE_PREFIX_PATH; do
+  echo "== $var =="
+  tr ':' '\n' <<< "${!var}" | sed '/^$/d'
+  tr ':' '\n' <<< "${!var}" | sed '/^$/d' | while read -r p; do
+    [ -d "$p" ] || echo "MISSING: $p"
+  done
+done
+```
+
+If warnings persist after `unset`, launch a clean build shell that strips inherited path variables before running colcon:
+```bash
+cd ~/ros2_kilted
+env -i HOME="$HOME" USER="$USER" SHELL=/bin/bash TERM="${TERM:-xterm}" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  /bin/bash --noprofile --norc -lc '
+    set -e
+    export COLCON_PYTHON_EXECUTABLE=/usr/bin/python3
+    rm -rf build install log
+    colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp --packages-skip rmw_zenoh_cpp --packages-skip-by-dep rmw_zenoh_cpp --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+    source install/setup.bash
+    command -v ros2
+  '
+```
+
+Important: `env -i ... /bin/bash -lc '...'` runs in a child shell. A successful `command -v ros2` inside that block verifies install artifacts, but it does **not** persist environment changes back to your current terminal. After it finishes, run:
+```bash
+cd ~/ros2_kilted
+source install/setup.bash
+command -v ros2
+```
+
+What your posted long build log means (important):
+- `Summary: 132 packages finished ...` and no `Failed <<<` line means the underlay build itself succeeded.
+- The repeated `setuptools ... Unbuilt egg for pytest-repeat` lines are warnings, not fatal errors.
+- The common reason for `ros2` still appearing missing after this exact `env -i` command is shell scope (child shell vs current shell), not package compile failure.
+
+Use this exact post-build proof in your current shell:
+```bash
+cd ~/ros2_kilted
+source install/setup.bash
+ROS2_BIN="$(find install -type f -path '*/bin/ros2' | head -n 1)"
+echo "ros2 bin: ${ROS2_BIN:-<not found>}"
+[ -n "$ROS2_BIN" ] && "$ROS2_BIN" --help | head -n 5
+command -v ros2
+```
+
+If `ROS2_BIN` is found but `command -v ros2` is still empty, your install is good and only PATH/sourcing is missing in the current shell.
+
+If `ROS2_BIN` is `<not found>` after sourcing, the issue is not shell PATH; `ros2` was never installed. Check whether `ros2cli` actually built:
+```bash
+cd ~/ros2_kilted
+rg '^(Finished|Failed) <<< ros2cli' log/latest_build/* || true
+colcon list --names-only   --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp   --packages-skip rmw_zenoh_cpp   --packages-skip-by-dep rmw_zenoh_cpp | rg '^ros2cli$' -n || true
+```
+
+Interpretation:
+- If `Finished <<< ros2cli` is missing, no `ros2` entrypoint can exist.
+- If the package-selection command does not print `ros2cli`, your skip set excluded it.
+
+If `rg '^(Finished|Failed) <<< ros2cli'` prints nothing, run these exact checks before rebuilding:
+```bash
+cd ~/ros2_kilted
+[ -d log/latest_build ] && rg -n '<<< ros2cli' log/latest_build/* || echo 'no latest_build logs yet'
+find install -type f -path '*/ros2cli*/package.sh' | head -n 5
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+```
+
+How to read these results:
+- `ros2cli` listed by `colcon list` only confirms source checkout, not build/install.
+- `install/.../ros2cli/package.sh` without `install/.../ros2cli/bin/ros2` means incomplete `ament_python` install step for ros2cli.
+- No `log/latest_build` evidence for ros2cli usually means ros2cli was never scheduled in the selected package set for that build invocation.
+- If you get `no latest_build logs yet`, either no completed `colcon build` has run since `log/` was cleaned, or `log/latest_build` is stale while `log/latest` now points to a `colcon list` run (`latest_list`).
+- If `install/ros2cli` exists while `log/latest_build/ros2cli/` is missing, reconcile with `logger_all.log`: an upstream failure (commonly `ament_cmake_ros`) can abort the graph before ros2cli runs in the *current* build, even though ros2cli artifacts may exist from an older successful build.
+
+When `log/latest_build` is missing or suspicious, run this fallback evidence block:
+```bash
+cd ~/ros2_kilted
+ls -la log || true
+readlink -f log/latest 2>/dev/null || true
+readlink -f log/latest_build 2>/dev/null || true
+[ -f log/latest_build/logger_all.log ] && rg -n 'Summary:|Failed <<<|Aborted <<<|<<< ros2cli' log/latest_build/logger_all.log || true
+```
+
+Note: running `colcon list` updates `log/latest` to `latest_list`, so `log/latest/*` may contain only list/debug metadata and no build/package completion data. For build diagnosis, prefer `log/latest_build/*` and especially `log/latest_build/logger_all.log`.
+
+This matches the Kilted source-build flow in the upstream ROS 2 docs: underlay build health must be restored first (ament/rcl layers), then CLI packages (`ros2cli`, `ros2run`, `ros2topic`) are expected to install. In short, treat missing `rcl*` package hooks as the primary blocker and `ros2cli` absence as downstream fallout.
+
+How to use `ros2cli/package.sh` correctly:
+- Do **not** execute `install/ros2cli/share/ros2cli/package.sh` directly as a command.
+- `package.sh` is an environment hook meant to be sourced by `install/setup.bash` / `install/local_setup.bash`.
+- Normal usage is:
+```bash
+cd ~/ros2_kilted
+source install/setup.bash
+command -v ros2
+ros2 --help | head -n 5
+```
+- If you need to debug just ros2cli's hook, source it (not execute it):
+```bash
+cd ~/ros2_kilted
+source install/ros2cli/share/ros2cli/package.sh
+command -v ros2
+```
+
+Recovery for this exact case (`ros2 bin: <not found>`): run a clean build that keeps `ros2cli` in scope and only skips known zenoh-problem packages:
+```bash
+cd ~/ros2_kilted
+env -i HOME="$HOME" USER="$USER" SHELL=/bin/bash TERM="${TERM:-xterm}" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin   /bin/bash --noprofile --norc -lc '
+    set -e
+    export COLCON_PYTHON_EXECUTABLE=/usr/bin/python3
+    rm -rf build install log
+    colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+    rg "^(Finished|Failed) <<< ros2cli" log/latest_build/* || true
+    find install -type f -path "*/ros2cli*/bin/ros2" | head -n 5
+  '
+```
+
+Then in your current shell:
+```bash
+cd ~/ros2_kilted
+source install/setup.bash
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+command -v ros2
+```
+
+Before starting another 50-minute rebuild, run this fast-fail preflight to prove `ros2cli` is in the selected package set:
+```bash
+cd ~/ros2_kilted
+colcon list --names-only   --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp   --packages-skip rmw_zenoh_cpp   --packages-skip-by-dep rmw_zenoh_cpp | rg '^ros2cli$|^ros2run$|^ros2topic$' -n
+```
+
+Interpretation:
+- If `ros2cli` is missing from this preflight output, the selection/skip combination has excluded it; a full rebuild will not install `ros2`.
+- In that case, remove `--packages-skip-by-dep rmw_zenoh_cpp` for the first pass and only keep `--packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation`, then re-check the selected set before building.
+- If `log/latest_build/logger_all.log` (or a known build log) shows `Skipping package 'ros2cli'` / `Skipping package 'ros2run'` / `Skipping package 'ros2topic'`, your current skip set has explicitly filtered out the CLI chain.
+
+To avoid blind loops, save a deterministic package-order log before each long build:
+```bash
+cd ~/ros2_kilted
+colcon list --topological-order --names-only > /tmp/colcon-topo-before-build.txt
+sed -n '1,120p' /tmp/colcon-topo-before-build.txt
+rg -n '^ros2cli$|^ros2run$|^ros2topic$' /tmp/colcon-topo-before-build.txt || true
+```
+
+Important: the first 120 lines are only a preview. `ros2cli` often appears later in large workspaces; always `rg '^ros2cli$' /tmp/colcon-topo-before-build.txt` before concluding it is missing.
+
+If `rg '^ros2cli$' /tmp/colcon-topo-before-build.txt` returns nothing, your current source graph does not include ros2cli in this workspace resolution (wrong branch/repos import or unexpected workspace contents), so `log/latest_build/ros2cli` will not exist for that build.
+
+If you are not using `env -i`, do this in a brand-new terminal before running `colcon`:
+```bash
+# 1) open a new shell (recommended)
+# 2) do NOT source ~/ros2_kilted/install/setup.bash before cleaning
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+export AMENT_PREFIX_PATH=""
+export CMAKE_PREFIX_PATH=""
+export COLCON_CURRENT_PREFIX=""
+cd ~/ros2_kilted
+rm -rf build install log
+colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp --packages-skip rmw_zenoh_cpp --packages-skip-by-dep rmw_zenoh_cpp --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+```
+
+Then rebuild CLI packages **without** skipping `ros2cli` and with zenoh dependency skipping only:
+```bash
+cd ~/ros2_kilted
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp \
+  --packages-skip-by-dep rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+Do **not** skip core ROS graph/runtime packages in this recovery path (for example: `rcl`, `rclpy`, `rcl_action`, `rcl_lifecycle`, `rcl_logging_*`, `pluginlib`, `class_loader`, `ros2cli`). Skipping these often creates new failures (for example `class_loader` failed, `lifecycle_msgs` aborted) and leaves the underlay incomplete.
+
+Common command mistakes to avoid:
+```bash
+# wrong: missing leading '--' before packages-skip-by-dep
+packages-skip-by-dep rmw_zenoh_cpp
+
+# correct
+--packages-skip-by-dep rmw_zenoh_cpp
+```
+
+If `command -v ros2` is still empty after that, verify ros2cli install artifacts directly:
+```bash
+find install -type f -path '*/ros2cli*/package.sh' | head -n 5
+find install -type f -path '*/bin/ros2' | head -n 10
+```
+
+`ros2cli` -> `ros2` mapping (what you should expect):
+- `ros2` is the console entrypoint installed by the `ros2cli` package (ament_python).
+- In non-merge installs, it usually lands at `~/ros2_kilted/install/ros2cli/bin/ros2`.
+- You do **not** manually build a separate `bin/ros2`; it appears automatically when `ros2cli` is successfully installed.
+
+Quick proof commands:
+```bash
+cd ~/ros2_kilted
+find install -type f -path '*/ros2cli*/package.sh' | head -n 5
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+find install -type f -path '*/bin/ros2' | head -n 10
+```
+
+If `ros2cli*/package.sh` exists but `ros2cli*/bin/ros2` does not, treat that as a failed/incomplete `ament_python` install and rebuild up-to ros2cli in a clean shell.
+
+If both commands print nothing, `ros2cli` is present in source but not installed in the current install tree. Run this exact recovery (single line command, no missing `--` prefixes):
+```bash
+cd ~/ros2_kilted
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+rm -rf build install log
+colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp --packages-skip rmw_zenoh_cpp --packages-skip-by-dep rmw_zenoh_cpp --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+find install -type f -path '*/bin/ros2' | head -n 10
+```
+
+If `find ... '*/bin/ros2'` finds a path but `command -v ros2` is still empty, export that bin dir and re-source:
+```bash
+ROS2_BIN="$(find ~/ros2_kilted/install -type f -path '*/bin/ros2' | head -n 1)"
+export PATH="$(dirname "$ROS2_BIN"):$PATH"
+source ~/ros2_kilted/install/setup.bash
+command -v ros2
+```
+
+If there are no `Failed <<<` lines and `command -v ros2` is still empty, run this focused sanity pass to confirm ros2cli dependencies are built and to show where `ros2` landed:
+```bash
+cd ~/ros2_kilted
+colcon list | rg '^ros2cli\b'
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp \
+  --packages-skip-by-dep rmw_zenoh_cpp \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+find install -type f -path '*/ros2cli*/package.sh' | head -n 5
+find install -type f -path '*/bin/ros2' | head -n 10
+```
+
+If `ros2` is still missing and you suspect `ros2cli` did not finish its install phase, run this focused debug pass (captures ros2cli stdout/stderr directly):
+```bash
+cd ~/ros2_kilted
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+rm -rf build install log
+colcon build --symlink-install   --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp   --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3   --event-handlers console_direct+
+```
+
+Immediately inspect ros2cli build/install evidence:
+```bash
+cd ~/ros2_kilted
+ls -la log/latest_build/ros2cli || true
+sed -n '1,220p' log/latest_build/ros2cli/stdout_stderr.log 2>/dev/null || true
+rg -n 'Traceback|ModuleNotFoundError|entry_points|Installing|Failed|ERROR' log/latest_build/ros2cli/* 2>/dev/null || true
+find install -type f -path '*/ros2cli*/package.sh' | head -n 5
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+```
+
+Interpretation for this debug pass:
+- If `log/latest_build/ros2cli/` does not exist, ros2cli was never scheduled in that build graph.
+- If ros2cli logs show Python traceback/module errors, fix those first (that is the reason `bin/ros2` is absent).
+- If ros2cli logs show success but `install/.../ros2cli/bin/ros2` is still absent, inspect install hooks:
+```bash
+source ~/ros2_kilted/install/setup.bash
+python3 -c "import importlib.util as iu; print('ros2cli module:', bool(iu.find_spec('ros2cli')))"
+```
+
+If your `install/` tree contains many packages (for example `builtin_interfaces`, `rcutils`, `rmw_*`) but **no `ros2cli/` directory at all**, treat that as a partial underlay where ros2cli and its chain were never installed.
+
+If your logs show many `-- Symlinking: .../install/<pkg>/...` lines (for example `action_msgs`, `ament_*`) that only proves those specific packages installed; it does **not** prove ros2cli ran.
+
+Before cleaning/restarting, check whether the previous build actually reached summary/completion:
+```bash
+cd ~/ros2_kilted
+rg -n 'Summary:|Failed <<<|Aborted <<<' log/latest_build/logger_all.log 2>/dev/null || true
+tail -n 40 log/latest_build/logger_all.log 2>/dev/null || true
+```
+
+Interpretation:
+- If `logger_all.log` has no `Summary:` line, the build was interrupted before completion (timeout/SSH drop/Ctrl-C).
+- In that case, resume first **without** deleting `build/ install/ log/`:
+```bash
+cd ~/ros2_kilted
+colcon build --symlink-install \
+  --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3 \
+  --event-handlers console_direct+
+```
+
+Run this exact proof block:
+```bash
+cd ~/ros2_kilted
+ls -d install/ros2cli 2>/dev/null || echo 'install/ros2cli missing'
+ls -d install/rcl install/rclpy install/rcl_action install/rcl_lifecycle 2>/dev/null || true
+colcon list --names-only --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp | rg '^ros2cli$|^rcl$|^rclpy$' -n || true
+```
+
+If `install/ros2cli` is missing, do not debug PATH yet; rebuild the ros2cli chain first:
+```bash
+cd ~/ros2_kilted
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3 \
+  --event-handlers console_direct+
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+```
+
+If your build summary shows this pattern instead:
+- `1 package failed: ros2cli`
+- aborted packages like `composition_interfaces`, `statistics_msgs`, `std_srvs`
+
+then inspect ros2cli's failure reason first (do not infer from aborted packages):
+```bash
+cd ~/ros2_kilted
+sed -n '1,220p' log/latest_build/ros2cli/stdout_stderr.log 2>/dev/null || true
+rg -n 'ERROR|Traceback|ModuleNotFoundError|Failed to find the following files|package.sh' log/latest_build/ros2cli/* 2>/dev/null || true
+```
+
+Most common cause in this scenario: missing dependency package scripts in install tree (for example `rmw_implementation`, `rcl`, `rclpy`), which means ros2cli was scheduled but its prerequisites were incomplete.
+
+Upstream dependency reconciliation (ros2cli repo vs ROS docs):
+- In `ros2/ros2cli`, the `ros2cli` package is `ament_python` and relies on the ROS client stack via `rclpy` and related `rcl*` runtime packages.
+- The official Kilted Ubuntu development setup builds a coherent underlay first, then uses `install/setup.bash`; it does not assume `ros2cli` can succeed if `rcl`, `rclpy`, `rcl_action`, `rcl_lifecycle`, `rcl_logging_interface`, `rcl_yaml_param_parser`, `rcl_logging_noop`, or `rcl_logging_spdlog` are missing from `install/`.
+- Therefore, if your missing set is exactly those `rcl*` packages, the discrepancy is underlay completeness, not a PATH-only problem.
+
+Use this prerequisite check before retrying ros2cli:
+```bash
+cd ~/ros2_kilted
+for p in rcl rclpy rcl_action rcl_lifecycle rcl_logging_interface rcl_yaml_param_parser rcl_logging_noop rcl_logging_spdlog; do
+  [ -f "install/$p/share/$p/package.sh" ] && echo "OK $p" || echo "MISSING $p"
+done
+```
+
+If any are missing, build prerequisites first, then ros2cli:
+```bash
+cd ~/ros2_kilted
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+rm -rf build install log
+colcon build --symlink-install   --packages-up-to rclpy rclcpp   --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools rmw_implementation   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3   --event-handlers console_direct+
+colcon build --symlink-install   --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp   --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools rmw_implementation   --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3   --event-handlers console_direct+
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+```
+
+If this two-stage command fails early with `1 package failed: ament_cmake_ros` (and aborts `std_msgs` / `lifecycle_msgs` / `composition_interfaces`), bootstrap ROS core CMake packages first, then resume:
+```bash
+cd ~/ros2_kilted
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+rm -rf build install log
+colcon build --symlink-install --packages-up-to ament_cmake_ros --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3 --event-handlers console_direct+
+sed -n '1,220p' log/latest_build/ament_cmake_ros/stdout_stderr.log 2>/dev/null || true
+rg -n 'ERROR|Traceback|ModuleNotFoundError|Failed|not found|package.sh' log/latest_build/ament_cmake_ros/* 2>/dev/null || true
+colcon build --symlink-install --packages-up-to rclpy rclcpp --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools rmw_implementation --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3 --event-handlers console_direct+
+colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools rmw_implementation --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3 --event-handlers console_direct+
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+```
+
+If `log/latest_build/ros2cli/` is empty but `ament_cmake_ros` failed, debug `ament_cmake_ros` first; ros2cli is downstream and will not produce logs until this underlay stage succeeds.
+
+Re-check the problematic set after this recovery:
+```bash
+for p in rcl rclpy rcl_action rcl_lifecycle rcl_logging_interface rcl_yaml_param_parser rcl_logging_noop rcl_logging_spdlog; do
+  [ -f "install/$p/share/$p/package.sh" ] && echo "OK $p" || echo "MISSING $p"
+done
+```
+
+Recovery command for this exact summary pattern:
+```bash
+cd ~/ros2_kilted
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_CURRENT_PREFIX PYTHONPATH VIRTUAL_ENV
+rm -rf build install log
+colcon build --symlink-install \
+  --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools rmw_implementation \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3 \
+  --event-handlers console_direct+
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+```
+
+If your build ends with this pattern:
+- `1 package failed: rmw_implementation`
+- aborted packages like `composition_interfaces`, `lifecycle_msgs`, `statistics_msgs`
+
+then rerun with `rmw_implementation` temporarily skipped so the CLI chain can finish, then verify `ros2` artifact creation:
+```bash
+cd ~/ros2_kilted
+colcon build --symlink-install \
+  --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp \
+  --packages-skip rmw_zenoh_cpp rmw_test_fixture_implementation zenoh_security_tools rmw_implementation \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3 \
+  --event-handlers console_direct+
+find install -type f -path '*/ros2cli*/bin/ros2' | head -n 5
+```
+
+Then pin runtime to Fast DDS in this underlay:
+```bash
+source ~/ros2_kilted/install/setup.bash
+export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+command -v ros2
+ros2 --help | head -n 5
+```
+
+If `colcon build --packages-select ros2cli` fails with missing `.../package.sh` files (`rmw_implementation`, `rcl`, `rclpy`, etc.), that is expected in a partially built workspace; use the `--packages-up-to ... --packages-skip ... --packages-skip-by-dep ...` command above instead.
+
+### Step 7: Validate middleware/runtime environment
+```bash
+export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+ros2 doctor --report || true
+```
+
+Optional: if you want to force Cyclone DDS for runtime checks, install and verify it before proceeding:
+```bash
+sudo apt update
+sudo apt install -y ros-kilted-rmw-cyclonedds-cpp
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+Verify:
+```bash
+echo "$RMW_IMPLEMENTATION"
+ros2 pkg list | rg '^rclcpp$|^ros2cli$' -n
+```
+
+Path note (source-build workflow): use `~/ros2_kilted/...` and `~/j5/ros_ws/...` paths for underlay/overlay commands in this guide.
+
+If you now see all of the following, your underlay is good enough and you should move on to overlay:
+- `source ~/ros2_kilted/install/setup.bash` succeeds with no errors
+- `find ~/ros2_kilted/install -type f -path "*/ros2cli*/bin/ros2" | head -n 1` returns a path
+- `command -v ros2` resolves to that underlay path (for example `~/ros2_kilted/install/ros2cli/bin/ros2`)
+- `ros2 pkg list | rg "^ros2cli$|^rclcpp$" -n` prints both packages
+
+### Step 8: Build J5 overlay only after underlay passes
+```bash
+cd ~/j5/ros_ws
+source ~/ros2_kilted/install/setup.bash
+rm -rf build install log
+rosdep install --from-paths src --ignore-src -r -y --rosdistro kilted --skip-keys "ament_python"
+colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+source install/setup.bash
+command -v ros2
+```
+
+### Step 9: Failure triage commands (compiler vs dependency vs environment)
+```bash
+cd ~/ros2_kilted
+rg 'Failed <<<' log/latest_build/*
+rg 'error:' log/latest_build/* | tail -n 40
+rg 'No module named|Cannot locate rosdep definition|package.sh|local_setup.bash|Symlinking:' log/latest_build/*
+```
+
+Interpretation:
+- `No module named ...` => missing Python package / wrong interpreter path.
+- `-- Symlinking: .../install/<pkg>/share/<pkg>/local_setup.bash` in `stdout.log` / `streams.log` is positive evidence that package `<pkg>` installed successfully.
+- Missing `package.sh` / `local_setup.bash` for downstream package requirements => partial install tree from failed dependency chain; clean rebuild required.
+- GCC/C++ template errors in zenoh packages => toolchain/vendor incompatibility; skip affected package(s), continue with Fast DDS/Cyclone.
+- `Manually-specified variables were not used by the project: Python3_EXECUTABLE` in vendor packages is usually benign.
+- `Unbuilt egg for pytest-repeat` warnings from setuptools are usually non-fatal warnings in this context.
+
+### Step 10: About egg warnings and `pkg_resources is deprecated`
+Run:
+```bash
+python3 - <<'PY'
+import sys
+print('python:', sys.executable)
+try:
+    import pkg_resources
+    print('pkg_resources import: ok (deprecation warning is non-fatal)')
+except Exception as e:
+    print('pkg_resources import failed:', e)
+PY
+```
+
+Notes:
+- `Unbuilt egg for pytest-repeat` warnings are usually non-fatal for ROS 2 builds.
+- `pkg_resources is deprecated` warnings from `vcs`/`rosdep` are informational unless accompanied by an actual traceback/exception.

--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="standalone"
+HOST="0.0.0.0"
+API_PORT="4000"
+UI_PORT="3000"
+PI_IP=""
+RACE_TOPIC="/race/lap_event"
+ROS_SETUP=""
+
+
+find_ros2_bin() {
+  local base="$1"
+  if [[ -x "$base/install/bin/ros2" ]]; then
+    echo "$base/install/bin"
+    return 0
+  fi
+  local candidate
+  candidate="$(find "$base/install" -type f -path '*/bin/ros2' 2>/dev/null | head -n 1 || true)"
+  if [[ -n "$candidate" ]]; then
+    dirname "$candidate"
+    return 0
+  fi
+  return 1
+}
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--mode standalone|ros2] [--host 0.0.0.0] [--api-port 4000] [--ui-port 3000] [--pi-ip <LAN_IP>] [--topic /race/lap_event] [--ros-setup /path/to/install/setup.bash]
+
+Starts race manager backend + frontend and optional bridge.
+- standalone: bridge runs demo mode (no ROS 2 required)
+- ros2: bridge subscribes to ROS 2 topic (requires a source-built ROS 2 workspace)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) MODE="$2"; shift 2 ;;
+    --host) HOST="$2"; shift 2 ;;
+    --api-port) API_PORT="$2"; shift 2 ;;
+    --ui-port) UI_PORT="$2"; shift 2 ;;
+    --pi-ip) PI_IP="$2"; shift 2 ;;
+    --topic) RACE_TOPIC="$2"; shift 2 ;;
+    --ros-setup) ROS_SETUP="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1"; usage; exit 1 ;;
+  esac
+done
+
+if [[ "$MODE" != "standalone" && "$MODE" != "ros2" ]]; then
+  echo "--mode must be standalone or ros2"
+  exit 1
+fi
+
+if [[ -z "$PI_IP" ]]; then
+  PI_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+fi
+if [[ -z "$PI_IP" ]]; then
+  PI_IP="localhost"
+fi
+
+if [[ ! -f "apps/racemanager/service/.env" && -f "apps/racemanager/service/.env.example" ]]; then
+  cp apps/racemanager/service/.env.example apps/racemanager/service/.env
+fi
+
+if [[ ! -d "apps/racemanager/service/.venv" ]]; then
+  python -m venv apps/racemanager/service/.venv
+fi
+
+source apps/racemanager/service/.venv/bin/activate
+pip install -r apps/racemanager/service/requirements.txt >/dev/null
+
+if [[ "$MODE" == "ros2" ]]; then
+  if [[ -z "$ROS_SETUP" ]]; then
+    if [[ -f "$HOME/j5/ros_ws/install/setup.bash" ]]; then
+      ROS_SETUP="$HOME/j5/ros_ws/install/setup.bash"
+    elif [[ -f "ros_ws/install/setup.bash" ]]; then
+      ROS_SETUP="ros_ws/install/setup.bash"
+    fi
+  fi
+
+  if [[ -z "$ROS_SETUP" || ! -f "$ROS_SETUP" ]]; then
+    echo "ROS 2 mode requested, but no workspace setup file was found."
+    echo "Build ROS 2 from source and provide --ros-setup /path/to/install/setup.bash (for example ~/ros2_kilted/install/setup.bash or ~/j5/ros_ws/install/setup.bash)"
+    echo "or run --mode standalone."
+    exit 2
+  fi
+
+  unset VIRTUAL_ENV
+  unset PYTHONPATH
+  unset AMENT_PREFIX_PATH
+  unset CMAKE_PREFIX_PATH
+  unset COLCON_CURRENT_PREFIX
+
+  # shellcheck disable=SC1090
+  source "$ROS_SETUP"
+
+  if ! command -v ros2 >/dev/null 2>&1; then
+    if [[ -f "$HOME/ros2_kilted/install/setup.bash" ]]; then
+      # shellcheck disable=SC1090
+      source "$HOME/ros2_kilted/install/setup.bash"
+      # shellcheck disable=SC1090
+      source "$ROS_SETUP"
+    fi
+  fi
+
+  if ! command -v ros2 >/dev/null 2>&1; then
+    echo "Sourced $ROS_SETUP, but 'ros2' is still missing from PATH."
+    echo "Source underlay then overlay in-order:"
+    echo "  source ~/ros2_kilted/install/setup.bash"
+    echo "  source ~/j5/ros_ws/install/setup.bash"
+    ROS2_BIN_DIR="$(find_ros2_bin "$HOME/ros2_kilted" || true)"
+    if [[ -n "${ROS2_BIN_DIR:-}" ]]; then
+      echo "Found ros2 binary under $ROS2_BIN_DIR, but PATH is still missing it."
+      export PATH="$ROS2_BIN_DIR:$PATH"
+      if command -v ros2 >/dev/null 2>&1; then
+        echo "Added $ROS2_BIN_DIR to PATH for this run."
+      fi
+    else
+      echo "ros2 binary not found under ~/ros2_kilted/install (merged or isolated layouts)."
+      echo "Check underlay sources include ros2cli: colcon list | rg '^ros2cli\b'"
+      echo "Rebuild from a clean workspace with dependencies, e.g.:"
+      echo "  rm -rf build install log"
+      echo "  colcon build --symlink-install --packages-up-to ros2cli ros2run ros2topic demo_nodes_cpp --packages-skip rmw_zenoh_cpp --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3"
+    fi
+    echo "Your source build may be incomplete; run colcon build and retry."
+    exit 2
+  fi
+fi
+
+cleanup() {
+  if [[ -n "${BRIDGE_PID:-}" ]]; then kill "$BRIDGE_PID" 2>/dev/null || true; fi
+  if [[ -n "${UI_PID:-}" ]]; then kill "$UI_PID" 2>/dev/null || true; fi
+  if [[ -n "${API_PID:-}" ]]; then kill "$API_PID" 2>/dev/null || true; fi
+}
+trap cleanup EXIT INT TERM
+
+export HTTP_HOST="$HOST"
+export HTTP_PORT="$API_PORT"
+export NEXT_PUBLIC_API_BASE="http://$PI_IP:$API_PORT"
+export NEXT_PUBLIC_WS_URL="ws://$PI_IP:$API_PORT/ws"
+
+python -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
+API_PID=$!
+
+(
+  cd apps/racemanager/ui
+  npm install >/dev/null
+  npm run dev -- --hostname "$HOST" --port "$UI_PORT"
+) &
+UI_PID=$!
+
+sleep 2
+
+if [[ "$MODE" == "ros2" ]]; then
+  python apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
+  BRIDGE_PID=$!
+else
+  python apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
+  BRIDGE_PID=$!
+fi
+
+echo "Race Manager started"
+echo "- Mode: $MODE"
+echo "- Backend: http://localhost:$API_PORT"
+echo "- Frontend (local): http://localhost:$UI_PORT"
+echo "- Frontend (LAN):   http://$PI_IP:$UI_PORT"
+echo "- API (LAN):        http://$PI_IP:$API_PORT"
+echo "- WS (LAN):         ws://$PI_IP:$API_PORT/ws"
+if [[ "$MODE" == "ros2" ]]; then
+  echo "- ROS setup:        $ROS_SETUP"
+fi
+
+echo "Press Ctrl+C to stop all processes."
+wait


### PR DESCRIPTION
### Motivation
- Move the repository to a ROS 2 source-build workflow using the `Kilted Kaiju` distro and provide actionable recovery/troubleshooting guidance for common source-build failures.
- Improve the Race Manager app docs and usability for headless devices (Raspberry Pi) and add a simple launcher to start backend, UI and bridge processes.
- Capture common developer workflows (MP4 replay ingestion, ROS overlay/underlay build gotchas, zenoh RMW workarounds) to reduce friction when onboarding and debugging builds.

### Description
- Updated the top-level `README.md` to replace `ROS 2 Iron` references with `ROS 2 Kilted Kaiju`, convert quick-start steps to a source-build workflow, and add extensive source-build troubleshooting and recovery instructions. 
- Greatly expanded `docs/README.md` with a comprehensive Kilted source-build runbook including preflight checks, step-by-step underlay/overlay build flows, `colcon` command patterns, zenoh `rmw_zenoh_cpp` workarounds, and PATH/sourcing triage commands. 
- Enhanced `apps/racemanager/README.md` with MP4 replay ingestion copy/paste commands, clearer ROS 2 source-build mode instructions, and a one-command launcher recommendation. 
- Updated `apps/racemanager/ui/README.md` to provide a headless/server dev server bind example (`npm run dev -- --hostname 0.0.0.0 --port 3000`).
- Added a new executable launcher `scripts/run_racemanager.sh` which prepares the service venv, builds env vars, optionally sources a source-built ROS 2 workspace, and concurrently starts the FastAPI backend, Next.js UI, and the bridge in either `standalone` or `ros2` modes.

### Testing
- No automated tests were run as part of this change set.
- The changes are documentation and tooling only and do not modify runtime library code or CI configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e875b24f08323986239d7d44cf02e)