### PR TITLE
Temporarily disable nounset when sourcing ROS setup and document UI default port

### DIFF
--- a/apps/racemanager/README.md
+++ b/apps/racemanager/README.md
@@ -203,6 +203,10 @@ The script prints browser URLs for local and LAN access (for example,
 - `NEXT_PUBLIC_API_BASE=http://<pi-ip>:4000`
 - `NEXT_PUBLIC_WS_URL=ws://<pi-ip>:4000/ws`
 
+By default the Race Manager UI runs on port `3000`, because the frontend uses
+Next.js (`npm run dev` → `next dev`) rather than Vite. If you try `5173`, the
+page will not respond unless you explicitly override `--ui-port 5173`.
+
 If ROS 2 is not installed system-wide, that is OK for this workflow. Build ROS 2 + dependencies from source, source your workspace `install/setup.bash`, then retry `--mode ros2`.
 
 

--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -31,12 +31,22 @@ find_python_bin() {
 
 source_setup_bash() {
   local setup_file="$1"
+  local restore_nounset="false"
   if [[ ! -f "$setup_file" ]]; then
     echo "Missing setup script: $setup_file"
     return 1
   fi
+  if [[ $- == *u* ]]; then
+    restore_nounset="true"
+    set +u
+  fi
   # shellcheck disable=SC1090
   source "$setup_file"
+  local source_status=$?
+  if [[ "$restore_nounset" == "true" ]]; then
+    set -u
+  fi
+  return "$source_status"
 }
 
 apply_defaults() {


### PR DESCRIPTION
### Motivation
- Sourcing a source-built ROS 2 `install/setup.bash` can reference variables (for example `COLCON_TRACE`) that are unset in the current shell when `set -u` is active, causing the launcher to abort with "unbound variable" errors. 
- Clarify UI troubleshooting by documenting that the Race Manager frontend uses Next.js (port `3000` by default), not Vite (`5173`), to reduce user confusion when the page does not respond.

### Description
- Update `source_setup_bash()` in `scripts/run_racemanager.sh` to detect if the shell has nounset enabled, temporarily run `set +u` while sourcing the provided `setup.bash`, then restore `set -u` afterwards and return the sourced script's exit status. 
- Preserve existing behavior when the setup file is missing and forward the sourced script's return code on failure. 
- Add a short note to `apps/racemanager/README.md` explaining that the UI defaults to Next.js on port `3000` and that `5173` will not respond unless `--ui-port 5173` is supplied.

### Testing
- Ran `bash -n scripts/run_racemanager.sh` to validate shell syntax and it succeeded. 
- Exercised `source_setup_bash` under `set -euo pipefail` with a synthetic `setup.bash` referencing an unset variable using a short Python-driven shell test, which succeeded. 
- Ran `pre-commit run --files scripts/run_racemanager.sh apps/racemanager/README.md` for the changed files and hooks passed for the applicable checks. 
- Ran `make test`, which reported `colcon not installed` in this environment so ROS/colcon-based tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb2d7c00808323b20a0ced92b36d5a)