### PR TITLE
ros2 bridge: offload message handling to background worker with queue and graceful shutdown

### DIFF
--- a/apps/racemanager/bridge/bridge.py
+++ b/apps/racemanager/bridge/bridge.py
@@ -12,7 +12,9 @@ import argparse
 import json
 import logging
 import os
+import queue
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -143,26 +145,56 @@ def run_ros2(bridge: RaceManagerBridge, *, topic: str) -> int:
     class Ros2LapBridge(Node):
         def __init__(self) -> None:
             super().__init__("race_manager_bridge")
-            self.create_subscription(String, topic, self._on_message, 10)
+            self._pending_messages: queue.Queue[Optional[str]] = queue.Queue(
+                maxsize=256
+            )
+            self._shutdown_event = threading.Event()
+            self._worker = threading.Thread(target=self._process_messages, daemon=True)
+            # Keep a strong reference to the subscription. rclpy subscriptions can
+            # be garbage-collected if not assigned, which may lead to unstable
+            # runtime behavior when messages are published.
+            self._subscription = self.create_subscription(
+                String, topic, self._on_message, 10
+            )
+            self._worker.start()
             self.get_logger().info(f"Subscribed to {topic}")
 
         def _on_message(self, msg: String) -> None:
             try:
-                lap = LapEvent.from_json(msg.data)
-                bridge.emit_lap(lap)
-                self.get_logger().info(
-                    f"forwarded lap car={lap.carId} lap={lap.sessionLap}"
+                self._pending_messages.put_nowait(msg.data)
+            except queue.Full:
+                self.get_logger().error(
+                    "dropping lap message because processing queue is full"
                 )
-            except Exception as err:
-                self.get_logger().error(f"failed to process lap message: {err}")
+
+        def _process_messages(self) -> None:
+            while not self._shutdown_event.is_set():
+                raw_message = self._pending_messages.get()
+                if raw_message is None:
+                    return
+                try:
+                    lap = LapEvent.from_json(raw_message)
+                    bridge.emit_lap(lap)
+                    self.get_logger().info(
+                        f"forwarded lap car={lap.carId} lap={lap.sessionLap}"
+                    )
+                except Exception as err:
+                    self.get_logger().error(f"failed to process lap message: {err}")
+
+        def close(self) -> None:
+            self._shutdown_event.set()
+            self._pending_messages.put(None)
+            self._worker.join(timeout=2)
 
     rclpy.init()
     node = Ros2LapBridge()
     try:
         rclpy.spin(node)
     finally:
+        node.close()
         node.destroy_node()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Prevent blocking and instability in the ROS 2 subscription callback by offloading JSON parsing and `emit_lap` to a background worker and avoid subscription garbage-collection.
- Ensure the bridge can drop excess messages when overwhelmed and shut down cleanly without hanging `rclpy`.

### Description
- Added `queue` and `threading` usage and created a bounded `self._pending_messages` queue with a daemon `_worker` thread that runs `_process_messages` to handle messages outside the callback.
- Kept a strong reference to the subscription in `self._subscription` to avoid rclpy subscription GC, changed `_on_message` to enqueue `msg.data`, and log and drop messages on `queue.Full`.
- Implemented `_process_messages` to parse `LapEvent` and call `bridge.emit_lap`, with error logging, and used a `None` sentinel plus `_shutdown_event` for graceful worker termination.
- Added `close` to signal and join the worker, invoked `node.close()` in the shutdown path, and only call `rclpy.shutdown()` if `rclpy.ok()`.

### Testing
- Ran the test suite with `pytest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33ca049b0832398e4bf1b39512178)