### PR TITLE
Fix Race Master Pro websocket backend targeting

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -70,6 +70,12 @@ Frontend starts at `http://localhost:5173`.
 For remote browser access, open `http://<pi-ip>:5173` and run Vite with host binding
 (for example `npm run dev -- --host 0.0.0.0`) if needed.
 
+By default the Vite UI talks to `http://<current-host>:8080` and
+`ws://<current-host>:8080/ws?client_type=organizer`. Override those targets with
+`VITE_API_BASE_URL=http://<api-host>:8080` and
+`VITE_WS_URL=ws://<api-host>:8080/ws` before starting `npm run dev` when the
+FastAPI service lives on a different host or port.
+
 ### 3. Run the Perception System
 
 ```bash

--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -70,9 +70,11 @@ Frontend starts at `http://localhost:5173`.
 For remote browser access, open `http://<pi-ip>:5173` and run Vite with host binding
 (for example `npm run dev -- --host 0.0.0.0`) if needed.
 
-By default the Vite UI talks to `http://<current-host>:8080` and
-`ws://<current-host>:8080/ws?client_type=organizer`. Override those targets with
-`VITE_API_BASE_URL=http://<api-host>:8080` and
+By default the Vite UI tries same-origin `/api` first and falls back to
+`http://<current-host>:8080`. Websocket traffic stays on same-origin `/ws` for
+HTTPS/reverse-proxy deployments and falls back to
+`ws://<current-host>:8080/ws?client_type=organizer` during local Vite dev. Override
+those targets with `VITE_API_BASE_URL=http://<api-host>:8080` and
 `VITE_WS_URL=ws://<api-host>:8080/ws` before starting `npm run dev` when the
 FastAPI service lives on a different host or port.
 

--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -114,10 +114,10 @@ _SETUP_STEPS = [
         "title": "WebSocket endpoint",
         "description": "Realtime events require a reachable WS endpoint based on backend_url.",
         "check_commands": [],
-        "connect_command": "Use ws://<backend-host>:<backend-port>/ws in the frontend environment and restart the UI",
+        "connect_command": "Set VITE_WS_URL=ws://<backend-host>:<backend-port>/ws (or NEXT_PUBLIC_WS_URL for Next.js), restart the UI, then verify",
         "stop_command": "echo 'No persistent process to stop for websocket endpoint'",
         "stop_commands": ["echo No persistent process to stop for websocket endpoint"],
-        "help": "For Next.js UI set NEXT_PUBLIC_WS_URL and NEXT_PUBLIC_API_BASE to your FastAPI service.",
+        "help": "For the Vite frontend set VITE_WS_URL and VITE_API_BASE_URL; for the Next.js demo use NEXT_PUBLIC_WS_URL and NEXT_PUBLIC_API_BASE. Both must point at the FastAPI service.",
     },
     {
         "id": "race_state",

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { backendBaseUrl, backendWsUrl } from '@/lib/utils'
 
 interface SetupCheckResult {
     command: string
@@ -30,7 +31,7 @@ interface WizardStatus {
 const defaultConfig = {
     pi_host: 'pi-host-or-ip.local',
     pi_user: 'pi-user',
-    backend_url: 'http://<pi-ip:8080',
+    backend_url: 'http://<pi-ip>:8080',
     preview_url: 'http://pi-ip:8091',
     race_name: 'Main Event',
     event_name: 'Weekend Session',
@@ -70,6 +71,9 @@ export default function SettingsPanel() {
     useEffect(() => {
         loadWizard()
     }, [])
+
+    const frontendApiUrl = backendBaseUrl()
+    const frontendWsUrl = backendWsUrl('organizer')
 
     const currentStep = useMemo(() => wizard?.steps.find(step => step.is_current), [wizard])
 
@@ -151,8 +155,21 @@ export default function SettingsPanel() {
         <div className="fade-in space-y-4">
             <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Settings · Race Setup Wizard</h2>
 
-            <div className="race-card p-4">
-                <h3 className="mb-2 text-base font-semibold">Configuration</h3>
+            <div className="race-card p-4 space-y-3">
+                <div>
+                    <h3 className="mb-2 text-base font-semibold">Configuration</h3>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                        Save the FastAPI base URL first, then verify the backend, websocket, and preview steps below before clicking <strong>Initialize Race State</strong>.
+                    </p>
+                </div>
+
+                <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200">
+                    <p><strong>Frontend API target:</strong> <code>{frontendApiUrl}</code></p>
+                    <p><strong>Frontend organizer websocket:</strong> <code>{frontendWsUrl}</code></p>
+                    <p className="mt-2 text-[var(--color-text-secondary)]">
+                        This Vite app uses <code>VITE_API_BASE_URL</code> and <code>VITE_WS_URL</code> when set. Without them it talks directly to <code>http://&lt;current-host&gt;:8080</code> and <code>ws://&lt;current-host&gt;:8080/ws</code>.
+                    </p>
+                </div>
                 <form className="grid gap-3 md:grid-cols-2" onSubmit={onSaveConfig}>
                     <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.pi_host} onChange={e => setConfig(prev => ({ ...prev, pi_host: e.target.value }))} placeholder="Pi host" />
                     <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.pi_user} onChange={e => setConfig(prev => ({ ...prev, pi_user: e.target.value }))} placeholder="Pi user" />
@@ -179,7 +196,10 @@ export default function SettingsPanel() {
             <div className="race-card p-4 space-y-3">
                 <h3 className="text-base font-semibold">Ordered Connection Checklist</h3>
                 {currentStep ? (
-                    <p className="text-xs text-[var(--color-text-secondary)]">Current blocking step: <strong>{currentStep.title}</strong> · Next command: <code>{currentStep.next_command}</code></p>
+                    <div className="space-y-1 text-xs text-[var(--color-text-secondary)]">
+                        <p>Current blocking step: <strong>{currentStep.title}</strong> · Next command: <code>{currentStep.next_command}</code></p>
+                        <p>Recommended order: 1) save config, 2) verify backend + preview + websocket, 3) initialize race state, 4) use Race Start / Pause / Resume controls.</p>
+                    </div>
                 ) : <p className="text-xs text-emerald-400">All setup steps are currently marked connected.</p>}
 
                 <div className="space-y-3">

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch, backendBaseUrl, backendWsUrl } from '@/lib/utils'
+import { apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl } from '@/lib/utils'
 
 interface SetupCheckResult {
     command: string
@@ -72,7 +72,7 @@ export default function SettingsPanel() {
         loadWizard()
     }, [])
 
