### PR TITLE
racemanager: add port checks, improve launcher/sourcing, update deps and docs

### DIFF
--- a/apps/racemanager/README.md
+++ b/apps/racemanager/README.md
@@ -203,6 +203,16 @@ The script prints browser URLs for local and LAN access (for example,
 - `NEXT_PUBLIC_API_BASE=http://<pi-ip>:4000`
 - `NEXT_PUBLIC_WS_URL=ws://<pi-ip>:4000/ws`
 
+By default the Race Manager UI runs on port `3000`, because the frontend uses
+Next.js (`npm run dev` → `next dev`) rather than Vite. If you try `5173`, the
+page will not respond unless you explicitly override `--ui-port 5173`.
+
+The launcher now installs the shared runtime Python dependencies needed by both
+the FastAPI service and the bridge into `apps/racemanager/service/.venv` before
+starting processes, and it exits early if either `--api-port` or `--ui-port` is
+already occupied so you do not get a false "started" message after an
+`EADDRINUSE` failure.
+
 If ROS 2 is not installed system-wide, that is OK for this workflow. Build ROS 2 + dependencies from source, source your workspace `install/setup.bash`, then retry `--mode ros2`.
 
 

--- a/apps/racemanager/bridge/requirements.txt
+++ b/apps/racemanager/bridge/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.32.3
+PyYAML==6.0.2
 # Optional: install opencv-python for MP4 replay ingestion
 opencv-python==4.10.0.84

--- a/apps/racemanager/service/main.py
+++ b/apps/racemanager/service/main.py
@@ -4,11 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime
 
-try:
-    from typing import Annotated
-except ImportError:  # pragma: no cover
-    from typing_extensions import Annotated
-
 from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 
@@ -46,9 +41,7 @@ class RepoProvider:
     def __init__(self) -> None:
         self._repo: RaceRepository | None = None
 
-    def __call__(
-        self, settings: Annotated[Settings, Depends(get_settings)]
-    ) -> RaceRepository:
+    def __call__(self, settings: Settings = Depends(get_settings)) -> RaceRepository:
         if self._repo is None:
             self._repo = get_repository(
                 settings.db_backend,
@@ -71,7 +64,7 @@ ws_manager = ConnectionManager()
 
 
 @app.get("/health")
-def health(settings: Annotated[Settings, Depends(get_settings)]) -> JSONResponse:
+def health(settings: Settings = Depends(get_settings)) -> JSONResponse:
     return JSONResponse(
         {"status": "ok", "config": settings.dict(include_sensitive=False)}
     )
@@ -80,7 +73,7 @@ def health(settings: Annotated[Settings, Depends(get_settings)]) -> JSONResponse
 @app.post("/ingest/lap", response_model=LapResponse)
 async def ingest_lap(
     payload: LapIngest,
-    repository: Annotated[RaceRepository, Depends(repo_provider)],
+    repository: RaceRepository = Depends(repo_provider),
 ) -> LapResponse:
     speed = calculate_speed_kph(payload.trackDistanceM, payload.lapTimeMs)
     try:
@@ -116,7 +109,7 @@ async def ingest_lap(
 @app.get("/races/{race_id}/leaderboard", response_model=LeaderboardResponse)
 def race_leaderboard(
     race_id: str,
-    repository: Annotated[RaceRepository, Depends(repo_provider)],
+    repository: RaceRepository = Depends(repo_provider),
 ) -> LeaderboardResponse:
     try:
         return repository.leaderboard(race_id)

--- a/apps/racemanager/service/requirements.txt
+++ b/apps/racemanager/service/requirements.txt
@@ -3,3 +3,5 @@ uvicorn==0.23.2
 pydantic==1.10.19
 pymongo==4.10.1
 python-dotenv==1.0.1
+requests==2.32.3
+PyYAML==6.0.2

--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -339,6 +339,20 @@ You can also use Race Manager Pro UI from another machine at
 - verify live feed appears
 - click **Capture Track Photo** to trigger remote snapshot save on Pi
 
+If you only want to bring the camera feed back for the **Computer Vision** tab
+and do **not** want to re-initialize the race, rerun just this preview command
+on the Pi:
+
+```bash
+python3 scripts/pi_preflight.py \
+  --camera-source /dev/video0 \
+  --capture-file track_snapshot.jpg \
+  --serve-preview --preview-host 0.0.0.0 --preview-port 8091
+```
+
+That command is safe to use independently of the race setup flow. Replace
+`/dev/video0` if your camera is exposed at a different device path.
+
 This verifies:
 - ROS2 CLI availability
 - Backend TCP/HTTP connectivity

--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -103,11 +103,11 @@ _SETUP_STEPS = [
         "title": "Camera preview stream",
         "description": "Preview and track-image capture endpoint from the Pi.",
         "check_commands": ["curl -sf {preview_url}/health"],
-        "connect_command": "python scripts/pi_preflight.py --serve-preview --preview-host 0.0.0.0 --preview-port 8091",
+        "connect_command": "python scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091",
         "stop_command": "pkill -f pi_preflight.py || true",
         "manual_connect": True,
         "stop_commands": ["pkill -f pi_preflight.py"],
-        "help": "Start the preview service and verify {preview_url}/health is reachable.",
+        "help": "Start the preview service to restore the Computer Vision feed without re-initializing the race, then verify {preview_url}/health is reachable.",
     },
     {
         "id": "websocket_endpoint",

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -105,6 +105,19 @@ export default function VisionPanel() {
                     Capture the track image here after the setup wizard in Settings marks connectivity as connected. Once
                     captured, return here to start object tracking and monitor lap-count logs.
                 </p>
+                <div className="rounded border border-slate-700 bg-slate-950 p-3">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Start camera feed only</p>
+                    <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+                        You can bring the camera preview back without re-initializing the race by running this on the Pi:
+                    </p>
+                    <code className="mt-2 block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091
+                    </code>
+                    <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+                        Then open the preview URL above, or load the stream again in this tab. Replace <code>/dev/video0</code> if your
+                        camera uses a different device.
+                    </p>
+                </div>
             </div>
 
             <div className="race-card p-4 space-y-3">

--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -29,14 +29,70 @@ find_python_bin() {
   return 1
 }
 
+is_port_in_use() {
+  local host="$1"
+  local port="$2"
+  local python_bin="${PYTHON_BIN:-$(find_python_bin || true)}"
+  if [[ -z "$python_bin" ]]; then
+    echo "Python is required to inspect port availability."
+    return 2
+  fi
+  "$python_bin" - "$host" "$port" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((host, port))
+    except OSError:
+        raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+}
+
 source_setup_bash() {
   local setup_file="$1"
+  local restore_nounset="false"
   if [[ ! -f "$setup_file" ]]; then
     echo "Missing setup script: $setup_file"
     return 1
   fi
+  if [[ $- == *u* ]]; then
+    restore_nounset="true"
+    set +u
+  fi
   # shellcheck disable=SC1090
   source "$setup_file"
+  local source_status=$?
+  if [[ "$restore_nounset" == "true" ]]; then
+    set -u
+  fi
+  return "$source_status"
+}
+
+ensure_port_available() {
+  local name="$1"
+  local host="$2"
+  local port="$3"
+  if is_port_in_use "$host" "$port"; then
+    echo "$name port $port is already in use on $host."
+    echo "Stop the existing process or choose a different port with --api-port/--ui-port."
+    return 1
+  fi
+}
+
+ensure_process_running() {
+  local pid="$1"
+  local name="$2"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "$name failed to stay running. Review the logs above and retry."
+    return 1
+  fi
 }
 
 apply_defaults() {
@@ -229,6 +285,9 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+ensure_port_available "API" "$HOST" "$API_PORT"
+ensure_port_available "UI" "$HOST" "$UI_PORT"
+
 export HTTP_HOST="$HOST"
 export HTTP_PORT="$API_PORT"
 export NEXT_PUBLIC_API_BASE="http://$PI_IP:$API_PORT"
@@ -247,6 +306,9 @@ API_PID=$!
 UI_PID=$!
 
 sleep 2
+
+ensure_process_running "$API_PID" "Backend"
+ensure_process_running "$UI_PID" "Frontend"
 
 if [[ "$MODE" == "ros2" ]]; then
   "$VENV_PYTHON" apps/racemanager/bridge/bridge.py --mode ros2 --service-url "http://localhost:$API_PORT" --topic "$RACE_TOPIC" &


### PR DESCRIPTION
### Motivation
- Improve the Race Manager launcher reliability by failing early when API/UI ports are occupied and by ensuring the started processes remain running.
- Make it easier to restore the camera preview without re-initializing a race and clarify the frontend port behavior in documentation and the UI.
- Ensure runtime Python dependencies used by the service/bridge are declared and available to the launcher.
- Simplify FastAPI dependency typing to remove a brittle `Annotated` fallback and make DI signatures clearer.

### Description
- Added port availability checks (`is_port_in_use`, `ensure_port_available`) and a process liveness check (`ensure_process_running`) to `scripts/run_racemanager.sh`, plus improved `source_setup_bash` handling for `set -u` to avoid sourcing failures.  The launcher now exits early if `--api-port` or `--ui-port` is already in use before attempting to start services. 
- Updated README `apps/racemanager/README.md` to document the default Next.js UI port (`3000`) and to note the launcher behavior around installing shared Python runtime dependencies into `apps/racemanager/service/.venv` and early exit on port conflicts. 
- Added `PyYAML==6.0.2` to `apps/racemanager/bridge/requirements.txt` and added `requests==2.32.3` and `PyYAML==6.0.2` to `apps/racemanager/service/requirements.txt`. 
- Simplified FastAPI dependency annotations in `apps/racemanager/service/main.py` by removing the `Annotated` fallback import and using `Depends(...)` as parameter defaults for DI providers. 
- Improved ROS/preview UX by adding an explicit camera-only preview `connect_command` and help text in `ros_ws/src/j5_perception/race-master-pro/backend/app/main.py`, added a short standalone-preview note to the package README, and added a UI panel in `VisionPanel.tsx` showing the `pi_preflight.py` preview-only command for users.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb2d7c00808323b20a0ced92b36d5a)