### PR TITLE
Retain ROS2 subscription reference in race manager bridge to prevent segfault

### DIFF
--- a/apps/racemanager/bridge/bridge.py
+++ b/apps/racemanager/bridge/bridge.py
@@ -143,7 +143,12 @@ def run_ros2(bridge: RaceManagerBridge, *, topic: str) -> int:
     class Ros2LapBridge(Node):
         def __init__(self) -> None:
             super().__init__("race_manager_bridge")
-            self.create_subscription(String, topic, self._on_message, 10)
+            # Keep a strong reference to the subscription. rclpy subscriptions can
+            # be garbage-collected if not assigned, which may lead to unstable
+            # runtime behavior when messages are published.
+            self._subscription = self.create_subscription(
+                String, topic, self._on_message, 10
+            )
             self.get_logger().info(f"Subscribed to {topic}")
 
         def _on_message(self, msg: String) -> None:


### PR DESCRIPTION
### Motivation
- Prevent a segmentation fault caused by the ROS 2 subscription object being garbage-collected when the node did not keep a strong reference, which caused crashes when a publisher sent a lap JSON message.

### Description
- Keep the subscription handle on the node instance by assigning `self._subscription = self.create_subscription(String, topic, self._on_message, 10)` and add an explanatory comment about avoiding GC-related instability.

### Testing
- Ran `pre-commit run --files apps/racemanager/bridge/bridge.py` and the configured hooks passed.
- Ran `make test` in this environment which printed `colcon not installed`, so full ROS/colcon-based tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33ca049b0832398e4bf1b39512178)