### PR TITLE
Add web-based race setup wizard, runtime controls, and documentation

### DIFF
--- a/docs/race_manager.md
+++ b/docs/race_manager.md
@@ -78,3 +78,20 @@ bridge and ROS workspace can reference it predictably:
 
 Keeping `racetrack-master-pro` inside `apps/racemanager` preserves a single interface point to the ROS/perception side and
 avoids duplicating bridge logic elsewhere in the workspace.
+
+
+## Race setup wizard in `race-master-pro`
+
+The `ros_ws/src/j5_perception/race-master-pro` app now includes an operator-first setup wizard in the **Settings** tab, paired with **Computer Vision** tab actions. The wizard enforces ordered checks and surfaces: the current blocking step, the exact shell command to run next, connect/stop buttons, and verification status for each stage.
+
+Flow covered end-to-end:
+
+1. ROS2 prerequisites and package visibility
+2. Headless Raspberry Pi connectivity
+3. Backend API health
+4. Camera preview + track image capture
+5. Race initialization data (event/race/racers/laps)
+6. Tracking start + lap log monitoring
+7. Pause/snapshot/resume controls with state restoration
+
+State is persisted server-side so laps counted, racer metadata, and setup context can be restored after pause/resume.

--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -351,3 +351,47 @@ See `docs/PI_DEPLOYMENT_GAP_ANALYSIS.md` for architecture status and priority ro
 ## License
 
 MIT
+
+
+## Web Setup Wizard (Settings + Vision tabs)
+
+Race setup can now be driven from the web UI in ordered steps under **Settings**:
+
+1. Verify ROS2 CLI availability (`ros2`, `launch`)
+2. Verify Raspberry Pi reachability
+3. Verify backend health endpoint
+4. Verify camera preview service
+5. Initialize race state (event/race/racers)
+
+The Settings wizard shows for each step:
+
+- verification status (connected/not connected)
+- exact command needed to continue
+- one-click buttons to verify, connect/reconnect, and stop
+- the next-step command so operators can progress linearly
+
+Backend endpoints added for this workflow:
+
+- `GET /api/setup/wizard`
+- `PUT /api/setup/wizard/config`
+- `POST /api/setup/wizard/steps/{step_id}/verify|connect|stop`
+- `POST /api/setup/wizard/initialize`
+- `POST /api/setup/wizard/reset`
+
+### Vision flow updates
+
+After setup is connected:
+
+- use **Vision** tab to capture the track image
+- start/stop tracking from the same panel
+- inspect live lap/tracking logs streamed from backend state
+
+### Pause / Resume with state restore
+
+Race state persistence now supports snapshot and resume:
+
+- `POST /api/races/{race_id}/snapshot` to persist race + laps + results + setup context
+- `POST /api/races/{race_id}/resume` to restore snapshot context and continue race
+- `GET /api/races/{race_id}/state` for current runtime state
+
+This enables preserving laps counted, track image workflow state, racer metadata, and log context when pausing/resuming operations through the web interface.

