### PR TITLE
Make run_racemanager.sh robust (venv/python detection, repo-root, ROS2 handling) and update ros_ws README

### DIFF
--- a/ros_ws/README.md
+++ b/ros_ws/README.md
@@ -4,6 +4,15 @@ This is a `colcon` overlay workspace containing J5 ROS 2 packages.
 
 ## Linux / Raspberry Pi quick start
 
+### Race manager script from `ros_ws`
+
+If you are already working from `~/j5/ros_ws`, run the existing repo-root script
+with a relative path:
+
+```bash
+../scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip>
+```
+
 1. Verify underlay launch support first (before moving to this overlay):
 
    ```bash

--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
 MODE="standalone"
 HOST="0.0.0.0"
 API_PORT="4000"
@@ -8,7 +12,20 @@ UI_PORT="3000"
 PI_IP=""
 RACE_TOPIC="/race/lap_event"
 ROS_SETUP=""
+VENV_DIR="apps/racemanager/service/.venv"
+VENV_PYTHON="$VENV_DIR/bin/python"
 
+find_python_bin() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+  return 1
+}
 
 find_ros2_bin() {
   local base="$1"
@@ -65,14 +82,20 @@ if [[ ! -f "apps/racemanager/service/.env" && -f "apps/racemanager/service/.env.
   cp apps/racemanager/service/.env.example apps/racemanager/service/.env
 fi
 
-if [[ ! -d "apps/racemanager/service/.venv" ]]; then
-  python -m venv apps/racemanager/service/.venv
+PYTHON_BIN="$(find_python_bin || true)"
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "Python is required but neither 'python3' nor 'python' was found on PATH."
+  exit 2
 fi
 
-source apps/racemanager/service/.venv/bin/activate
-pip install -r apps/racemanager/service/requirements.txt >/dev/null
+if [[ ! -d "$VENV_DIR" ]]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+"$VENV_PYTHON" -m pip install -r apps/racemanager/service/requirements.txt >/dev/null
 
 if [[ "$MODE" == "ros2" ]]; then
+  ROS_UNDERLAY_SETUP="$HOME/ros2_kilted/install/setup.bash"
   if [[ -z "$ROS_SETUP" ]]; then
     if [[ -f "$HOME/j5/ros_ws/install/setup.bash" ]]; then
       ROS_SETUP="$HOME/j5/ros_ws/install/setup.bash"
@@ -94,15 +117,19 @@ if [[ "$MODE" == "ros2" ]]; then
   unset CMAKE_PREFIX_PATH
   unset COLCON_CURRENT_PREFIX
 
+  set +u
   # shellcheck disable=SC1090
   source "$ROS_SETUP"
+  set -u
 
   if ! command -v ros2 >/dev/null 2>&1; then
-    if [[ -f "$HOME/ros2_kilted/install/setup.bash" ]]; then
+    if [[ -f "$ROS_UNDERLAY_SETUP" ]]; then
+      set +u
       # shellcheck disable=SC1090
-      source "$HOME/ros2_kilted/install/setup.bash"
+      source "$ROS_UNDERLAY_SETUP"
       # shellcheck disable=SC1090
       source "$ROS_SETUP"
+      set -u
     fi
   fi
 
@@ -142,7 +169,7 @@ export HTTP_PORT="$API_PORT"
 export NEXT_PUBLIC_API_BASE="http://$PI_IP:$API_PORT"
 export NEXT_PUBLIC_WS_URL="ws://$PI_IP:$API_PORT/ws"
 
-python -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
+"$VENV_PYTHON" -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
 API_PID=$!
 
 (
@@ -155,10 +182,10 @@ UI_PID=$!
 sleep 2
 
 if [[ "$MODE" == "ros2" ]]; then
-  python apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
+  "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
   BRIDGE_PID=$!
 else
-  python apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
+  "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
   BRIDGE_PID=$!
 fi
 


### PR DESCRIPTION
### Motivation
- Ensure `run_racemanager.sh` can be run reliably from the repo by resolving the script and switching to the repository root. 
- Create and use a dedicated virtual environment with a discovered Python interpreter so installs and runtime invocations are consistent. 
- Improve ROS 2 overlay/underlay detection and sourcing to reduce user setup issues and provide clearer guidance when `ros2` is missing. 

### Description
- Resolve `SCRIPT_DIR` and `REPO_ROOT` and `cd` into the repo root at script start so relative paths work when invoked from `ros_ws` or other locations. 
- Add `find_python_bin()` and `VENV_DIR` (`apps/racemanager/service/.venv`) and create a venv with the discovered Python, then use the venv's Python for `pip`, `uvicorn`, and the bridge process. 
- Harden ROS handling by probing for `ros_ws` and an underlay (`~/ros2_kilted`), sourcing with `set +u`/`set -u` around `source`, and adjusting PATH if a `ros2` binary is found under an underlay. 
- Replace direct `python`/venv activation usage with explicit `VENV_PYTHON` calls and add clearer exit messages when Python or ROS setup is missing. 
- Add a short `ros_ws` README snippet that documents running the existing repo-root script from `~/j5/ros_ws` using a relative path example. 

### Testing
- No automated tests were run for these script and documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ac40b9188323a5158c72d5ae7367)