### PR TITLE
Make j5_voice launch optional, keep hello node running, and expand onboarding docs/troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ source ~/j5/ros_ws/install/setup.bash
 
 ```
 
-Install Python dependencies:
+Install Python dependencies (system Python on Debian/Ubuntu may enforce PEP 668):
 ```bash
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 pre-commit install
 ```
+
+If you need system-wide installs, prefer apt packages; use `pip --break-system-packages`
+only when you understand the trade-offs.
 
 Launch the robot:
 ```bash
@@ -142,10 +147,59 @@ Then rebuild the J5 overlay:
 ```bash
 cd ~/j5/ros_ws
 rm -rf build install log
-colcon build --symlink-install --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
+colcon build --symlink-install --allow-overriding fastdds \
+  --cmake-args -DPython3_EXECUTABLE=/usr/bin/python3
 source install/setup.bash
 ```
 
+If `ros2 launch` returns `invalid choice: 'launch'`, you are in a partial ROS CLI environment.
+From a fresh shell, verify the launch command is actually available before attempting bringup:
+```bash
+source ~/ros2_kilted/install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+ros2 -h | rg -w launch || true
+ros2 pkg list | rg '^j5_bringup$' || true
+```
+Only run bringup when `ros2 -h` includes `launch`:
+```bash
+ros2 launch j5_bringup bringup.launch.py
+```
+If `ros2 -h` still does not include `launch`, your underlay may be missing launch CLI plugins, or
+your shell may be invoking the wrong `ros2` binary. After installing/building `ros2launch` and
+`launch_ros`, verify binary + plugin discovery explicitly:
+```bash
+hash -r
+command -v ros2
+ros2 extensions | rg 'launch|ros2launch' || true
+ROS2_BIN="$(find ~/ros2_kilted/install -type f -path '*/bin/ros2' | head -n 1)"
+echo "$ROS2_BIN"
+"$ROS2_BIN" -h | rg -w launch || true
+```
+If `"$ROS2_BIN"` shows `launch` but `ros2` does not, your PATH is pointing at another install.
+`j5_bringup` being discoverable alone is not sufficient.
+If `"$ROS2_BIN"` still does **not** show `launch` (your current case), your source underlay
+`~/ros2_kilted` is missing launch plugins in that same install tree.
+
+For a source-only workflow, build launch packages in that underlay and re-source:
+```bash
+cd ~/ros2_kilted
+colcon list | rg '^(ros2launch|launch_ros)$' || true
+colcon build --symlink-install --packages-up-to ros2launch launch_ros
+source install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+ros2 -h | rg -w launch
+```
+Do **not** mix ROS distro package names (for example installing `ros-iron-*` on a Kilted setup):
+underlay, apt packages, and sourced environment must all target the same distro.
+
+`demo_nodes_py` is optional and may be absent in source-built setups; it is not a
+reliable bringup health check for this repo. Prefer non-execution checks first:
+```bash
+ros2 pkg list | rg '^j5_'
+ros2 pkg executables j5_voice
+```
+If the package is present but runtime nodes crash on your target, treat that as a package-level
+bug to debug separately from underlay/overlay environment setup.
 
 Because CMake caches the interpreter path, if you ever configured in a venv you must clean the ROS underlay build cache before retrying:
 ```bash

--- a/ros_ws/README.md
+++ b/ros_ws/README.md
@@ -1,7 +1,109 @@
 # J5 ROS 2 Workspace
 
-This is a colcon workspace containing J5 ROS 2 packages. Build with:
+This is a `colcon` overlay workspace containing J5 ROS 2 packages.
 
-- Open a ROS 2-enabled PowerShell
-- cd to this folder and run: `colcon build --symlink-install`
-- Then: `.\install\local_setup.ps1`
+## Linux / Raspberry Pi quick start
+
+1. Verify underlay launch support first (before moving to this overlay):
+
+   ```bash
+   source ~/ros2_kilted/install/setup.bash
+   ros2 -h | rg -w launch
+   ```
+
+2. Build from this workspace root:
+
+   ```bash
+   cd ~/j5/ros_ws
+   colcon build --symlink-install --allow-overriding fastdds
+   ```
+
+3. Source the overlay:
+
+   ```bash
+   source install/setup.bash
+   ```
+
+4. Launch bringup (voice placeholder node is disabled by default):
+
+   ```bash
+   ros2 launch j5_bringup bringup.launch.py
+   ```
+
+5. Optional: enable the placeholder voice node explicitly:
+
+   ```bash
+   ros2 launch j5_bringup bringup.launch.py start_voice:=true
+   ```
+
+## Troubleshooting
+
+### `ros2 launch` is missing (only `run/topic/pkg` shown)
+
+If `ros2 -h` does not list `launch`, you are in a partial ROS environment.
+In a fresh shell, source underlay then overlay and verify `launch` is an actual CLI command:
+
+```bash
+source ~/ros2_kilted/install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+ros2 -h | rg -w launch || true
+ros2 pkg list | rg '^j5_bringup$' || true
+```
+
+If the first command prints nothing, `launch` is not registered in your active ROS CLI.
+That means your underlay is incomplete for launch workflows. Install or build launch CLI
+packages in the underlay (`ros2launch` and `launch_ros`), then re-source underlay + overlay.
+`j5_bringup` showing up in `ros2 pkg list` does not guarantee `ros2 launch` is installed.
+
+For source-built underlays, ensure `ros2launch` and `launch_ros` are present in `src/` and successfully built.
+Do **not** mix ROS distro package sets across workspaces.
+
+If launch packages are installed but `ros2 -h` still does not show `launch`, you are likely invoking
+the wrong `ros2` binary (or stale shell command cache). Verify and test directly:
+
+```bash
+hash -r
+command -v ros2
+ros2 extensions | rg 'launch|ros2launch' || true
+ROS2_BIN="$(find ~/ros2_kilted/install -type f -path '*/bin/ros2' | head -n 1)"
+echo "$ROS2_BIN"
+"$ROS2_BIN" -h | rg -w launch || true
+```
+
+If `"$ROS2_BIN"` includes `launch` but `ros2` does not, your PATH/shell is pointing to a different
+installation. Re-source underlay then overlay in a fresh shell and re-check `command -v ros2`.
+
+If `"$ROS2_BIN"` also lacks `launch`, the source underlay itself is missing launch plugins.
+Build launch packages in `~/ros2_kilted` and re-source underlay + overlay:
+
+```bash
+cd ~/ros2_kilted
+colcon list | rg '^(ros2launch|launch_ros)$' || true
+colcon build --symlink-install --packages-up-to ros2launch launch_ros
+source install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+ros2 -h | rg -w launch
+```
+
+### `demo_nodes_py` not found
+
+`demo_nodes_py` is a ROS demo package and may not exist in your source-built underlay.
+Use package discovery checks first instead of running nodes:
+
+```bash
+ros2 pkg list | rg '^j5_'
+ros2 pkg executables j5_voice
+```
+
+If `j5_voice` executables exist but crash at runtime (for example allocator/corruption errors),
+track that as a package/runtime bug; it does not invalidate launch-extension diagnostics.
+
+### Other common build/runtime issues
+
+- If `ros2` is not found, your underlay is not sourced in the current shell.
+- If `fastcdr package NOT found` appears while building `fastdds`, source the ROS 2
+  underlay first so dependencies are discoverable.
+- If colcon warns that `fastdds` exists in the underlay, use
+  `--allow-overriding fastdds` intentionally (as shown above) and keep runtime RMW/distro versions consistent.
+- Linker warnings like `libfastdds.so.3.2 ... may conflict with libfastdds.so.3.5` indicate mixed Fast DDS
+  libraries between underlay and overlay; keep underlay/overlay builds aligned and treat runtime crashes as ABI mismatch symptoms.

--- a/ros_ws/src/j5_bringup/launch/bringup.launch.py
+++ b/ros_ws/src/j5_bringup/launch/bringup.launch.py
@@ -1,13 +1,28 @@
 #!/usr/bin/env python3
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    start_voice = LaunchConfiguration("start_voice")
+
     return LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "start_voice",
+                default_value="false",
+                description="Start placeholder j5_voice hello node",
+            ),
             # Placeholder nodes
             # Node(package='j5_perception', executable='vision_node', name='vision'),
-            Node(package="j5_voice", executable="hello", name="voice_hello"),
+            Node(
+                package="j5_voice",
+                executable="hello",
+                name="voice_hello",
+                condition=IfCondition(start_voice),
+            ),
         ]
     )

--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -2,31 +2,71 @@
 
 A comprehensive real-time race tracking system with AI-powered computer vision, designed as a ROS2 perception module. Uses cameras as data sources and AI models (YOLO + DeepSORT) to track racing vehicles, compute lap times, and visualize race data.
 
-## Quick Start (3 Steps)
+## Prerequisites (verify first)
 
-### 1. Start the Backend
+Run from a fresh shell before starting backend/frontend/perception:
+
+```bash
+# source ROS2 underlay + J5 overlay (source-build flow)
+source ~/ros2_kilted/install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
+
+# verify CLI + package visibility
+command -v ros2
+ros2 -h | rg -w launch
+ros2 pkg list | rg '^racetracker_perception$'
+```
+
+If `ros2` or `launch` is missing, fix underlay/overlay first (do not continue to backend/frontend until this passes).
+
+## Quick Start (source-build workflow)
+
+### 1. Start the Backend (Python deps in venv)
+
 ```bash
 cd backend
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 python -m app.main
 ```
+
 Backend starts at `http://localhost:8080` (API docs at `/docs`).
 
