### PR TITLE
Fix racemanager FastAPI dependency annotations

### DIFF
--- a/apps/racemanager/service/main.py
+++ b/apps/racemanager/service/main.py
@@ -1,7 +1,5 @@
 """FastAPI race manager service for standalone and ROS-fed deployments."""
 
-from __future__ import annotations
-
 from datetime import datetime
 
 from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect


### PR DESCRIPTION
### Motivation
- Fix a FastAPI startup crash where `Settings` was treated as an unresolved forward reference and caused a `NameError` when FastAPI/Pydantic evaluated dependency annotations on app import.

### Description
- Remove postponed annotation evaluation by deleting `from __future__ import annotations` from `apps/racemanager/service/main.py` so `Settings` and other types are evaluated at import time and dependency signatures resolve correctly.

### Testing
- Ran `python3 -m py_compile apps/racemanager/service/main.py apps/racemanager/service/config.py apps/racemanager/service/repository.py apps/racemanager/service/schemas.py` and `pre-commit run --files apps/racemanager/service/main.py` which passed; `make test` reported `colcon not installed` in this environment, and an attempted isolated `pip install` to validate runtime startup was blocked by network/PyPI access restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1e5303bc8323bb03c763b3dbeba0)