### PR TITLE
Fix ROS 2 bridge subscription lifetime, message handling, and shutdown behavior

### DIFF
--- a/apps/racemanager/bridge/bridge.py
+++ b/apps/racemanager/bridge/bridge.py
@@ -143,12 +143,19 @@ def run_ros2(bridge: RaceManagerBridge, *, topic: str) -> int:
     class Ros2LapBridge(Node):
         def __init__(self) -> None:
             super().__init__("race_manager_bridge")
-            self.create_subscription(String, topic, self._on_message, 10)
+            # Keep a strong reference to the subscription. rclpy subscriptions can
+            # be garbage-collected if not assigned, which may lead to unstable
+            # runtime behavior when messages are published.
+            self._subscription = self.create_subscription(
+                String, topic, self._on_message, 10
+            )
             self.get_logger().info(f"Subscribed to {topic}")
 
         def _on_message(self, msg: String) -> None:
             try:
-                lap = LapEvent.from_json(msg.data)
+                # Copy to a pure Python string before processing.
+                raw_message = str(msg.data)
+                lap = LapEvent.from_json(raw_message)
                 bridge.emit_lap(lap)
                 self.get_logger().info(
                     f"forwarded lap car={lap.carId} lap={lap.sessionLap}"
@@ -160,9 +167,12 @@ def run_ros2(bridge: RaceManagerBridge, *, topic: str) -> int:
     node = Ros2LapBridge()
     try:
         rclpy.spin(node)
+    except KeyboardInterrupt:
+        logger.info("received Ctrl-C, shutting down ROS 2 bridge")
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Prevent unstable runtime behavior in the ROS 2 lap bridge due to subscriptions being garbage-collected or messages being processed in a non-Python-native form.
- Improve shutdown and signal handling to ensure the ROS 2 runtime is cleanly shut down on Ctrl-C and only when appropriate.

### Description
- Keep a strong reference to the ROS 2 subscription by assigning `self._subscription = create_subscription(...)` to prevent GC-related issues with `create_subscription`.
- Convert incoming ROS 2 message payload to a native Python string via `raw_message = str(msg.data)` before calling `LapEvent.from_json(raw_message)` to avoid type/serialization issues.
- Add `except KeyboardInterrupt` during `rclpy.spin(node)` to log shutdown on Ctrl-C events.
- Only call `rclpy.shutdown()` in the `finally` block when `rclpy.ok()` returns true to avoid calling shutdown after an already-terminated runtime.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33ca049b0832398e4bf1b39512178)