### PR TITLE
Enhance run_racemanager.sh: venv, ros2 support, systemd, doctor, and npm caching; update READMEs

### DIFF
--- a/apps/racemanager/README.md
+++ b/apps/racemanager/README.md
@@ -179,6 +179,15 @@ single mini PC with only a USB camera and add ROS later.
 Use `scripts/run_racemanager.sh` from the repo root to start backend + frontend and
 (optionally) the bridge in standalone/demo or ROS 2 mode.
 
+This launcher is the **all-in-one equivalent** of the manual service/UI/bridge steps above
+(so you can run without `tmux` if preferred).
+
+Before starting processes, run:
+
+```bash
+./scripts/run_racemanager.sh --mode ros2 --doctor
+```
+
 Examples:
 
 ```bash

--- a/ros_ws/README.md
+++ b/ros_ws/README.md
@@ -4,6 +4,64 @@ This is a `colcon` overlay workspace containing J5 ROS 2 packages.
 
 ## Linux / Raspberry Pi quick start
 
+### Race manager script from `ros_ws`
+
+If you are already working from `~/j5/ros_ws`, run the existing repo-root script
+with a relative path:
+
+```bash
+../scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip>
+```
+
+For unattended headless startup on boot (systemd), print and run the generated
+service setup snippet:
+
+```bash
+../scripts/run_racemanager.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip> --print-systemd
+```
+
+If your Pi IP is dynamic or unavailable at setup time, omit `--pi-ip`; the generated
+systemd command will omit that flag and let the script auto-detect the current IP each
+service start.
+
+If the service restarts/fails, inspect logs with:
+
+```bash
+sudo journalctl -u racemanager.service -n 200 --no-pager
+```
+
+Before enabling systemd, you can run a non-launch diagnostic check:
+
+```bash
+../scripts/run_racemanager.sh --mode ros2 --doctor
+```
+
+You only need to edit/regenerate the systemd unit when `ExecStart` arguments change.
+For normal script updates, a restart is enough:
+
+```bash
+sudo systemctl restart racemanager.service
+```
+
+After updating `scripts/run_racemanager.sh`, reload and restart the service to
+pick up the new script version:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart racemanager.service
+sudo systemctl status racemanager.service --no-pager
+```
+
+If you still see `PRINT_SYSTEMD: unbound variable`, verify the script on the Pi
+contains `PRINT_SYSTEMD="false"` near the top, then restart the service:
+
+```bash
+grep -n 'PRINT_SYSTEMD' ~/j5/scripts/run_racemanager.sh
+sudo systemctl daemon-reload
+sudo systemctl restart racemanager.service
+sudo journalctl -u racemanager.service -n 50 --no-pager
+```
+
 1. Verify underlay launch support first (before moving to this overlay):
 
    ```bash

--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
 
 MODE="standalone"
 HOST="0.0.0.0"
@@ -8,7 +12,39 @@ UI_PORT="3000"
 PI_IP=""
 RACE_TOPIC="/race/lap_event"
 ROS_SETUP=""
+VENV_DIR="apps/racemanager/service/.venv"
+VENV_PYTHON="$VENV_DIR/bin/python"
+PRINT_SYSTEMD="false"
+DOCTOR_MODE="false"
 
+# Defensive defaults for strict shells/systemd environments.
+apply_defaults() {
+  MODE="${MODE:-standalone}"
+  HOST="${HOST:-0.0.0.0}"
+  API_PORT="${API_PORT:-4000}"
+  UI_PORT="${UI_PORT:-3000}"
+  PI_IP="${PI_IP:-}"
+  RACE_TOPIC="${RACE_TOPIC:-/race/lap_event}"
+  ROS_SETUP="${ROS_SETUP:-}"
+  PRINT_SYSTEMD="${PRINT_SYSTEMD:-false}"
+  DOCTOR_MODE="${DOCTOR_MODE:-false}"
+}
+
+apply_defaults
+
+trap 'rc=$?; echo "[run_racemanager] ERROR line ${BASH_LINENO[0]}: ${BASH_COMMAND} (exit ${rc})" >&2' ERR
+
+find_python_bin() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+  return 1
+}
 
 find_ros2_bin() {
   local base="$1"
@@ -27,12 +63,67 @@ find_ros2_bin() {
 
 usage() {
   cat <<USAGE
-Usage: $0 [--mode standalone|ros2] [--host 0.0.0.0] [--api-port 4000] [--ui-port 3000] [--pi-ip <LAN_IP>] [--topic /race/lap_event] [--ros-setup /path/to/install/setup.bash]
+Usage: $0 [--mode standalone|ros2] [--host 0.0.0.0] [--api-port 4000] [--ui-port 3000] [--pi-ip <LAN_IP>] [--topic /race/lap_event] [--ros-setup /path/to/install/setup.bash] [--print-systemd] [--doctor]
 
 Starts race manager backend + frontend and optional bridge.
 - standalone: bridge runs demo mode (no ROS 2 required)
 - ros2: bridge subscribes to ROS 2 topic (requires a source-built ROS 2 workspace)
+- print-systemd: print a ready-to-run systemd setup snippet and exit
+- doctor: run environment checks only (no services started)
 USAGE
+}
+
+print_systemd_snippet() {
+  local service_user
+  local service_home
+  local service_ros_setup
+  local pi_ip_arg
+  service_user="${SUDO_USER:-$(id -un)}"
+  service_home="$(eval echo "~${service_user}")"
+  service_ros_setup="${ROS_SETUP:-}"
+
+  if [[ -n "${PI_IP:-}" ]]; then
+    pi_ip_arg=" --pi-ip ${PI_IP}"
+  else
+    pi_ip_arg=""
+  fi
+
+  if [[ "$MODE" == "ros2" && -z "$service_ros_setup" ]]; then
+    if [[ -f "$service_home/j5/ros_ws/install/setup.bash" ]]; then
+      service_ros_setup="$service_home/j5/ros_ws/install/setup.bash"
+    elif [[ -f "$REPO_ROOT/ros_ws/install/setup.bash" ]]; then
+      service_ros_setup="$REPO_ROOT/ros_ws/install/setup.bash"
+    fi
+  fi
+
+  cat <<SYSTEMD
+sudo tee /etc/systemd/system/racemanager.service >/dev/null <<'EOF'
+[Unit]
+Description=Race Manager stack
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${service_user}
+WorkingDirectory=${REPO_ROOT}
+Environment=HOME=${service_home}
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=${REPO_ROOT}/scripts/run_racemanager.sh --mode ${MODE} --host ${HOST} --api-port ${API_PORT} --ui-port ${UI_PORT}${pi_ip_arg} --topic ${RACE_TOPIC}${service_ros_setup:+ --ros-setup ${service_ros_setup}}
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now racemanager.service
+sudo systemctl status racemanager.service --no-pager
+sudo journalctl -u racemanager.service -n 200 --no-pager
+# If you change scripts/run_racemanager.sh later, restart service:
+# sudo systemctl restart racemanager.service
+SYSTEMD
 }
 
 while [[ $# -gt 0 ]]; do
@@ -44,14 +135,45 @@ while [[ $# -gt 0 ]]; do
     --pi-ip) PI_IP="$2"; shift 2 ;;
     --topic) RACE_TOPIC="$2"; shift 2 ;;
     --ros-setup) ROS_SETUP="$2"; shift 2 ;;
+    --print-systemd) PRINT_SYSTEMD="true"; shift ;;
+    --doctor) DOCTOR_MODE="true"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown argument: $1"; usage; exit 1 ;;
   esac
 done
 
+# Re-apply critical defaults after argument parsing to survive partial/merged edits.
+apply_defaults
+
+for cmd in npm; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing dependency: '$cmd' is not on PATH."
+    echo "Install once on Ubuntu Server: sudo apt update && sudo apt install -y nodejs npm python3-venv"
+    exit 2
+  fi
+done
+
 if [[ "$MODE" != "standalone" && "$MODE" != "ros2" ]]; then
   echo "--mode must be standalone or ros2"
   exit 1
+fi
+
+apply_defaults
+
+if [[ "${PRINT_SYSTEMD:-false}" == "true" ]]; then
+  print_systemd_snippet
+  exit 0
+fi
+
+if [[ "${DOCTOR_MODE:-false}" == "true" ]]; then
+  echo "[run_racemanager] doctor: mode=$MODE host=$HOST api_port=$API_PORT ui_port=$UI_PORT"
+  echo "[run_racemanager] doctor: repo_root=$REPO_ROOT"
+  echo "[run_racemanager] doctor: python=$(find_python_bin || echo missing) npm=$(command -v npm || echo missing)"
+  echo "[run_racemanager] doctor: ros2=$(command -v ros2 || echo missing)"
+  if [[ "$MODE" == "ros2" ]]; then
+    echo "[run_racemanager] doctor: ros_setup=${ROS_SETUP:-auto}"
+  fi
+  exit 0
 fi
 
 if [[ -z "$PI_IP" ]]; then
@@ -65,14 +187,25 @@ if [[ ! -f "apps/racemanager/service/.env" && -f "apps/racemanager/service/.env.
   cp apps/racemanager/service/.env.example apps/racemanager/service/.env
 fi
 
-if [[ ! -d "apps/racemanager/service/.venv" ]]; then
-  python -m venv apps/racemanager/service/.venv
+PYTHON_BIN="$(find_python_bin || true)"
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "Python is required but neither 'python3' nor 'python' was found on PATH."
+  exit 2
 fi
 
-source apps/racemanager/service/.venv/bin/activate
-pip install -r apps/racemanager/service/requirements.txt >/dev/null
+if [[ ! -d "$VENV_DIR" ]]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+if [[ ! -x "$VENV_PYTHON" ]]; then
+  echo "Virtualenv python not found at $VENV_PYTHON"
+  exit 2
+fi
+
+"$VENV_PYTHON" -m pip install -r apps/racemanager/service/requirements.txt >/dev/null
 
 if [[ "$MODE" == "ros2" ]]; then
+  ROS_UNDERLAY_SETUP="$HOME/ros2_kilted/install/setup.bash"
   if [[ -z "$ROS_SETUP" ]]; then
     if [[ -f "$HOME/j5/ros_ws/install/setup.bash" ]]; then
       ROS_SETUP="$HOME/j5/ros_ws/install/setup.bash"
@@ -94,15 +227,19 @@ if [[ "$MODE" == "ros2" ]]; then
   unset CMAKE_PREFIX_PATH
   unset COLCON_CURRENT_PREFIX
 
+  set +u
   # shellcheck disable=SC1090
   source "$ROS_SETUP"
+  set -u
 
   if ! command -v ros2 >/dev/null 2>&1; then
-    if [[ -f "$HOME/ros2_kilted/install/setup.bash" ]]; then
+    if [[ -f "$ROS_UNDERLAY_SETUP" ]]; then
+      set +u
       # shellcheck disable=SC1090
-      source "$HOME/ros2_kilted/install/setup.bash"
+      source "$ROS_UNDERLAY_SETUP"
       # shellcheck disable=SC1090
       source "$ROS_SETUP"
+      set -u
     fi
   fi
 
@@ -142,12 +279,35 @@ export HTTP_PORT="$API_PORT"
 export NEXT_PUBLIC_API_BASE="http://$PI_IP:$API_PORT"
 export NEXT_PUBLIC_WS_URL="ws://$PI_IP:$API_PORT/ws"
 
-python -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
+"$VENV_PYTHON" -m uvicorn apps.racemanager.service.main:app --host "$HOST" --port "$API_PORT" --env-file apps/racemanager/service/.env &
 API_PID=$!
 
 (
   cd apps/racemanager/ui
-  npm install >/dev/null
+  LOCKFILE=""
+  if [[ -f package-lock.json ]]; then
+    LOCKFILE="package-lock.json"
+  elif [[ -f npm-shrinkwrap.json ]]; then
+    LOCKFILE="npm-shrinkwrap.json"
+  fi
+
+  DEPS_HASH_SOURCE="package.json"
+  if [[ -n "$LOCKFILE" ]]; then
+    DEPS_HASH_SOURCE="$LOCKFILE"
+  fi
+
+  CURRENT_DEPS_HASH="$(sha256sum "$DEPS_HASH_SOURCE" | awk '{print $1}')"
+  STORED_DEPS_HASH=""
+  if [[ -f node_modules/.deps-hash ]]; then
+    STORED_DEPS_HASH="$(cat node_modules/.deps-hash)"
+  fi
+
+  if [[ ! -d node_modules || "$CURRENT_DEPS_HASH" != "$STORED_DEPS_HASH" ]]; then
+    npm install >/dev/null
+    mkdir -p node_modules
+    printf '%s\n' "$CURRENT_DEPS_HASH" > node_modules/.deps-hash
+  fi
+
   npm run dev -- --hostname "$HOST" --port "$UI_PORT"
 ) &
 UI_PID=$!
@@ -155,10 +315,10 @@ UI_PID=$!
 sleep 2
 
 if [[ "$MODE" == "ros2" ]]; then
-  python apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
+  "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &
   BRIDGE_PID=$!
 else
-  python apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
+  "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode demo --service-url "http://localhost:$API_PORT" &
   BRIDGE_PID=$!
 fi
 


### PR DESCRIPTION
### Motivation
- Provide a single, robust all-in-one launcher for the Race Manager stack that works headless, under systemd, and with source-built ROS 2 workspaces.
- Make startup resilient in strict shells and CI/systemd environments by detecting/creating a virtualenv and locating Python/ROS binaries automatically.
- Reduce repeated frontend installs and make it easier to generate a systemd unit or run quick environment checks.

### Description
- Reworked `scripts/run_racemanager.sh` to set `SCRIPT_DIR`/`REPO_ROOT`, apply defensive defaults, and enable stricter error handling with traps for better diagnostics.
- Added Python detection (`find_python_bin`), automatic venv creation and use (`VENV_DIR`), and switched pip/uvicorn/bridge invocation to the venv Python binary.
- Added `--print-systemd` to emit a ready-to-run systemd service snippet and `--doctor` for environment checks; both are non-startup modes.
- Improved ROS 2 handling by allowing provided `--ros-setup`, searching for common overlay/underlay setup files, unsetting conflicting env vars, and repairing PATH when possible.
- Implemented npm dependency caching in `apps/racemanager/ui` by hashing `package-lock.json`/`npm-shrinkwrap.json` or `package.json` to avoid unnecessary `npm install` runs.
- Added checks for required commands (`npm`, Python) and clearer error messages, and ensured proper cleanup of child processes on exit.
- Updated `apps/racemanager/README.md` and `ros_ws/README.md` with usage examples for the new launcher, `--doctor`, `--print-systemd`, and systemd setup instructions.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ac40b9188323a5158c72d5ae7367)