### PR TITLE
Add ROS 2 packaging for racetracker_perception node

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -11,6 +11,11 @@ Run from a fresh shell before starting backend/frontend/perception:
 source ~/ros2_kilted/install/setup.bash
 source ~/j5/ros_ws/install/setup.bash
 
+# build/install the race-master-pro ROS2 node into the overlay
+cd ~/j5/ros_ws
+colcon build --symlink-install --packages-select racetracker_perception
+source ~/j5/ros_ws/install/setup.bash
+
 # verify CLI + package visibility
 command -v ros2
 ros2 -h | rg -w launch

--- a/ros_ws/src/j5_perception/race-master-pro/package.xml
+++ b/ros_ws/src/j5_perception/race-master-pro/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>racetracker_perception</name>
+  <version>0.1.0</version>
+  <description>ROS 2 perception node for Race Master Pro.</description>
+  <maintainer email="opensource@j5.ai">J5 Maintainers</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <depend>rclpy</depend>
+  <depend>std_msgs</depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/ros_ws/src/j5_perception/race-master-pro/setup.cfg
+++ b/ros_ws/src/j5_perception/race-master-pro/setup.cfg
@@ -1,0 +1,5 @@
+[develop]
+script_dir=$base/lib/racetracker_perception
+
+[install]
+install_scripts=$base/lib/racetracker_perception

--- a/ros_ws/src/j5_perception/race-master-pro/setup.py
+++ b/ros_ws/src/j5_perception/race-master-pro/setup.py
@@ -1,0 +1,25 @@
+from setuptools import find_packages, setup
+
+package_name = "racetracker_perception"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=[package_name] + find_packages(include=["perception", "perception.*"]),
+    package_dir={package_name: "perception/ros2_node/racetracker_perception"},
+    data_files=[
+        ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
+        (f"share/{package_name}", ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="J5 Maintainers",
+    maintainer_email="opensource@j5.ai",
+    description="ROS 2 perception node for Race Master Pro.",
+    license="MIT",
+    entry_points={
+        "console_scripts": [
+            "perception_node = racetracker_perception.perception_node:main",
+        ],
+    },
+)


### PR DESCRIPTION
### Motivation
- Fix the failure where `ros2 run racetracker_perception perception_node` could not find the package because the node lacked ROS 2 packaging and entrypoint metadata.
- Provide standard `ament_python` packaging so the racetracker perception node can be discovered, built into the overlay, and executed via the ROS2 CLI.

### Description
- Add `package.xml` declaring `ament_python` buildtool and runtime dependencies (`rclpy`, `std_msgs`) and export the `ament_python` build type.
- Add `setup.py` to provide setuptools packaging, map the package directory to the existing node, and register a console script entry point `perception_node = racetracker_perception.perception_node:main`.
- Add `setup.cfg` and `resource/racetracker_perception` to register the package resource and script install location.
- Update `README.md` to document building the new package into the overlay with `colcon build --symlink-install --packages-select racetracker_perception` and re-sourcing the overlay before running the node.

### Testing
- Ran `pre-commit run --files ...` against the new/changed files and the configured hooks passed (black, trailing-whitespace, end-of-file-fixer).
- Ran `make test`, which fell back because `colcon` is not installed in this environment and reported `/bin/sh: 1: colcon: not found`.
- Ran `python3 -m py_compile ros_ws/src/j5_perception/race-master-pro/setup.py` which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0730588148323860387bb2dba25af)