-    const frontendApiUrl = backendBaseUrl()
+    const frontendApiUrl = configuredApiBaseUrl() ?? `same-origin /api → fallback ${backendBaseUrl()}`
     const frontendWsUrl = backendWsUrl('organizer')
 
     const currentStep = useMemo(() => wizard?.steps.find(step => step.is_current), [wizard])
@@ -167,7 +167,7 @@ export default function SettingsPanel() {
                     <p><strong>Frontend API target:</strong> <code>{frontendApiUrl}</code></p>
                     <p><strong>Frontend organizer websocket:</strong> <code>{frontendWsUrl}</code></p>
                     <p className="mt-2 text-[var(--color-text-secondary)]">
-                        This Vite app uses <code>VITE_API_BASE_URL</code> and <code>VITE_WS_URL</code> when set. Without them it talks directly to <code>http://&lt;current-host&gt;:8080</code> and <code>ws://&lt;current-host&gt;:8080/ws</code>.
+                        This Vite app uses <code>VITE_API_BASE_URL</code> and <code>VITE_WS_URL</code> when set. Without them, API calls try same-origin <code>/api</code> first and fall back to <code>http://&lt;current-host&gt;:8080</code>; websocket calls stay on same-origin <code>/ws</code> for HTTPS/proxied deployments and fall back to <code>ws://&lt;current-host&gt;:8080/ws</code> for local Vite dev.
                     </p>
                 </div>
                 <form className="grid gap-3 md:grid-cols-2" onSubmit={onSaveConfig}>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { backendBaseUrl, backendWsUrl } from '@/lib/utils'
+import { apiFetch, backendBaseUrl, backendWsUrl } from '@/lib/utils'
 
 interface SetupCheckResult {
     command: string
@@ -47,7 +47,7 @@ export default function SettingsPanel() {
 
     const loadWizard = async () => {
         try {
-            const response = await fetch('/api/setup/wizard')
+            const response = await apiFetch('/api/setup/wizard')
             if (!response.ok) throw new Error('Failed to load wizard status')
             const payload: WizardStatus = await response.json()
             const rawNames = (payload.config.racer_names as string[] | undefined) || []
@@ -80,7 +80,7 @@ export default function SettingsPanel() {
     const runStepAction = async (stepId: string, action: 'verify' | 'connect' | 'stop') => {
         setBusyStepId(stepId)
         try {
-            const response = await fetch(`/api/setup/wizard/steps/${stepId}/${action}`, { method: 'POST' })
+            const response = await apiFetch(`/api/setup/wizard/steps/${stepId}/${action}`, { method: 'POST' })
             if (!response.ok) throw new Error(`Failed to ${action} step ${stepId}`)
             const payload = await response.json()
             setWizard(payload.wizard || payload)
@@ -95,7 +95,7 @@ export default function SettingsPanel() {
     const onSaveConfig = async (event: FormEvent) => {
         event.preventDefault()
         try {
-            const response = await fetch('/api/setup/wizard/config', {
+            const response = await apiFetch('/api/setup/wizard/config', {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -128,7 +128,7 @@ export default function SettingsPanel() {
             resume: `/api/races/${raceId}/resume`,
         }
         try {
-            const response = await fetch(endpointMap[action], { method: 'POST' })
+            const response = await apiFetch(endpointMap[action], { method: 'POST' })
             if (!response.ok) throw new Error(`Failed to ${action} race`)
             await loadWizard()
         } catch (err) {
@@ -138,7 +138,7 @@ export default function SettingsPanel() {
 
     const initializeRace = async () => {
         try {
-            const response = await fetch('/api/setup/wizard/initialize', { method: 'POST' })
+            const response = await apiFetch('/api/setup/wizard/initialize', { method: 'POST' })
             const payload = await response.json()
             if (!response.ok) {
                 const detail = payload?.detail ? String(payload.detail) : 'Failed to initialize race state'

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { apiFetch } from '@/lib/utils'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -19,7 +20,7 @@ export default function VisionPanel() {
 
     const refreshWizardContext = async () => {
         try {
-            const response = await fetch('/api/setup/wizard')
+            const response = await apiFetch('/api/setup/wizard')
             if (!response.ok) return
             const payload = await response.json()
             setRaceContext(payload.race_context || {})
@@ -51,7 +52,7 @@ export default function VisionPanel() {
             setStatusMessage(payload.message || 'Snapshot captured successfully.')
             const raceId = String(raceContext.race_id || '')
             if (raceId) {
-                await fetch(`/api/races/${raceId}/logs`, {
+                await apiFetch(`/api/races/${raceId}/logs`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ entry: `${new Date().toISOString()} Track image captured from Vision panel` }),
@@ -78,7 +79,7 @@ export default function VisionPanel() {
             return
         }
         const endpoint = start ? `/api/races/${raceId}/tracking/start` : `/api/races/${raceId}/tracking/stop`
-        const response = await fetch(endpoint, { method: 'POST' })
+        const response = await apiFetch(endpoint, { method: 'POST' })
         if (response.ok) {
             await refreshWizardContext()
             setStatusMessage(start ? 'Object tracking started.' : 'Object tracking stopped.')

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
@@ -72,7 +72,7 @@ export function generateId(): string {
     return crypto.randomUUID()
 }
 
-function configuredApiBaseUrl(): string | null {
+export function configuredApiBaseUrl(): string | null {
     const configured = import.meta.env.VITE_API_BASE_URL?.trim()
     return configured ? configured.replace(/\/$/, '') : null
 }
@@ -88,11 +88,26 @@ export function backendBaseUrl(): string {
     return `http://${window.location.hostname}:8080`
 }
 
+
+function sameOriginWsBaseUrl(): string {
+    return `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`
+}
+
+function directBackendWsBaseUrl(): string {
+    return `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:8080/ws`
+}
+
+function shouldUseSameOriginWsProxy(): boolean {
+    return window.location.protocol === 'https:' || !['5173', '4173'].includes(window.location.port)
+}
+
 export function backendWsUrl(clientType = 'organizer'): string {
     const configured = import.meta.env.VITE_WS_URL?.trim()
     const baseUrl = configured
         ? configured.replace(/\/$/, '')
-        : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:8080/ws`
+        : shouldUseSameOriginWsProxy()
+            ? sameOriginWsBaseUrl()
+            : directBackendWsBaseUrl()
     const separator = baseUrl.includes('?') ? '&' : '?'
     return `${baseUrl}${separator}client_type=${encodeURIComponent(clientType)}`
 }

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
@@ -99,6 +99,12 @@ export function backendWsUrl(clientType = 'organizer'): string {
 
 export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
     const normalizedPath = path.startsWith('/') ? path : `/${path}`
+    const configuredBaseUrl = configuredApiBaseUrl()
+
+    if (configuredBaseUrl) {
+        return fetch(`${configuredBaseUrl}${normalizedPath}`, init)
+    }
+
     const response = await fetch(normalizedPath, init)
     if (response.status !== 404) {
         return response

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
@@ -72,11 +72,29 @@ export function generateId(): string {
     return crypto.randomUUID()
 }
 
-function backendBaseUrl(): string {
+function configuredApiBaseUrl(): string | null {
+    const configured = import.meta.env.VITE_API_BASE_URL?.trim()
+    return configured ? configured.replace(/\/$/, '') : null
+}
+
+export function backendBaseUrl(): string {
+    const configured = configuredApiBaseUrl()
+    if (configured) {
+        return configured
+    }
     if (typeof window === 'undefined') {
         return 'http://localhost:8080'
     }
     return `http://${window.location.hostname}:8080`
+}
+
+export function backendWsUrl(clientType = 'organizer'): string {
+    const configured = import.meta.env.VITE_WS_URL?.trim()
+    const baseUrl = configured
+        ? configured.replace(/\/$/, '')
+        : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:8080/ws`
+    const separator = baseUrl.includes('?') ? '&' : '?'
+    return `${baseUrl}${separator}client_type=${encodeURIComponent(clientType)}`
 }
 
 export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useRef, useEffect, type ReactNode } from 'react'
-import type { LiveRaceState, LiveRacer, RaceStatus } from '@/types'
+import type { LiveRaceState, LiveRacer } from '@/types'
+import { backendWsUrl } from '@/lib/utils'
 
 // ── Connection Status ──────────────────────────────────────
 
@@ -60,8 +61,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
 
     // Auto-connect WebSocket on mount
     useEffect(() => {
-        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-        const wsUrl = `${protocol}//${window.location.host}/ws?client_type=organizer`
+        const wsUrl = backendWsUrl('organizer')
 
         let reconnectTimer: ReturnType<typeof setTimeout>
         let ws: WebSocket
@@ -87,7 +87,6 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             ws.onclose = () => {
                 setConnectionStatus('disconnected')
                 wsRef.current = null
-                // Reconnect after 3 seconds
                 reconnectTimer = setTimeout(connect, 3000)
             }
 


### PR DESCRIPTION
### Motivation
- The frontend was constructing the organizer WebSocket against the Vite dev server (`:5173`) instead of the FastAPI backend (`:8080`), causing `WebSocket closed before the connection is established` errors.  
- The Settings wizard did not show the actual API/WS targets the frontend was using, and backend wizard help text referenced the wrong env var guidance for the Vite UI, making setup confusing.

### Description
- Add helper functions to compute frontend targets with optional overrides: `backendBaseUrl()` and `backendWsUrl()` in `frontend/src/lib/utils.ts`.  
- Use the new `backendWsUrl('organizer')` in `frontend/src/stores/raceStore.tsx` so the organizer WebSocket defaults to the FastAPI backend (`ws://<host>:8080/ws?client_type=organizer`) and supports `VITE_WS_URL` overrides.  
- Improve the Settings wizard UI in `frontend/src/components/settings/SettingsPanel.tsx` to display the active API/WebSocket targets, clarify the recommended setup order, and fix a `backend_url` placeholder typo.  
- Update backend wizard help text in `backend/app/main.py` to explicitly call out `VITE_WS_URL`/`VITE_API_BASE_URL` for the Vite frontend and `NEXT_PUBLIC_*` variables for the Next.js demo.  
- Document the frontend networking defaults and override env vars in `README.md` under the frontend start instructions.

### Testing
- Ran `pre-commit run --files <changed-files>` for the modified files and the configured hooks passed.  
- Ran `python -m py_compile ros_ws/src/j5_perception/race-master-pro/backend/app/main.py` which succeeded (no syntax errors).  
- Ran `make test` in this environment but `colcon` is not installed, so the repo test target could not run here (reported as blocked).  
- Attempted `npm run build` in `ros_ws/src/j5_perception/race-master-pro/frontend` but the build failed in this container due to missing/invalid frontend type-definition packages (e.g. `@types/react`, `@types/react-dom`, various `d3-*` typings), so full frontend build validation could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1df03c5c83238294bd87977664b6)