+For headless/remote access from another device on the same network, use the Pi host IP
+(for example `http://<pi-ip>:8080`) instead of `localhost`.
+
+> `ModuleNotFoundError: No module named 'fastapi'` means the backend venv is not active
+> (or requirements were not installed in that interpreter).
+
 ### 2. Start the Frontend
+
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
+
 Frontend starts at `http://localhost:5173`.
 
+For remote browser access, open `http://<pi-ip>:5173` and run Vite with host binding
+(for example `npm run dev -- --host 0.0.0.0`) if needed.
+
 ### 3. Run the Perception System
+
 ```bash
 # Standalone mode (no ROS2 needed, uses mock cameras)
 python -m perception.standalone.standalone_runner
 
-# Or with ROS2
+# ROS2 node mode (requires sourced underlay + overlay in THIS shell)
 ros2 run racetracker_perception perception_node
+```
+
+If you see `ros2: command not found` here, re-source before running the node:
+
+```bash
+source ~/ros2_kilted/install/setup.bash
+source ~/j5/ros_ws/install/setup.bash
 ```
 
 ## Features

--- a/ros_ws/src/j5_voice/j5_voice/hello.py
+++ b/ros_ws/src/j5_voice/j5_voice/hello.py
@@ -11,9 +11,14 @@ class HelloVoice(Node):
 def main():
     rclpy.init()
     node = HelloVoice()
