### PR TITLE
Enhance run_racemanager.sh: venv handling, ROS underlay support, systemd snippet; update README

### DIFF
--- a/ros_ws/README.md
+++ b/ros_ws/README.md
@@ -4,6 +4,22 @@ This is a `colcon` overlay workspace containing J5 ROS 2 packages.
 
 ## Linux / Raspberry Pi quick start
 
+### Race manager script from `ros_ws`
+
+If you are already working from `~/j5/ros_ws`, run the existing repo-root script
+with a relative path:
+
+```bash
+../scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip>
+```
+
+For unattended headless startup on boot (systemd), print and run the generated
+service setup snippet:
+
+```bash
+../scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip> --print-systemd
+```
+
 1. Verify underlay launch support first (before moving to this overlay):
 
    ```bash

--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
 MODE="standalone"
 HOST="0.0.0.0"
 API_PORT="4000"
@@ -8,7 +12,21 @@ UI_PORT="3000"
 PI_IP=""
 RACE_TOPIC="/race/lap_event"
 ROS_SETUP=""
+VENV_DIR="apps/racemanager/service/.venv"
+VENV_PYTHON="$VENV_DIR/bin/python"
+PRINT_SYSTEMD="false"
 
+find_python_bin() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+  return 1
+}
 
 find_ros2_bin() {
   local base="$1"
@@ -27,12 +45,41 @@ find_ros2_bin() {
 
 usage() {
   cat <<USAGE
-Usage: $0 [--mode standalone|ros2] [--host 0.0.0.0] [--api-port 4000] [--ui-port 3000] [--pi-ip <LAN_IP>] [--topic /race/lap_event] [--ros-setup /path/to/install/setup.bash]
+Usage: $0 [--mode standalone|ros2] [--host 0.0.0.0] [--api-port 4000] [--ui-port 3000] [--pi-ip <LAN_IP>] [--topic /race/lap_event] [--ros-setup /path/to/install/setup.bash] [--print-systemd]
 
 Starts race manager backend + frontend and optional bridge.
 - standalone: bridge runs demo mode (no ROS 2 required)
 - ros2: bridge subscribes to ROS 2 topic (requires a source-built ROS 2 workspace)
+- print-systemd: print a ready-to-run systemd setup snippet and exit
 USAGE
+}
+
+print_systemd_snippet() {
+  local service_user
+  service_user="${SUDO_USER:-$(id -un)}"
+  cat <<SYSTEMD
+sudo tee /etc/systemd/system/racemanager.service >/dev/null <<'EOF'
+[Unit]
+Description=Race Manager stack
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${service_user}
+WorkingDirectory=${REPO_ROOT}
+ExecStart=${REPO_ROOT}/scripts/run_racemanager.sh --mode ${MODE} --host ${HOST} --api-port ${API_PORT} --ui-port ${UI_PORT} --pi-ip ${PI_IP} --topic ${RACE_TOPIC}${ROS_SETUP:+ --ros-setup ${ROS_SETUP}}
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now racemanager.service
+sudo systemctl status racemanager.service --no-pager
+SYSTEMD
 }
 
 while [[ $# -gt 0 ]]; do
@@ -44,9 +91,18 @@ while [[ $# -gt 0 ]]; do
     --pi-ip) PI_IP="$2"; shift 2 ;;
     --topic) RACE_TOPIC="$2"; shift 2 ;;
     --ros-setup) ROS_SETUP="$2"; shift 2 ;;
+    --print-systemd) PRINT_SYSTEMD="true"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown argument: $1"; usage; exit 1 ;;
   esac
+done
+
+for cmd in npm; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing dependency: '$cmd' is not on PATH."
+    echo "Install once on Ubuntu Server: sudo apt update && sudo apt install -y nodejs npm python3-venv"
+    exit 2
+  fi
 done
 
 if [[ "$MODE" != "standalone" && "$MODE" != "ros2" ]]; then
@@ -57,6 +113,11 @@ fi
 if [[ -z "$PI_IP" ]]; then
   PI_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
 fi
+
+if [[ "$PRINT_SYSTEMD" == "true" ]]; then
+  print_systemd_snippet
+  exit 0
+fi
 if [[ -z "$PI_IP" ]]; then
   PI_IP="localhost"
 fi
@@ -65,14 +126,25 @@ if [[ ! -f "apps/racemanager/service/.env" && -f "apps/racemanager/service/.env.
   cp apps/racemanager/service/.env.example apps/racemanager/service/.env
 fi
 
-if [[ ! -d "apps/racemanager/service/.venv" ]]; then
-  python -m venv apps/racemanager/service/.venv
+PYTHON_BIN="$(find_python_bin || true)"
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "Python is required but neither 'python3' nor 'python' was found on PATH."
+  exit 2
 fi
 
-source apps/racemanager/service/.venv/bin/activate
-pip install -r apps/racemanager/service/requirements.txt >/dev/null
+if [[ ! -d "$VENV_DIR" ]]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+if [[ ! -x "$VENV_PYTHON" ]]; then
+  echo "Virtualenv python not found at $VENV_PYTHON"
+  exit 2
+fi
+
+"$VENV_PYTHON" -m pip install -r apps/racemanager/service/requirements.txt >/dev/null
 
 if [[ "$MODE" == "ros2" ]]; then
+  ROS_UNDERLAY_SETUP="$HOME/ros2_kilted/install/setup.bash"
   if [[ -z "$ROS_SETUP" ]]; then
     if [[ -f "$HOME/j5/ros_ws/install/setup.bash" ]]; then
       ROS_SETUP="$HOME/j5/ros_ws/install/setup.bash"
@@ -94,15 +166,19 @@ if [[ "$MODE" == "ros2" ]]; then
   unset CMAKE_PREFIX_PATH
   unset COLCON_CURRENT_PREFIX
 
+  set +u
   # shellcheck disable=SC1090
   source "$ROS_SETUP"
+  set -u
 
   if ! command -v ros2 >/dev/null 2>&1; then
-    if [[ -f "$HOME/ros2_kilted/install/setup.bash" ]]; then
+    if [[ -f "$ROS_UNDERLAY_SETUP" ]]; then
+      set +u
       # shellcheck disable=SC1090
-      source "$HOME/ros2_kilted/install/setup.bash"
+      source "$ROS_UNDERLAY_SETUP"
       # shellcheck disable=SC1090
       source "$ROS_SETUP"
+      set -u
     fi
   fi
 
@@ -142,7 +218,7 @@ export HTTP_PORT="$API_PORT"
 export NEXT_PUBLIC_API_BASE="http://$PI_IP:$API_PORT"
 export NEXT_PUBLIC_WS_URL="ws://$PI_IP:$API_PORT/ws"
 
-python -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
+"$VENV_PYTHON" -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
 API_PID=$!
 
 (
@@ -155,10 +231,10 @@ UI_PID=$!
 sleep 2
 
 if [[ "$MODE" == "ros2" ]]; then
-  python apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
+  "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
   BRIDGE_PID=$!
 else
-  python apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
+  "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
   BRIDGE_PID=$!
 fi
 


### PR DESCRIPTION
### Motivation

- Make the race manager launcher robust and usable from the repo root (including when invoked from `ros_ws`) and add unattended startup support via systemd.
- Ensure a predictable Python environment by creating and using a virtualenv instead of relying on global `python` behavior.
- Improve ROS 2 overlay/underlay detection and sourcing so the `ros2` CLI is available when requested.

### Description

- Add repo root detection and `cd` to the repository in `scripts/run_racemanager.sh` and document invoking the script from `ros_ws` in `ros_ws/README.md` with a relative path example.
- Implement `find_python_bin` and use `apps/racemanager/service/.venv` with an identified Python binary, and run installs and processes through the venv Python (`$VENV_PYTHON`).
- Add a `--print-systemd` option and `print_systemd_snippet` function that prints, installs, enables, and shows the status of a ready-to-run systemd unit for unattended startup.
- Add a check for `npm` on PATH and improved error messages for missing dependencies.
- Enhance ROS handling by searching for workspace setup files (`~/j5/ros_ws/install/setup.bash` and `ros_ws/install/setup.bash`), optionally sourcing an underlay (`~/ros2_kilted/install/setup.bash`), and using `set +u`/`set -u` around `source` to avoid `nounset` issues.
- Replace direct `python` calls with the venv Python for running `uvicorn` and the bridge, and adjust virtualenv creation and validation logic.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ac40b9188323a5158c72d5ae7367)