### PR TITLE
Restore missing launcher helpers in run_racemanager.sh

### DIFF
--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -75,6 +75,26 @@ source_setup_bash() {
   return "$source_status"
 }
 
+ensure_port_available() {
+  local name="$1"
+  local host="$2"
+  local port="$3"
+  if is_port_in_use "$host" "$port"; then
+    echo "$name port $port is already in use on $host."
+    echo "Stop the existing process or choose a different port with --api-port/--ui-port."
+    return 1
+  fi
+}
+
+ensure_process_running() {
+  local pid="$1"
+  local name="$2"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "$name failed to stay running. Review the logs above and retry."
+    return 1
+  fi
+}
+
 apply_defaults() {
   if [[ -z "$PI_IP" ]]; then
     PI_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"


### PR DESCRIPTION
### Motivation

- The race manager launcher referenced runtime helper functions that were missing and caused `command not found` during startup checks, so restore them to re-enable port and process validation.

### Description

- Add `ensure_port_available()` to call the existing `is_port_in_use()` helper and print a clear error if the API/UI port is already occupied and return non-zero.
- Add `ensure_process_running()` to verify spawned PIDs via `kill -0` and print a failure message if backend or frontend processes die after startup.
- Insert both helpers into `scripts/run_racemanager.sh` immediately after `source_setup_bash()` so the script can validate ports and process health as intended.

### Testing

- Ran `bash -n scripts/run_racemanager.sh && ./scripts/run_racemanager.sh --mode ros2 --doctor`, which completed and printed diagnostics (including `ros2=missing`).
- Ran `pre-commit run --files scripts/run_racemanager.sh`, which passed the configured hooks for the changed file.
- Ran `make test`, which executed but printed `colcon not installed` in this environment so ROS/colcon-backed tests were not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc18ebdae88323b41486db20387718)