--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -8,6 +8,7 @@ import json
 import uuid
 from datetime import datetime
 from contextlib import asynccontextmanager
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -66,8 +67,9 @@ _SETUP_STEPS = [
         "id": "ros2_cli",
         "title": "ROS2 CLI on PATH",
         "description": "Ensure ros2 and launch verbs are available in the active shell.",
-        "check_commands": ["command -v ros2", "ros2 -h | rg -w launch"],
-        "connect_command": "source /opt/ros/iron/setup.bash && source ~/alive/j5/ros_ws/install/setup.bash",
+        "check_commands": ["ros2 --help"],
+        "check_contains": ["launch"],
+        "connect_command": ". /opt/ros/iron/setup.bash && . ~/alive/j5/ros_ws/install/setup.bash",
         "stop_command": "pkill -f ros2 || true",
     },
     {
@@ -77,6 +79,8 @@ _SETUP_STEPS = [
         "check_commands": ["ping -c 1 {pi_host}"],
         "connect_command": "ssh {pi_user}@{pi_host} 'echo pi-online'",
         "stop_command": "echo 'No persistent process to stop for connectivity check'",
+        "connect_commands": ["ssh {pi_user}@{pi_host} echo pi-online"],
+        "stop_commands": ["echo No persistent process to stop for connectivity check"],
     },
     {
         "id": "backend_service",
@@ -85,6 +89,8 @@ _SETUP_STEPS = [
         "check_commands": ["curl -sf {backend_url}/health"],
         "connect_command": "cd backend && source .venv/bin/activate && python -m app.main",
         "stop_command": "pkill -f 'python -m app.main' || true",
+        "manual_connect": True,
+        "stop_commands": ["pkill -f python -m app.main"],
     },
     {
         "id": "vision_preview",
@@ -93,6 +99,8 @@ _SETUP_STEPS = [
         "check_commands": ["curl -sf {preview_url}/health"],
         "connect_command": "python scripts/pi_preflight.py --serve-preview --preview-host 0.0.0.0 --preview-port 8091",
         "stop_command": "pkill -f pi_preflight.py || true",
+        "manual_connect": True,
+        "stop_commands": ["pkill -f pi_preflight.py"],
     },
     {
         "id": "race_state",
@@ -101,6 +109,7 @@ _SETUP_STEPS = [
         "check_commands": [],
         "connect_command": "POST /api/setup/wizard/initialize",
         "stop_command": "POST /api/setup/wizard/reset",
+        "manual_connect": True,
     },
 ]
 
@@ -140,9 +149,34 @@ async def _set_state_json(key: str, value):
     await insert_row("system_state", payload)
 
 
+def _validate_setup_config(config: dict) -> dict:
+    merged = {**_DEFAULT_SETUP_CONFIG, **config}
+
+    def _safe_token(name: str, value: str):
+        if not value or any(
+            ch in value for ch in [";", "&", "|", "$", "`", "\n", "\r", "\t"]
+        ):
+            raise HTTPException(400, f"Invalid characters in {name}")
+
+    pi_host = str(merged.get("pi_host", "")).strip()
+    pi_user = str(merged.get("pi_user", "")).strip()
+    _safe_token("pi_host", pi_host)
+    _safe_token("pi_user", pi_user)
+
+    for field in ("backend_url", "preview_url"):
+        parsed = urlparse(str(merged.get(field, "")).strip())
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise HTTPException(400, f"Invalid URL for {field}")
+
+    merged["pi_host"] = pi_host
+    merged["pi_user"] = pi_user
+    return merged
+
+
 async def _run_shell_command(command: str):
-    process = await asyncio.create_subprocess_shell(
-        command,
+    argv = command.split()
+    process = await asyncio.create_subprocess_exec(
+        *argv,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
@@ -162,6 +196,7 @@ def _render_command(template: str, config: dict):
 
 async def _build_setup_status():
     config = await _get_state_json("setup_config", _DEFAULT_SETUP_CONFIG)
+    config = _validate_setup_config(config)
     overrides = await _get_state_json("setup_step_overrides", {})
     race_context = await _get_state_json("race_context", {})
     steps = []
@@ -176,10 +211,17 @@ async def _build_setup_status():
             for cmd_template in step["check_commands"]:
                 command = _render_command(cmd_template, config)
                 result = await _run_shell_command(command)
+                expected_tokens = step.get("check_contains", [])
+                if expected_tokens and result["ok"]:
+                    result["ok"] = all(
+                        token in result["stdout"] for token in expected_tokens
+                    )
                 checks.append(result)
                 if not result["ok"]:
                     check_ok = False
-        connected = bool(state.get("connected", check_ok))
+        connected = bool(check_ok)
+        if state.get("connected") is False:
+            connected = False
         step_data = {
             "id": step["id"],
             "title": step["title"],
@@ -624,7 +666,7 @@ async def get_setup_wizard_status():
 
 @app.put("/api/setup/wizard/config")
 async def update_setup_wizard_config(config: dict):
-    merged = {**_DEFAULT_SETUP_CONFIG, **config}
+    merged = _validate_setup_config(config)
     await _set_state_json("setup_config", merged)
     return await _build_setup_status()
 
@@ -652,21 +694,30 @@ async def verify_setup_step(step_id: str):
 @app.post("/api/setup/wizard/steps/{step_id}/connect")
 async def connect_setup_step(step_id: str):
     config = await _get_state_json("setup_config", _DEFAULT_SETUP_CONFIG)
+    config = _validate_setup_config(config)
     step = next((item for item in _SETUP_STEPS if item["id"] == step_id), None)
     if not step:
         raise HTTPException(404, "Setup step not found")
     command = _render_command(step["connect_command"], config)
     result = {
-        "ok": True,
-        "stdout": "Use this command in a dedicated terminal for long-running services.",
+        "ok": False,
+        "stdout": "Run the command shown and then click Verify.",
         "stderr": "",
-        "return_code": 0,
+        "return_code": 1,
     }
-    if step_id in {"ros2_cli", "pi_connectivity"}:
-        result = await _run_shell_command(command)
+    connect_commands = step.get("connect_commands", [])
+    if connect_commands:
+        rendered = [_render_command(cmd, config) for cmd in connect_commands]
+        last_result = None
+        for cmd in rendered:
+            last_result = await _run_shell_command(cmd)
+            if not last_result["ok"]:
+                break
+        if last_result:
+            result = last_result
     overrides = await _get_state_json("setup_step_overrides", {})
     overrides[step_id] = {
-        "connected": result["ok"],
+        "connected": bool(result["ok"]),
         "last_action": {
             "type": "connect",
             "timestamp": datetime.now().isoformat(),
@@ -691,11 +742,18 @@ async def connect_setup_step(step_id: str):
 @app.post("/api/setup/wizard/steps/{step_id}/stop")
 async def stop_setup_step(step_id: str):
     config = await _get_state_json("setup_config", _DEFAULT_SETUP_CONFIG)
+    config = _validate_setup_config(config)
     step = next((item for item in _SETUP_STEPS if item["id"] == step_id), None)
     if not step:
         raise HTTPException(404, "Setup step not found")
     command = _render_command(step["stop_command"], config)
-    result = await _run_shell_command(command)
+    stop_commands = step.get("stop_commands", [command])
+    result = {"ok": True, "stdout": "", "stderr": "", "return_code": 0}
+    for raw_cmd in stop_commands:
+        rendered = _render_command(raw_cmd, config)
+        result = await _run_shell_command(rendered)
+        if not result["ok"]:
+            break
     overrides = await _get_state_json("setup_step_overrides", {})
     overrides[step_id] = {
         "connected": False,

--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -3,6 +3,7 @@ Race Master Pro — FastAPI Backend
 Main application entry point with REST API + WebSocket endpoints.
 """
 
+import asyncio
 import json
 import uuid
 from datetime import datetime
@@ -59,6 +60,145 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+_SETUP_STEPS = [
+    {
+        "id": "ros2_cli",
+        "title": "ROS2 CLI on PATH",
+        "description": "Ensure ros2 and launch verbs are available in the active shell.",
+        "check_commands": ["command -v ros2", "ros2 -h | rg -w launch"],
+        "connect_command": "source /opt/ros/iron/setup.bash && source ~/alive/j5/ros_ws/install/setup.bash",
+        "stop_command": "pkill -f ros2 || true",
+    },
+    {
+        "id": "pi_connectivity",
+        "title": "Headless Raspberry Pi Reachability",
+        "description": "Verify the configured Pi host responds before starting services.",
+        "check_commands": ["ping -c 1 {pi_host}"],
+        "connect_command": "ssh {pi_user}@{pi_host} 'echo pi-online'",
+        "stop_command": "echo 'No persistent process to stop for connectivity check'",
+    },
+    {
+        "id": "backend_service",
+        "title": "Race Master backend API",
+        "description": "Backend must be reachable to drive setup + live controls.",
+        "check_commands": ["curl -sf {backend_url}/health"],
+        "connect_command": "cd backend && source .venv/bin/activate && python -m app.main",
+        "stop_command": "pkill -f 'python -m app.main' || true",
+    },
+    {
+        "id": "vision_preview",
+        "title": "Camera preview stream",
+        "description": "Preview and track-image capture endpoint from the Pi.",
+        "check_commands": ["curl -sf {preview_url}/health"],
+        "connect_command": "python scripts/pi_preflight.py --serve-preview --preview-host 0.0.0.0 --preview-port 8091",
+        "stop_command": "pkill -f pi_preflight.py || true",
+    },
+    {
+        "id": "race_state",
+        "title": "Race configured",
+        "description": "Race metadata + racers + lap target saved and ready to initialize.",
+        "check_commands": [],
+        "connect_command": "POST /api/setup/wizard/initialize",
+        "stop_command": "POST /api/setup/wizard/reset",
+    },
+]
+
+_DEFAULT_SETUP_CONFIG = {
+    "pi_host": "raspberrypi.local",
+    "pi_user": "pi",
+    "backend_url": "http://localhost:8080",
+    "preview_url": "http://localhost:8091",
+    "race_name": "Main Event",
+    "event_name": "Weekend Session",
+    "total_laps": 20,
+    "racer_names": ["Racer 1", "Racer 2"],
+}
+
+
+async def _get_state_json(key: str, default: dict | list | None = None):
+    row = await get_row("system_state", key, id_column="key")
+    if not row:
+        return default
+    try:
+        return json.loads(row["value"])
+    except json.JSONDecodeError:
+        return default
+
+
+async def _set_state_json(key: str, value):
+    payload = {"key": key, "value": json.dumps(value)}
+    existing = await get_row("system_state", key, id_column="key")
+    if existing:
+        await update_row(
+            "system_state",
+            key,
+            {"value": payload["value"], "updated_at": datetime.now().isoformat()},
+            id_column="key",
+        )
+        return
+    await insert_row("system_state", payload)
+
+
+async def _run_shell_command(command: str):
+    process = await asyncio.create_subprocess_shell(
+        command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    return {
+        "command": command,
+        "return_code": process.returncode,
+        "stdout": stdout.decode().strip(),
+        "stderr": stderr.decode().strip(),
+        "ok": process.returncode == 0,
+    }
+
+
+def _render_command(template: str, config: dict):
+    return template.format(**config)
+
+
+async def _build_setup_status():
+    config = await _get_state_json("setup_config", _DEFAULT_SETUP_CONFIG)
+    overrides = await _get_state_json("setup_step_overrides", {})
+    race_context = await _get_state_json("race_context", {})
+    steps = []
+    for step in _SETUP_STEPS:
+        state = overrides.get(step["id"], {})
+        checks = []
+        check_ok = True
+        if step["id"] == "race_state":
+            check_ok = bool(race_context.get("race_id"))
+            checks = [{"command": "race context exists", "ok": check_ok}]
+        else:
+            for cmd_template in step["check_commands"]:
+                command = _render_command(cmd_template, config)
+                result = await _run_shell_command(command)
+                checks.append(result)
+                if not result["ok"]:
+                    check_ok = False
+        connected = bool(state.get("connected", check_ok))
+        step_data = {
+            "id": step["id"],
+            "title": step["title"],
+            "description": step["description"],
+            "connected": connected,
+            "checks": checks,
+            "next_command": _render_command(step["connect_command"], config),
+            "stop_command": _render_command(step["stop_command"], config),
+            "last_action": state.get("last_action"),
+            "last_error": state.get("last_error"),
+        }
+        steps.append(step_data)
+    for idx, step in enumerate(steps):
+        if not step["connected"]:
+            step["is_current"] = True
+            if idx + 1 < len(steps):
+                step["next_step_command"] = steps[idx + 1]["next_command"]
+            break
+    return {"config": config, "steps": steps, "race_context": race_context}
 
 
 # ── Health ──────────────────────────────────────────────────
@@ -474,6 +614,276 @@ async def championship_standings(champ_id: str):
     )
 
 
+# ── Setup Wizard + Runtime State ──────────────────────────
+
+
+@app.get("/api/setup/wizard")
+async def get_setup_wizard_status():
+    return await _build_setup_status()
+
+
+@app.put("/api/setup/wizard/config")
+async def update_setup_wizard_config(config: dict):
+    merged = {**_DEFAULT_SETUP_CONFIG, **config}
+    await _set_state_json("setup_config", merged)
+    return await _build_setup_status()
+
+
+@app.post("/api/setup/wizard/steps/{step_id}/verify")
+async def verify_setup_step(step_id: str):
+    status = await _build_setup_status()
+    step = next((item for item in status["steps"] if item["id"] == step_id), None)
+    if not step:
+        raise HTTPException(404, "Setup step not found")
+    overrides = await _get_state_json("setup_step_overrides", {})
+    overrides[step_id] = {
+        "connected": step["connected"],
+        "last_action": {
+            "type": "verify",
+            "timestamp": datetime.now().isoformat(),
+            "result": step["checks"],
+        },
+        "last_error": None if step["connected"] else "Verification failed",
+    }
+    await _set_state_json("setup_step_overrides", overrides)
+    return await _build_setup_status()
+
+
+@app.post("/api/setup/wizard/steps/{step_id}/connect")
+async def connect_setup_step(step_id: str):
+    config = await _get_state_json("setup_config", _DEFAULT_SETUP_CONFIG)
+    step = next((item for item in _SETUP_STEPS if item["id"] == step_id), None)
+    if not step:
+        raise HTTPException(404, "Setup step not found")
+    command = _render_command(step["connect_command"], config)
+    result = {
+        "ok": True,
+        "stdout": "Use this command in a dedicated terminal for long-running services.",
+        "stderr": "",
+        "return_code": 0,
+    }
+    if step_id in {"ros2_cli", "pi_connectivity"}:
+        result = await _run_shell_command(command)
+    overrides = await _get_state_json("setup_step_overrides", {})
+    overrides[step_id] = {
+        "connected": result["ok"],
+        "last_action": {
+            "type": "connect",
+            "timestamp": datetime.now().isoformat(),
+            "command": command,
+            "result": result,
+        },
+        "last_error": (
+            None
+            if result["ok"]
+            else result.get("stderr") or result.get("stdout") or "Connect failed"
+        ),
+    }
+    await _set_state_json("setup_step_overrides", overrides)
+    return {
+        "step_id": step_id,
+        "command": command,
+        "result": result,
+        "wizard": await _build_setup_status(),
+    }
+
+
+@app.post("/api/setup/wizard/steps/{step_id}/stop")
+async def stop_setup_step(step_id: str):
+    config = await _get_state_json("setup_config", _DEFAULT_SETUP_CONFIG)
+    step = next((item for item in _SETUP_STEPS if item["id"] == step_id), None)
+    if not step:
+        raise HTTPException(404, "Setup step not found")
+    command = _render_command(step["stop_command"], config)
+    result = await _run_shell_command(command)
+    overrides = await _get_state_json("setup_step_overrides", {})
+    overrides[step_id] = {
+        "connected": False,
+        "last_action": {
+            "type": "stop",
+            "timestamp": datetime.now().isoformat(),
+            "command": command,
+            "result": result,
+        },
+        "last_error": (
+            None
+            if result["ok"]
+            else result.get("stderr") or result.get("stdout") or "Stop failed"
+        ),
+    }
+    await _set_state_json("setup_step_overrides", overrides)
+    return {
+        "step_id": step_id,
+        "command": command,
+        "result": result,
+        "wizard": await _build_setup_status(),
+    }
+
+
+@app.post("/api/setup/wizard/initialize")
+async def initialize_race_from_wizard():
+    config = await _get_state_json("setup_config", _DEFAULT_SETUP_CONFIG)
+    event = await insert_row(
+        "race_events",
+        {
+            "id": str(uuid.uuid4()),
+            "name": config.get("event_name", "Setup Wizard Event"),
+            "championship_id": None,
+            "track_id": None,
+            "event_date": datetime.now().date().isoformat(),
+            "round_number": 1,
+        },
+    )
+    race = await insert_row(
+        "races",
+        {
+            "id": str(uuid.uuid4()),
+            "event_id": event["id"],
+            "type": "main",
+            "status": "setup",
+            "total_laps": int(config.get("total_laps", 20)),
+            "start_time": None,
+            "end_time": None,
+        },
+    )
+    racers = []
+    for idx, name in enumerate(config.get("racer_names", []), start=1):
+        racer = await insert_row(
+            "racer_profiles",
+            {
+                "id": str(uuid.uuid4()),
+                "name": name,
+                "number": str(idx),
+                "profile_pic": None,
+                "vehicle_description": None,
+            },
+        )
+        racers.append(racer)
+    context = {
+        "race_id": race["id"],
+        "event_id": event["id"],
+        "race_name": config.get("race_name", "Main Event"),
+        "track_image_captured": False,
+        "tracking_enabled": False,
+        "racers": racers,
+        "log_stream": [],
+    }
+    await _set_state_json("race_context", context)
+    overrides = await _get_state_json("setup_step_overrides", {})
+    overrides["race_state"] = {
+        "connected": True,
+        "last_action": {"type": "initialize", "timestamp": datetime.now().isoformat()},
+        "last_error": None,
+    }
+    await _set_state_json("setup_step_overrides", overrides)
+    return {
+        "race": race,
+        "event": event,
+        "racers": racers,
+        "wizard": await _build_setup_status(),
+    }
+
+
+@app.post("/api/setup/wizard/reset")
+async def reset_wizard_race_context():
+    await _set_state_json("race_context", {})
+    overrides = await _get_state_json("setup_step_overrides", {})
+    overrides["race_state"] = {
+        "connected": False,
+        "last_action": {"type": "reset", "timestamp": datetime.now().isoformat()},
+        "last_error": None,
+    }
+    await _set_state_json("setup_step_overrides", overrides)
+    return await _build_setup_status()
+
+
+@app.get("/api/races/{race_id}/state")
+async def get_race_runtime_state(race_id: str):
+    race = await get_row("races", race_id)
+    if not race:
+        raise HTTPException(404, "Race not found")
+    context = await _get_state_json("race_context", {})
+    snapshots = await _get_state_json("race_snapshots", {})
+    return {"race": race, "context": context, "snapshot": snapshots.get(race_id)}
+
+
+@app.post("/api/races/{race_id}/snapshot")
+async def snapshot_race_state(race_id: str):
+    race = await get_row("races", race_id)
+    if not race:
+        raise HTTPException(404, "Race not found")
+    laps = await get_all_rows("lap_records", where={"race_id": race_id})
+    results = await get_all_rows("race_results", where={"race_id": race_id})
+    context = await _get_state_json("race_context", {})
+    snapshot = {
+        "race": race,
+        "laps": laps,
+        "results": results,
+        "context": context,
+        "saved_at": datetime.now().isoformat(),
+    }
+    snapshots = await _get_state_json("race_snapshots", {})
+    snapshots[race_id] = snapshot
+    await _set_state_json("race_snapshots", snapshots)
+    return snapshot
+
+
+@app.post("/api/races/{race_id}/resume")
+async def resume_race_from_snapshot(race_id: str):
+    snapshots = await _get_state_json("race_snapshots", {})
+    snapshot = snapshots.get(race_id)
+    if not snapshot:
+        raise HTTPException(404, "No snapshot found for race")
+    await update_row("races", race_id, {"status": "active"})
+    await _set_state_json("race_context", snapshot.get("context", {}))
+    await manager.broadcast_all(
+        {
+            "type": "raceResume",
+            "data": {"race_id": race_id, "snapshot_time": snapshot.get("saved_at")},
+            "timestamp": datetime.now().isoformat(),
+        }
+    )
+    return {"resumed": True, "snapshot": snapshot}
+
+
+@app.post("/api/races/{race_id}/tracking/start")
+async def start_tracking(race_id: str):
+    context = await _get_state_json("race_context", {})
+    context["tracking_enabled"] = True
+    context.setdefault("log_stream", []).append(
+        f"{datetime.now().isoformat()} Tracking started for race {race_id}"
+    )
+    await _set_state_json("race_context", context)
+    return context
+
+
+@app.post("/api/races/{race_id}/tracking/stop")
+async def stop_tracking(race_id: str):
+    context = await _get_state_json("race_context", {})
+    context["tracking_enabled"] = False
+    context.setdefault("log_stream", []).append(
+        f"{datetime.now().isoformat()} Tracking stopped for race {race_id}"
+    )
+    await _set_state_json("race_context", context)
+    return context
+
+
+@app.post("/api/races/{race_id}/logs")
+async def append_race_log(race_id: str, payload: dict):
+    context = await _get_state_json("race_context", {})
+    entry = payload.get("entry", f"{datetime.now().isoformat()} log")
+    context.setdefault("log_stream", []).append(entry)
+    await _set_state_json("race_context", context)
+    await manager.broadcast_all(
+        {
+            "type": "lapLog",
+            "data": {"race_id": race_id, "entry": entry},
+            "timestamp": datetime.now().isoformat(),
+        }
+    )
+    return {"ok": True, "entry": entry}
+
+
 # ── WebSocket ───────────────────────────────────────────────
 
 
@@ -505,6 +915,8 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str = "spectator
                 "raceStart",
                 "racePause",
                 "raceFinish",
+                "raceResume",
+                "lapLog",
             ):
                 # Relay race events to all clients
                 message["timestamp"] = datetime.now().isoformat()

--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/schemas.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/schemas.py
@@ -167,4 +167,11 @@ CREATE INDEX IF NOT EXISTS idx_lap_records_racer ON lap_records(racer_profile_id
 CREATE INDEX IF NOT EXISTS idx_lap_records_race_racer ON lap_records(race_id, racer_profile_id);
 CREATE INDEX IF NOT EXISTS idx_detections_race ON detections(race_id);
 CREATE INDEX IF NOT EXISTS idx_detections_timestamp ON detections(recorded_at);
+
+-- Generic key/value system state store for setup wizard + runtime snapshots
+CREATE TABLE IF NOT EXISTS system_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 """

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,12 +1,218 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+
+interface SetupCheckResult {
+    command: string
+    ok: boolean
+    stdout?: string
+    stderr?: string
+}
+
+interface SetupStep {
+    id: string
+    title: string
+    description: string
+    connected: boolean
+    checks: SetupCheckResult[]
+    next_command: string
+    stop_command: string
+    next_step_command?: string
+    is_current?: boolean
+    last_error?: string | null
+}
+
+interface WizardStatus {
+    config: Record<string, unknown>
+    steps: SetupStep[]
+    race_context: Record<string, unknown>
+}
+
+const defaultConfig = {
+    pi_host: 'raspberrypi.local',
+    pi_user: 'pi',
+    backend_url: 'http://localhost:8080',
+    preview_url: 'http://localhost:8091',
+    race_name: 'Main Event',
+    event_name: 'Weekend Session',
+    total_laps: 20,
+    racer_names: 'Racer 1, Racer 2',
+}
+
 export default function SettingsPanel() {
+    const [wizard, setWizard] = useState<WizardStatus | null>(null)
+    const [busyStepId, setBusyStepId] = useState<string | null>(null)
+    const [error, setError] = useState('')
+    const [config, setConfig] = useState(defaultConfig)
+
+    const loadWizard = async () => {
+        try {
+            const response = await fetch('/api/setup/wizard')
+            if (!response.ok) throw new Error('Failed to load wizard status')
+            const payload: WizardStatus = await response.json()
+            const rawNames = (payload.config.racer_names as string[] | undefined) || []
+            setWizard(payload)
+            setConfig({
+                pi_host: String(payload.config.pi_host ?? defaultConfig.pi_host),
+                pi_user: String(payload.config.pi_user ?? defaultConfig.pi_user),
+                backend_url: String(payload.config.backend_url ?? defaultConfig.backend_url),
+                preview_url: String(payload.config.preview_url ?? defaultConfig.preview_url),
+                race_name: String(payload.config.race_name ?? defaultConfig.race_name),
+                event_name: String(payload.config.event_name ?? defaultConfig.event_name),
+                total_laps: Number(payload.config.total_laps ?? defaultConfig.total_laps),
+                racer_names: rawNames.join(', '),
+            })
+            setError('')
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Unable to load setup wizard.')
+        }
+    }
+
+    useEffect(() => {
+        loadWizard()
+    }, [])
+
+    const currentStep = useMemo(() => wizard?.steps.find(step => step.is_current), [wizard])
+
+    const runStepAction = async (stepId: string, action: 'verify' | 'connect' | 'stop') => {
+        setBusyStepId(stepId)
+        try {
+            const response = await fetch(`/api/setup/wizard/steps/${stepId}/${action}`, { method: 'POST' })
+            if (!response.ok) throw new Error(`Failed to ${action} step ${stepId}`)
+            const payload = await response.json()
+            setWizard(payload.wizard || payload)
+            setError('')
+        } catch (err) {
+            setError(err instanceof Error ? err.message : `Unable to ${action} step.`)
+        } finally {
+            setBusyStepId(null)
+        }
+    }
+
+    const onSaveConfig = async (event: FormEvent) => {
+        event.preventDefault()
+        try {
+            const response = await fetch('/api/setup/wizard/config', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    ...config,
+                    racer_names: config.racer_names
+                        .split(',')
+                        .map(name => name.trim())
+                        .filter(Boolean),
+                }),
+            })
+            if (!response.ok) throw new Error('Failed to save wizard config')
+            const payload = await response.json()
+            setWizard(payload)
+            setError('')
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Unable to save setup configuration.')
+        }
+    }
+
+    const controlRace = async (action: 'start' | 'pause' | 'snapshot' | 'resume') => {
+        const raceId = String(wizard?.race_context?.race_id || '')
+        if (!raceId) {
+            setError('Initialize race state first before using race controls.')
+            return
+        }
+        const endpointMap: Record<'start' | 'pause' | 'snapshot' | 'resume', string> = {
+            start: `/api/races/${raceId}/start`,
+            pause: `/api/races/${raceId}/pause`,
+            snapshot: `/api/races/${raceId}/snapshot`,
+            resume: `/api/races/${raceId}/resume`,
+        }
+        try {
+            const response = await fetch(endpointMap[action], { method: 'POST' })
+            if (!response.ok) throw new Error(`Failed to ${action} race`)
+            await loadWizard()
+        } catch (err) {
+            setError(err instanceof Error ? err.message : `Unable to ${action} race.`)
+        }
+    }
+
+    const initializeRace = async () => {
+        try {
+            const response = await fetch('/api/setup/wizard/initialize', { method: 'POST' })
+            if (!response.ok) throw new Error('Failed to initialize race state')
+            const payload = await response.json()
+            setWizard(payload.wizard)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Unable to initialize race.')
+        }
+    }
+
     return (
         <div className="fade-in space-y-4">
-            <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Settings</h2>
-            <div className="race-card p-8 text-center">
-                <div className="text-4xl mb-3">⚙️</div>
-                <p className="text-[var(--color-text-secondary)]">
-                    Track setup, race configuration, app settings, and data import/export.
-                </p>
+            <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Settings · Race Setup Wizard</h2>
+
+            <div className="race-card p-4">
+                <h3 className="mb-2 text-base font-semibold">Configuration</h3>
+                <form className="grid gap-3 md:grid-cols-2" onSubmit={onSaveConfig}>
+                    <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.pi_host} onChange={e => setConfig(prev => ({ ...prev, pi_host: e.target.value }))} placeholder="Pi host" />
+                    <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.pi_user} onChange={e => setConfig(prev => ({ ...prev, pi_user: e.target.value }))} placeholder="Pi user" />
+                    <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.backend_url} onChange={e => setConfig(prev => ({ ...prev, backend_url: e.target.value }))} placeholder="Backend URL" />
+                    <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.preview_url} onChange={e => setConfig(prev => ({ ...prev, preview_url: e.target.value }))} placeholder="Preview URL" />
+                    <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.event_name} onChange={e => setConfig(prev => ({ ...prev, event_name: e.target.value }))} placeholder="Event name" />
+                    <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.race_name} onChange={e => setConfig(prev => ({ ...prev, race_name: e.target.value }))} placeholder="Race name" />
+                    <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" type="number" min={1} value={config.total_laps} onChange={e => setConfig(prev => ({ ...prev, total_laps: Number(e.target.value) }))} placeholder="Total laps" />
+                    <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm md:col-span-2" value={config.racer_names} onChange={e => setConfig(prev => ({ ...prev, racer_names: e.target.value }))} placeholder="Racer names (comma separated)" />
+                    <div className="md:col-span-2 flex gap-2">
+                        <button className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500" type="submit">Save Config</button>
+                        <button className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500" type="button" onClick={initializeRace}>Initialize Race State</button>
+                        <button className="rounded bg-slate-700 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-600" type="button" onClick={loadWizard}>Refresh</button>
+                        <button className="rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500" type="button" onClick={() => controlRace('start')}>Race Start</button>
+                        <button className="rounded bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" type="button" onClick={() => controlRace('pause')}>Race Pause</button>
+                        <button className="rounded bg-violet-600 px-4 py-2 text-sm font-semibold text-white hover:bg-violet-500" type="button" onClick={() => controlRace('snapshot')}>Save Snapshot</button>
+                        <button className="rounded bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-500" type="button" onClick={() => controlRace('resume')}>Race Resume</button>
+                    </div>
+                </form>
+            </div>
+
+            {error ? <p className="text-sm text-red-400">{error}</p> : null}
+
+            <div className="race-card p-4 space-y-3">
+                <h3 className="text-base font-semibold">Ordered Connection Checklist</h3>
+                {currentStep ? (
+                    <p className="text-xs text-[var(--color-text-secondary)]">Current blocking step: <strong>{currentStep.title}</strong> · Next command: <code>{currentStep.next_command}</code></p>
+                ) : <p className="text-xs text-emerald-400">All setup steps are currently marked connected.</p>}
+
+                <div className="space-y-3">
+                    {wizard?.steps.map((step, idx) => (
+                        <div key={step.id} className={`rounded border p-3 ${step.connected ? 'border-emerald-700 bg-emerald-950/30' : 'border-amber-700 bg-amber-950/30'}`}>
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                                <div>
+                                    <p className="font-semibold">{idx + 1}. {step.title}</p>
+                                    <p className="text-xs text-[var(--color-text-secondary)]">{step.description}</p>
+                                </div>
+                                <span className={`text-xs font-semibold ${step.connected ? 'text-emerald-400' : 'text-amber-300'}`}>{step.connected ? 'Connected' : 'Not connected'}</span>
+                            </div>
+
+                            <div className="mt-2 text-xs space-y-1">
+                                <p>Command to continue: <code>{step.next_command}</code></p>
+                                {step.next_step_command ? <p>Next step command: <code>{step.next_step_command}</code></p> : null}
+                            </div>
+
+                            <div className="mt-3 flex flex-wrap gap-2">
+                                <button className="rounded bg-blue-600 px-3 py-1 text-xs font-semibold text-white" onClick={() => runStepAction(step.id, 'verify')} disabled={busyStepId === step.id}>Verify</button>
+                                <button className="rounded bg-emerald-600 px-3 py-1 text-xs font-semibold text-white" onClick={() => runStepAction(step.id, 'connect')} disabled={busyStepId === step.id}>Connect / Reconnect</button>
+                                <button className="rounded bg-rose-700 px-3 py-1 text-xs font-semibold text-white" onClick={() => runStepAction(step.id, 'stop')} disabled={busyStepId === step.id}>Stop</button>
+                            </div>
+
+                            {step.checks.length > 0 ? (
+                                <ul className="mt-3 space-y-1 text-xs">
+                                    {step.checks.map(check => (
+                                        <li key={check.command} className={check.ok ? 'text-emerald-300' : 'text-rose-300'}>
+                                            {check.ok ? '✓' : '✗'} {check.command}
+                                        </li>
+                                    ))}
+                                </ul>
+                            ) : null}
+
+                            {step.last_error ? <p className="mt-2 text-xs text-rose-300">Last error: {step.last_error}</p> : null}
+                        </div>
+                    ))}
+                </div>
             </div>
         </div>
     )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from 'react'
+import { FormEvent, useEffect, useMemo, useState } from 'react'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -12,9 +12,25 @@ export default function VisionPanel() {
     const [statusMessage, setStatusMessage] = useState('')
     const [statusError, setStatusError] = useState(false)
     const [capturing, setCapturing] = useState(false)
+    const [raceContext, setRaceContext] = useState<Record<string, unknown>>({})
 
     const normalizedBaseUrl = useMemo(() => previewBaseUrl.trim().replace(/\/$/, ''), [previewBaseUrl])
     const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
+
+    const refreshWizardContext = async () => {
+        try {
+            const response = await fetch('/api/setup/wizard')
+            if (!response.ok) return
+            const payload = await response.json()
+            setRaceContext(payload.race_context || {})
+        } catch {
+            // ignore for panel resilience
+        }
+    }
+
+    useEffect(() => {
+        refreshWizardContext()
+    }, [])
 
     const onCapture = async (event: FormEvent) => {
         event.preventDefault()
@@ -33,12 +49,40 @@ export default function VisionPanel() {
             }
 
             setStatusMessage(payload.message || 'Snapshot captured successfully.')
+            const raceId = String(raceContext.race_id || '')
+            if (raceId) {
+                await fetch(`/api/races/${raceId}/logs`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ entry: `${new Date().toISOString()} Track image captured from Vision panel` }),
+                })
+            }
+            await refreshWizardContext()
         } catch (error) {
             const message = error instanceof Error ? error.message : 'Unable to capture snapshot.'
             setStatusMessage(message)
             setStatusError(true)
         } finally {
             setCapturing(false)
+        }
+    }
+
+    const trackingEnabled = Boolean(raceContext.tracking_enabled)
+    const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
+
+    const toggleTracking = async (start: boolean) => {
+        const raceId = String(raceContext.race_id || '')
+        if (!raceId) {
+            setStatusMessage('Initialize race in Settings before starting object tracking.')
+            setStatusError(true)
+            return
+        }
+        const endpoint = start ? `/api/races/${raceId}/tracking/start` : `/api/races/${raceId}/tracking/stop`
+        const response = await fetch(endpoint, { method: 'POST' })
+        if (response.ok) {
+            await refreshWizardContext()
+            setStatusMessage(start ? 'Object tracking started.' : 'Object tracking stopped.')
+            setStatusError(false)
         }
     }
 
