### PR TITLE
Use repo-root venv and robust Python/ROS detection in run_racemanager; document usage from ros_ws

### DIFF
--- a/ros_ws/README.md
+++ b/ros_ws/README.md
@@ -4,6 +4,15 @@ This is a `colcon` overlay workspace containing J5 ROS 2 packages.
 
 ## Linux / Raspberry Pi quick start
 
+### Race manager script from `ros_ws`
+
+If you are already working from `~/j5/ros_ws`, run the existing repo-root script
+with a relative path:
+
+```bash
+../scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip>
+```
+
 1. Verify underlay launch support first (before moving to this overlay):
 
    ```bash

--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
 MODE="standalone"
 HOST="0.0.0.0"
 API_PORT="4000"
@@ -8,7 +12,20 @@ UI_PORT="3000"
 PI_IP=""
 RACE_TOPIC="/race/lap_event"
 ROS_SETUP=""
+VENV_DIR="apps/racemanager/service/.venv"
+VENV_PYTHON="$VENV_DIR/bin/python"
 
+find_python_bin() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+  return 1
+}
 
 find_ros2_bin() {
   local base="$1"
@@ -65,12 +82,17 @@ if [[ ! -f "apps/racemanager/service/.env" && -f "apps/racemanager/service/.env.
   cp apps/racemanager/service/.env.example apps/racemanager/service/.env
 fi
 
-if [[ ! -d "apps/racemanager/service/.venv" ]]; then
-  python -m venv apps/racemanager/service/.venv
+PYTHON_BIN="$(find_python_bin || true)"
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "Python is required but neither 'python3' nor 'python' was found on PATH."
+  exit 2
 fi
 
-source apps/racemanager/service/.venv/bin/activate
-pip install -r apps/racemanager/service/requirements.txt >/dev/null
+if [[ ! -d "$VENV_DIR" ]]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+"$VENV_PYTHON" -m pip install -r apps/racemanager/service/requirements.txt >/dev/null
 
 if [[ "$MODE" == "ros2" ]]; then
   if [[ -z "$ROS_SETUP" ]]; then
@@ -94,15 +116,19 @@ if [[ "$MODE" == "ros2" ]]; then
   unset CMAKE_PREFIX_PATH
   unset COLCON_CURRENT_PREFIX
 
+  set +u
   # shellcheck disable=SC1090
   source "$ROS_SETUP"
+  set -u
 
   if ! command -v ros2 >/dev/null 2>&1; then
     if [[ -f "$HOME/ros2_kilted/install/setup.bash" ]]; then
+      set +u
       # shellcheck disable=SC1090
       source "$HOME/ros2_kilted/install/setup.bash"
       # shellcheck disable=SC1090
       source "$ROS_SETUP"
+      set -u
     fi
   fi
 
@@ -142,7 +168,7 @@ export HTTP_PORT="$API_PORT"
 export NEXT_PUBLIC_API_BASE="http://$PI_IP:$API_PORT"
 export NEXT_PUBLIC_WS_URL="ws://$PI_IP:$API_PORT/ws"
 
-python -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
+"$VENV_PYTHON" -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
 API_PID=$!
 
 (
@@ -155,10 +181,10 @@ UI_PID=$!
 sleep 2
 
 if [[ "$MODE" == "ros2" ]]; then
-  python apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
+  "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
   BRIDGE_PID=$!
 else
-  python apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
+  "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
   BRIDGE_PID=$!
 fi
 


### PR DESCRIPTION
### Motivation

- Provide a more robust, repo-root-relative script for running the Race Manager that can be executed from `ros_ws` and other locations.
- Ensure the script creates and uses a per-repo virtual environment and reliably finds a usable Python interpreter.
- Improve ROS 2 setup detection and sourcing to avoid PATH/`set -u` issues when sourcing setup files.

### Description

- Added a README section explaining how to run the race manager from `~/j5/ros_ws` using a relative path to `scripts/run_racemanager.sh`.
- Updated `scripts/run_racemanager.sh` to determine `SCRIPT_DIR` and `REPO_ROOT` and `cd` to the repo root at startup.
- Implemented `find_python_bin()` to prefer `python3` then `python`, fail early if neither is found, and use the discovered interpreter to create a venv at `apps/racemanager/service/.venv`.
- Switched all invocations that previously used `python`/`python -m` to use the venv python (`$VENV_PYTHON`) for installing requirements, running `uvicorn`, and launching the bridge, and added safer ROS setup sourcing with temporary `set +u`/`set -u` toggles.

### Testing

- Ran `scripts/run_racemanager.sh --help` to validate argument parsing and usage output, which completed successfully.
- Performed a local standalone-mode smoke test that created the venv, installed requirements, started the backend (`uvicorn`) and frontend (`npm dev`), and launched the bridge in demo mode, and the processes started as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ac40b9188323a5158c72d5ae7367)