-    rclpy.spin_once(node, timeout_sec=0.1)
-    node.destroy_node()
-    rclpy.shutdown()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Make the placeholder `j5_voice` node opt-in for bringup so bringup doesn't start unnecessary demo nodes by default. 
- Ensure the `hello` node behaves like a long-running ROS 2 node and shuts down cleanly on interrupt. 
- Improve onboarding and source-build troubleshooting for ROS 2 underlay/overlay workflows and common build issues. 

### Description
- Add a launch argument `start_voice` to `bringup.launch.py` and wrap the `j5_voice` `hello` node with `IfCondition` so it only starts when `start_voice` is true. 
- Change `j5_voice` `hello.py` to call `rclpy.spin()` and handle `KeyboardInterrupt`, then destroy the node and call `rclpy.shutdown()` only if `rclpy.ok()`. 
- Update top-level `README.md` and `ros_ws/README.md` with virtualenv guidance (`python3 -m venv .venv` + `source .venv/bin/activate`), diagnostic commands, explicit `colcon build` flags including `--allow-overriding fastdds`, and detailed checks for missing `ros2 launch`. 
- Expand `race-master-pro` README with backend/frontend/perception quick start notes, venv instructions for the backend, and additional troubleshooting hints for headless access and missing dependencies. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9bc35cec8323ae835f13bbb8f075)