### PR TITLE
Fix ROS 2 subscription lifetime and improve spin/shutdown behavior in bridge

### DIFF
--- a/apps/racemanager/bridge/bridge.py
+++ b/apps/racemanager/bridge/bridge.py
@@ -143,12 +143,19 @@ def run_ros2(bridge: RaceManagerBridge, *, topic: str) -> int:
     class Ros2LapBridge(Node):
         def __init__(self) -> None:
             super().__init__("race_manager_bridge")
-            self.create_subscription(String, topic, self._on_message, 10)
+            # Keep a strong reference to the subscription. rclpy subscriptions can
+            # be garbage-collected if not assigned, which may lead to unstable
+            # runtime behavior when messages are published.
+            self._subscription = self.create_subscription(
+                String, topic, self._on_message, 10
+            )
             self.get_logger().info(f"Subscribed to {topic}")
 
         def _on_message(self, msg: String) -> None:
             try:
-                lap = LapEvent.from_json(msg.data)
+                # Copy to a pure Python string before processing.
+                raw_message = str(msg.data)
+                lap = LapEvent.from_json(raw_message)
                 bridge.emit_lap(lap)
                 self.get_logger().info(
                     f"forwarded lap car={lap.carId} lap={lap.sessionLap}"
@@ -158,11 +165,22 @@ def run_ros2(bridge: RaceManagerBridge, *, topic: str) -> int:
 
     rclpy.init()
     node = Ros2LapBridge()
+    executor = rclpy.executors.SingleThreadedExecutor()
+    executor.add_node(node)
     try:
-        rclpy.spin(node)
+        while rclpy.ok():
+            executor.spin_once(timeout_sec=0.2)
+    except KeyboardInterrupt:
+        logger.info("received Ctrl-C, shutting down ROS 2 bridge")
     finally:
+        try:
+            executor.remove_node(node)
+            executor.shutdown(timeout_sec=1.0)
+        except Exception as err:
+            logger.debug("executor shutdown warning: %s", err)
         node.destroy_node()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
     return 0
 
 


### PR DESCRIPTION
### Motivation

- Prevent intermittent ROS 2 bridge failures caused by subscriptions being garbage-collected and improve robustness of the ROS 2 runtime loop and shutdown.

### Description

- Keep a strong reference to the ROS 2 subscription by assigning it to `self._subscription` to prevent garbage collection. 
- Copy incoming `msg.data` into a pure Python string before parsing to avoid type/encoding issues when calling `LapEvent.from_json`.
- Replace `rclpy.spin(node)` with an explicit `SingleThreadedExecutor` loop using `executor.spin_once(timeout_sec=0.2)` to allow controlled spinning and responsive shutdown handling.
- Add graceful executor teardown with `executor.remove_node(node)` and `executor.shutdown(timeout_sec=1.0)` inside a `try/except`, and only call `rclpy.shutdown()` if `rclpy.ok()`.

### Testing

- Ran the project's unit test suite with `pytest -q` and all tests completed successfully. 
- Ran static checks (`flake8`) on the modified file and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33ca049b0832398e4bf1b39512178)