### PR TITLE
Improve setup wizard diagnostics and block race initialization when prerequisites fail

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -75,6 +75,7 @@ _SETUP_STEPS = [
         "check_contains": ["launch"],
         "connect_command": ". /opt/ros/iron/setup.bash && . ~/alive/j5/ros_ws/install/setup.bash",
         "stop_command": "pkill -f ros2 || true",
+        "help": "The API process cannot mutate your terminal PATH. Run the source command in the shell where you launch ROS nodes, then click Verify.",
     },
     {
         "id": "pi_connectivity",
@@ -84,6 +85,7 @@ _SETUP_STEPS = [
         "connect_command": "Verify host + API reachability (no interactive shell needed)",
         "stop_command": "echo 'No persistent process to stop for connectivity check'",
         "stop_commands": ["echo No persistent process to stop for connectivity check"],
+        "help": "Set pi_host to an address that resolves from this machine and ensure SSH/API ports are reachable.",
     },
     {
         "id": "backend_service",
@@ -94,6 +96,7 @@ _SETUP_STEPS = [
         "stop_command": "pkill -f 'python -m app.main' || true",
         "manual_connect": True,
         "stop_commands": ["pkill -f python -m app.main"],
+        "help": "If this fails, start the backend on the configured host/port and confirm GET /health returns 200.",
     },
     {
         "id": "vision_preview",
@@ -104,6 +107,17 @@ _SETUP_STEPS = [
         "stop_command": "pkill -f pi_preflight.py || true",
         "manual_connect": True,
         "stop_commands": ["pkill -f pi_preflight.py"],
+        "help": "Start the preview service and verify {preview_url}/health is reachable.",
+    },
+    {
+        "id": "websocket_endpoint",
+        "title": "WebSocket endpoint",
+        "description": "Realtime events require a reachable WS endpoint based on backend_url.",
+        "check_commands": [],
+        "connect_command": "Use ws://<backend-host>:<backend-port>/ws in the frontend environment and restart the UI",
+        "stop_command": "echo 'No persistent process to stop for websocket endpoint'",
+        "stop_commands": ["echo No persistent process to stop for websocket endpoint"],
+        "help": "For Next.js UI set NEXT_PUBLIC_WS_URL and NEXT_PUBLIC_API_BASE to your FastAPI service.",
     },
     {
         "id": "race_state",
@@ -274,6 +288,13 @@ async def _check_http_health(url: str):
         }
 
 
+async def _check_ws_port(url: str):
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return await _check_tcp_port(host, port)
+
+
 def _render_command(template: str, config: dict):
     return template.format(**config)
 
@@ -333,6 +354,13 @@ async def _build_setup_status():
         elif step["id"] == "vision_preview":
             checks = [await _check_http_health(config["preview_url"])]
             check_ok = all(item["ok"] for item in checks)
+        elif step["id"] == "websocket_endpoint":
+            ws_result = await _check_ws_port(config["backend_url"])
+            ws_result["command"] = (
+                f"ws tcp://{urlparse(config['backend_url']).hostname}:{urlparse(config['backend_url']).port or 80}"
+            )
+            checks = [ws_result]
+            check_ok = all(item["ok"] for item in checks)
         else:
             for cmd_template in step["check_commands"]:
                 command = _render_command(cmd_template, config)
@@ -358,6 +386,7 @@ async def _build_setup_status():
             "stop_command": _render_command(step["stop_command"], config),
             "last_action": state.get("last_action"),
             "last_error": state.get("last_error"),
+            "help": _render_command(step.get("help", ""), config),
         }
         steps.append(step_data)
     for idx, step in enumerate(steps):
@@ -939,6 +968,16 @@ async def stop_setup_step(step_id: str):
 
 @app.post("/api/setup/wizard/initialize")
 async def initialize_race_from_wizard():
+    status = await _build_setup_status()
+    blocking_step = next(
+        (item for item in status["steps"] if not item["connected"]), None
+    )
+    if blocking_step:
+        raise HTTPException(
+            400,
+            f"Setup blocked by '{blocking_step['title']}'. Run: {blocking_step['next_command']} and verify this step before initializing race state.",
+        )
+
     config = await _get_state_json("setup_config", _DEFAULT_SETUP_CONFIG)
     event = await insert_row(
         "race_events",

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -18,6 +18,7 @@ interface SetupStep {
     next_step_command?: string
     is_current?: boolean
     last_error?: string | null
+    help?: string
 }
 
 interface WizardStatus {
@@ -134,9 +135,13 @@ export default function SettingsPanel() {
     const initializeRace = async () => {
         try {
             const response = await fetch('/api/setup/wizard/initialize', { method: 'POST' })
-            if (!response.ok) throw new Error('Failed to initialize race state')
             const payload = await response.json()
+            if (!response.ok) {
+                const detail = payload?.detail ? String(payload.detail) : 'Failed to initialize race state'
+                throw new Error(detail)
+            }
             setWizard(payload.wizard)
+            setError('')
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Unable to initialize race.')
         }
@@ -209,6 +214,7 @@ export default function SettingsPanel() {
                                 </ul>
                             ) : null}
 
+                            {step.help ? <p className="mt-2 text-xs text-slate-300">How to unblock: {step.help}</p> : null}
                             {step.last_error ? <p className="mt-2 text-xs text-rose-300">Last error: {step.last_error}</p> : null}
                         </div>
                     ))}


### PR DESCRIPTION
### Motivation
- Users cannot tell why `Initialize Race State` appears to do nothing when prerequisites are missing, and the Settings tab lacked guidance for websocket env vars and ROS2 sourcing. 
- The wizard should provide actionable, per-step instructions and prevent creating a race when required services or connectivity are not ready.

### Description
- Added per-step `help` guidance to setup steps (ROS2, Pi connectivity, backend, preview) and introduced a new `websocket_endpoint` step that instructs setting `NEXT_PUBLIC_API_BASE` / `NEXT_PUBLIC_WS_URL` for the frontend. 
- Implemented `_check_ws_port` and integrated a websocket TCP reachability check into the wizard status so the WS endpoint step can be validated. 
- Included `help` in the returned wizard `step` objects and surfaced it in the frontend `SettingsPanel` so the UI shows a “How to unblock” hint for failing steps. 
- Changed `/api/setup/wizard/initialize` to detect any blocking prereq and return HTTP 400 with a clear message naming the blocking step and the exact `next_command` to run before initialization. 

### Testing
- Ran `pre-commit run --files ros_ws/src/j5_perception/race-master-pro/backend/app/main.py ros_ws/src/components/settings/SettingsPanel.tsx` which initially caused `black` to reformat the backend file but completed successfully thereafter. 
- Ran `make test` which executed; the environment does not have `colcon` installed and printed `colcon not installed` (no functional test runner available in this environment). 
- Ran `python -m py_compile ros_ws/src/j5_perception/race-master-pro/backend/app/main.py` which succeeded. 
- Attempted frontend build with `npm --prefix ros_ws/src/j5_perception/race-master-pro/frontend run build` which failed due to missing TypeScript ambient type packages (`TS2688`), so a full UI compile was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b74877aa308323b4be670f6cc4b86f)