### PR TITLE
Register racetracker_perception as a ROS2 ament_python package and add console entry point

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -7,8 +7,12 @@ A comprehensive real-time race tracking system with AI-powered computer vision, 
 Run from a fresh shell before starting backend/frontend/perception:
 
 ```bash
-# source ROS2 underlay + J5 overlay (source-build flow)
+# source ROS2 underlay
 source ~/ros2_kilted/install/setup.bash
+
+# build + source the J5 overlay so racetracker_perception is registered
+cd ~/j5/ros_ws
+colcon build --symlink-install --packages-select racetracker_perception
 source ~/j5/ros_ws/install/setup.bash
 
 # verify CLI + package visibility
@@ -67,6 +71,15 @@ If you see `ros2: command not found` here, re-source before running the node:
 ```bash
 source ~/ros2_kilted/install/setup.bash
 source ~/j5/ros_ws/install/setup.bash
+```
+
+If you see `Package 'racetracker_perception' not found`, build and re-source the overlay:
+
+```bash
+cd ~/j5/ros_ws
+colcon build --symlink-install --packages-select racetracker_perception
+source ~/j5/ros_ws/install/setup.bash
+ros2 pkg list | rg '^racetracker_perception$'
 ```
 
 ## Features

--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/package.xml
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>racetracker_perception</name>
+  <version>0.1.0</version>
+  <description>Race Master Pro ROS2 perception node package.</description>
+  <maintainer email="devnull@example.com">Race Master Pro</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/setup.cfg
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/setup.cfg
@@ -1,0 +1,5 @@
+[develop]
+script_dir=$base/lib/racetracker_perception
+
+[install]
+install_scripts=$base/lib/racetracker_perception

--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/setup.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/setup.py
@@ -1,0 +1,25 @@
+from setuptools import find_packages, setup
+
+package_name = "racetracker_perception"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=find_packages(exclude=["test"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
+        (f"share/{package_name}", ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Race Master Pro",
+    maintainer_email="devnull@example.com",
+    description="Race Master Pro ROS2 perception node package.",
+    license="MIT",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "perception_node = racetracker_perception.perception_node:main",
+        ],
+    },
+)


### PR DESCRIPTION
### Motivation
- Ensure `racetracker_perception` is discoverable and runnable via `ros2` so `ros2 pkg list` and `ros2 run racetracker_perception perception_node` resolve correctly.

### Description
- Added a ROS2 `ament_python` `package.xml` at `ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/package.xml` declaring `rclpy` and `sensor_msgs` runtime deps.
- Added a Python `setup.py` with a `console_scripts` entry point `perception_node = racetracker_perception.perception_node:main` so the node can be launched via `ros2 run`.
- Added `setup.cfg` and an empty package resource file under `perception/ros2_node/resource` to satisfy ament/packaging layout requirements.
- Updated `race-master-pro/README.md` to include an explicit `colcon build --packages-select racetracker_perception` step and a troubleshooting block for `Package 'racetracker_perception' not found`.

### Testing
- Ran `pre-commit run --files` on the changed files and the hooks passed.
- Ran `make test`, which invokes `colcon test` in this environment; `colcon` is not installed so the Makefile printed a warning and the test step could not run full ROS tests, making results inconclusive for runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0730588148323860387bb2dba25af)