@@ -57,8 +101,8 @@ export default function VisionPanel() {
                     />
                 </label>
                 <p className="text-xs text-[var(--color-text-secondary)]">
-                    Run preflight with <code>--serve-preview --preview-host 0.0.0.0 --preview-port 8091</code> on the Pi,
-                    then use this Vision tab to view the live camera and trigger the track photo.
+                    Capture the track image here after the setup wizard in Settings marks connectivity as connected. Once
+                    captured, return here to start object tracking and monitor lap-count logs.
                 </p>
             </div>
 
@@ -69,7 +113,7 @@ export default function VisionPanel() {
                     className="w-full rounded border border-slate-700 bg-black"
                 />
 
-                <form onSubmit={onCapture}>
+                <form onSubmit={onCapture} className="flex flex-wrap items-center gap-2">
                     <button
                         type="submit"
                         disabled={capturing}
@@ -77,11 +121,39 @@ export default function VisionPanel() {
                     >
                         {capturing ? 'Capturing…' : 'Capture Track Photo'}
                     </button>
+                    <button
+                        type="button"
+                        className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500"
+                        onClick={() => toggleTracking(true)}
+                    >
+                        Start Tracking
+                    </button>
+                    <button
+                        type="button"
+                        className="rounded bg-rose-700 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600"
+                        onClick={() => toggleTracking(false)}
+                    >
+                        Stop Tracking
+                    </button>
                 </form>
+
+                <p className="text-xs text-[var(--color-text-secondary)]">
+                    Tracking status: <span className={trackingEnabled ? 'text-emerald-400' : 'text-amber-300'}>{trackingEnabled ? 'Enabled' : 'Disabled'}</span>
+                </p>
 
                 {statusMessage ? (
                     <p className={`text-sm ${statusError ? 'text-red-400' : 'text-emerald-400'}`}>{statusMessage}</p>
                 ) : null}
+            </div>
+
+            <div className="race-card p-4 space-y-2">
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Lap / Tracking Logs</h3>
+                {logs.length === 0 ? <p className="text-xs text-[var(--color-text-secondary)]">No logs yet. Start tracking to populate this feed.</p> : null}
+                <div className="max-h-56 overflow-auto rounded border border-slate-700 bg-slate-950 p-2 text-xs text-slate-200">
+                    {logs.map((line, index) => (
+                        <p key={`${line}-${index}`}>{String(line)}</p>
+                    ))}
+                </div>
             </div>
         </div>
     )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/types/index.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/types/index.ts
@@ -182,6 +182,8 @@ export type WSMessageType =
     | 'raceStart'
     | 'racePause'
     | 'raceFinish'
+    | 'raceResume'
+    | 'lapLog'
     | 'racerAdded'
     | 'visionDetection'
     | 'connectionCount'


### PR DESCRIPTION
### Motivation
- Provide an operator-friendly, ordered setup wizard in the web UI to make race setup (prereqs, Pi connectivity, camera preview, race data) discoverable and actionable. 
- Surface exact commands, one-click verify/connect/stop actions and the next-step guidance so non-shell-savvy operators can progress linearly. 
- Persist setup and runtime context so races can be paused/snapshotted and later resumed with laps, racer metadata, and logs restored. 
- Integrate vision capture and tracking controls into the flow so track photo, object tracking and lap logs are visible and controllable from the browser.

### Description
- Backend: added a `system_state` KV table and helpers for JSON state, a `_SETUP_STEPS` definition, an async shell-run helper, and command templating to evaluate per-step checks and produce actionable commands. 
- Backend APIs: added `GET /api/setup/wizard`, `PUT /api/setup/wizard/config`, `POST /api/setup/wizard/steps/{id}/verify|connect|stop`, `POST /api/setup/wizard/initialize`, `POST /api/setup/wizard/reset`, plus runtime endpoints `GET /api/races/{race_id}/state`, `POST /api/races/{race_id}/snapshot`, `POST /api/races/{race_id}/resume`, `POST /api/races/{race_id}/tracking/start|stop`, and `POST /api/races/{race_id}/logs` to support snapshot/resume/tracking/log flows. 
- WebSocket: emit new message types (`raceResume`, `lapLog`) through existing relay so UI clients receive resume/log events. 
- Frontend: replaced the placeholder SettingsPanel with a full setup wizard UI (config form, ordered checklist, command visibility, verify/connect/stop buttons, and race control buttons for start/pause/snapshot/resume) and enhanced VisionPanel to trigger track capture, start/stop tracking, and display log stream tied to the persisted race context. 
- Types & docs: updated frontend `WSMessageType` to include the new events, and updated `README.md` and `docs/race_manager.md` with the new web wizard workflow and the list of backend endpoints.

### Testing
- Ran `pre-commit` on the modified files; hooks auto-formatted as-needed and the final pre-commit run passed for the staged files. 
- Ran `make lint`/pre-commit all-files locally in the container (formatting hooks adjusted files then re-run), final relevant checks passed for the changed files. 
- Ran `make test` which falls back to a ROS build test path; `colcon` is not installed in this environment so the container reported `colcon not found`. 
- Attempted frontend build with `npm run build` / `npm run dev`; the environment is missing dev tooling (`vite` and some TypeScript type packages), so the frontend build/dev server could not be brought up here. 
- Attempted a Playwright screenshot of the running frontend but the dev server was not available (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71d0b284c8323864a06602452fa65)