### PR TITLE
Add run_race_master_pro launcher, refreshable race store, and UI race-control updates

### DIFF
--- a/apps/racemanager/README.md
+++ b/apps/racemanager/README.md
@@ -207,6 +207,11 @@ By default the Race Manager UI runs on port `3000`, because the frontend uses
 Next.js (`npm run dev` → `next dev`) rather than Vite. If you try `5173`, the
 page will not respond unless you explicitly override `--ui-port 5173`.
 
+Typical healthy startup logs include `✓ Ready`, `✓ Compiled /`, and `GET / 200`
+from Next.js. Those lines mean the UI did build and is serving traffic; if the
+browser is blank, double-check that you are opening port `3000` (or your
+explicit `--ui-port` override) rather than the legacy Vite port `5173`.
+
 If ROS 2 is not installed system-wide, that is OK for this workflow. Build ROS 2 + dependencies from source, source your workspace `install/setup.bash`, then retry `--mode ros2`.
 
 

--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -39,6 +39,19 @@ If `ros2` or `launch` is missing, fix underlay/overlay first (do not continue to
 
 ## Quick Start (source-build workflow)
 
+### One-command launcher
+
+From the repo root you can now start the Race Master Pro backend plus the Vite
+walkthrough UI with:
+
+```bash
+./scripts/run_race_master_pro.sh --mode ros2 --host 0.0.0.0 --pi-ip <pi-lan-ip>
+```
+
+That launcher keeps the Settings/Computer Vision/Dashboard workflow on the
+legacy Vite port (`5173`) while pointing the UI at the FastAPI backend on
+`8080`.
+
 ### 1. Start the Backend (Python deps in venv)
 
 ```bash

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/layout/BottomBar.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/layout/BottomBar.tsx
@@ -2,7 +2,7 @@ import { Play, Pause, Flag } from 'lucide-react'
 import type { LiveRaceState } from '@/types'
 import type { ConnectionStatus } from '@/stores/raceStore'
 import { useRaceContext } from '@/stores/raceStore'
-import { formatRaceTime } from '@/lib/utils'
+import { formatRaceTime, apiFetch } from '@/lib/utils'
 import { useState, useEffect } from 'react'
 
 interface BottomBarProps {
@@ -11,10 +11,9 @@ interface BottomBarProps {
 }
 
 export default function BottomBar({ liveRace, connectionStatus }: BottomBarProps) {
-    const { sendWsMessage } = useRaceContext()
+    const { refreshRaceState } = useRaceContext()
     const [elapsed, setElapsed] = useState(0)
 
-    // Tick the elapsed timer when race is active
     useEffect(() => {
         if (liveRace?.status !== 'active') {
             setElapsed(liveRace?.elapsed_time ?? 0)
@@ -26,16 +25,18 @@ export default function BottomBar({ liveRace, connectionStatus }: BottomBarProps
         return () => clearInterval(interval)
     }, [liveRace?.status, liveRace?.elapsed_time])
 
-    const handleStart = () => {
-        sendWsMessage({ type: 'raceStart', data: { race_id: liveRace?.race_id } })
-    }
-
-    const handlePause = () => {
-        sendWsMessage({ type: 'racePause', data: { race_id: liveRace?.race_id } })
-    }
-
-    const handleFinish = () => {
-        sendWsMessage({ type: 'raceFinish', data: { race_id: liveRace?.race_id } })
+    const controlRace = async (action: 'start' | 'pause' | 'finish' | 'resume') => {
+        if (!liveRace?.race_id) return
+        const endpointMap = {
+            start: `/api/races/${liveRace.race_id}/start`,
+            pause: `/api/races/${liveRace.race_id}/pause`,
+            finish: `/api/races/${liveRace.race_id}/finish`,
+            resume: `/api/races/${liveRace.race_id}/resume`,
+        }
+        const response = await apiFetch(endpointMap[action], { method: 'POST' })
+        if (response.ok) {
+            await refreshRaceState(liveRace.race_id)
+        }
     }
 
     const maxLap = liveRace
@@ -44,18 +45,17 @@ export default function BottomBar({ liveRace, connectionStatus }: BottomBarProps
 
     return (
         <footer className="app-bottombar">
-            {/* Race Controls */}
             <div className="flex items-center gap-2">
                 {liveRace?.status === 'active' ? (
                     <>
                         <button
-                            onClick={handlePause}
+                            onClick={() => controlRace('pause')}
                             className="flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--color-accent-orange)] text-black hover:opacity-90 transition-opacity"
                         >
                             <Pause size={12} /> Pause
                         </button>
                         <button
-                            onClick={handleFinish}
+                            onClick={() => controlRace('finish')}
                             className="flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--color-accent-green)] text-black hover:opacity-90 transition-opacity"
                         >
                             <Flag size={12} /> Finish
@@ -63,7 +63,7 @@ export default function BottomBar({ liveRace, connectionStatus }: BottomBarProps
                     </>
                 ) : liveRace?.status === 'setup' || liveRace?.status === 'paused' ? (
                     <button
-                        onClick={handleStart}
+                        onClick={() => controlRace(liveRace.status === 'paused' ? 'resume' : 'start')}
                         className="flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--color-accent-red)] text-white hover:opacity-90 transition-opacity"
                     >
                         <Play size={12} /> {liveRace.status === 'paused' ? 'Resume' : 'Start Race'}
@@ -73,10 +73,8 @@ export default function BottomBar({ liveRace, connectionStatus }: BottomBarProps
                 )}
             </div>
 
-            {/* Spacer */}
             <div className="flex-1" />
 
-            {/* Race Timer */}
             {liveRace && (
                 <div className="flex items-center gap-4 text-xs">
                     <div className="font-timing text-[var(--color-text-primary)] text-sm">
@@ -88,10 +86,8 @@ export default function BottomBar({ liveRace, connectionStatus }: BottomBarProps
                 </div>
             )}
 
-            {/* Spacer */}
             <div className="flex-1" />
 
-            {/* Status Indicators */}
             <div className="flex items-center gap-3 text-xs text-[var(--color-text-muted)]">
                 <span>
                     WS: {connectionStatus === 'connected' ? '🟢' : connectionStatus === 'connecting' ? '🟡' : '🔴'}

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl } from '@/lib/utils'
+import { useRaceContext } from '@/stores/raceStore'
 
 interface SetupCheckResult {
     command: string
@@ -40,6 +41,7 @@ const defaultConfig = {
 }
 
 export default function SettingsPanel() {
+    const { refreshRaceState } = useRaceContext()
     const [wizard, setWizard] = useState<WizardStatus | null>(null)
     const [busyStepId, setBusyStepId] = useState<string | null>(null)
     const [error, setError] = useState('')
@@ -63,6 +65,7 @@ export default function SettingsPanel() {
                 racer_names: rawNames.join(', '),
             })
             setError('')
+            await refreshRaceState(String(payload.race_context?.race_id || ''))
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Unable to load setup wizard.')
         }
@@ -85,6 +88,7 @@ export default function SettingsPanel() {
             const payload = await response.json()
             setWizard(payload.wizard || payload)
             setError('')
+            await refreshRaceState(String(payload?.wizard?.race_context?.race_id || payload?.race_context?.race_id || ''))
         } catch (err) {
             setError(err instanceof Error ? err.message : `Unable to ${action} step.`)
         } finally {
@@ -110,27 +114,30 @@ export default function SettingsPanel() {
             const payload = await response.json()
             setWizard(payload)
             setError('')
+            await refreshRaceState(String(payload?.race_context?.race_id || ''))
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Unable to save setup configuration.')
         }
     }
 
-    const controlRace = async (action: 'start' | 'pause' | 'snapshot' | 'resume') => {
+    const controlRace = async (action: 'start' | 'pause' | 'snapshot' | 'resume' | 'finish') => {
         const raceId = String(wizard?.race_context?.race_id || '')
         if (!raceId) {
             setError('Initialize race state first before using race controls.')
             return
         }
-        const endpointMap: Record<'start' | 'pause' | 'snapshot' | 'resume', string> = {
+        const endpointMap: Record<'start' | 'pause' | 'snapshot' | 'resume' | 'finish', string> = {
             start: `/api/races/${raceId}/start`,
             pause: `/api/races/${raceId}/pause`,
             snapshot: `/api/races/${raceId}/snapshot`,
             resume: `/api/races/${raceId}/resume`,
+            finish: `/api/races/${raceId}/finish`,
         }
         try {
             const response = await apiFetch(endpointMap[action], { method: 'POST' })
             if (!response.ok) throw new Error(`Failed to ${action} race`)
             await loadWizard()
+            await refreshRaceState(raceId)
         } catch (err) {
             setError(err instanceof Error ? err.message : `Unable to ${action} race.`)
         }
@@ -146,6 +153,7 @@ export default function SettingsPanel() {
             }
             setWizard(payload.wizard)
             setError('')
+            await refreshRaceState(String(payload?.wizard?.race_context?.race_id || ''))
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Unable to initialize race.')
         }
@@ -187,6 +195,7 @@ export default function SettingsPanel() {
                         <button className="rounded bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" type="button" onClick={() => controlRace('pause')}>Race Pause</button>
                         <button className="rounded bg-violet-600 px-4 py-2 text-sm font-semibold text-white hover:bg-violet-500" type="button" onClick={() => controlRace('snapshot')}>Save Snapshot</button>
                         <button className="rounded bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-500" type="button" onClick={() => controlRace('resume')}>Race Resume</button>
+                        <button className="rounded bg-rose-700 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" type="button" onClick={() => controlRace('finish')}>Race Finish</button>
                     </div>
                 </form>
             </div>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -1,35 +1,110 @@
 import { createContext, useContext, useState, useCallback, useRef, useEffect, type ReactNode } from 'react'
 import type { LiveRaceState, LiveRacer } from '@/types'
-import { backendWsUrl } from '@/lib/utils'
-
-// ── Connection Status ──────────────────────────────────────
+import { apiFetch, backendWsUrl, stringToColor } from '@/lib/utils'
 
 export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected'
 
-// ── Context Shape ──────────────────────────────────────────
-
 interface RaceContextValue {
-    // Live race state
     liveRace: LiveRaceState | null
     setLiveRace: (race: LiveRaceState | null) => void
     updateRacerPosition: (racerProfileId: string, updates: Partial<LiveRacer>) => void
-
-    // Connection
     connectionStatus: ConnectionStatus
     setConnectionStatus: (status: ConnectionStatus) => void
-
-    // Track visibility
     showTrack: boolean
     toggleTrack: () => void
-
-    // WebSocket
     wsRef: React.MutableRefObject<WebSocket | null>
     sendWsMessage: (msg: Record<string, unknown>) => void
+    refreshRaceState: (raceId?: string | null) => Promise<void>
 }
 
 const RaceContext = createContext<RaceContextValue | null>(null)
 
-// ── Provider ───────────────────────────────────────────────
+interface RuntimeStateResponse {
+    race?: {
+        id?: string
+        status?: LiveRaceState['status']
+        total_laps?: number
+    }
+    context?: {
+        race_name?: string
+        racers?: Array<Record<string, unknown>>
+    }
+}
+
+interface LapRecordResponse {
+    racer_profile_id?: string
+    lap_number?: number
+    lap_time?: number
+}
+
+function buildLiveRace(statePayload: RuntimeStateResponse, activeRaceId: string, laps: LapRecordResponse[]): LiveRaceState {
+    const race = statePayload.race || {}
+    const context = statePayload.context || {}
+    const racers = Array.isArray(context.racers) ? context.racers : []
+    const lapStats = new Map<string, { currentLap: number, bestLapTime: number | null, lastLapTime: number | null, totalTime: number }>()
+
+    for (const lap of laps) {
+        const racerId = String(lap.racer_profile_id || '')
+        if (!racerId) continue
+        const lapNumber = Number(lap.lap_number || 0)
+        const lapTime = Number(lap.lap_time || 0)
+        const current = lapStats.get(racerId) || {
+            currentLap: 0,
+            bestLapTime: null,
+            lastLapTime: null,
+            totalTime: 0,
+        }
+
+        current.currentLap = Math.max(current.currentLap, lapNumber)
+        current.lastLapTime = lapTime || current.lastLapTime
+        current.totalTime += lapTime
+        current.bestLapTime = current.bestLapTime == null
+            ? (lapTime || null)
+            : lapTime > 0
+                ? Math.min(current.bestLapTime, lapTime)
+                : current.bestLapTime
+        lapStats.set(racerId, current)
+    }
+
+    const liveRacers = racers
+        .map((racer): LiveRacer => {
+            const racerId = String(racer.id || '')
+            const stats = lapStats.get(racerId)
+            return {
+                racer_profile_id: racerId,
+                name: String(racer.name || `Racer ${racerId || '?'}`),
+                number: String(racer.number || ''),
+                color: stringToColor(String(racer.name || racerId || 'racer')),
+                current_position: 0,
+                current_lap: stats?.currentLap || 0,
+                best_lap_time: stats?.bestLapTime ?? null,
+                current_lap_time: 0,
+                last_lap_time: stats?.lastLapTime ?? null,
+                total_time: stats?.totalTime || 0,
+                gap_to_leader: 0,
+                status: race.status === 'finished' ? 'finished' : 'racing',
+                track_position: null,
+            }
+        })
+        .sort((a, b) => {
+            if (b.current_lap !== a.current_lap) return b.current_lap - a.current_lap
+            return a.total_time - b.total_time
+        })
+        .map((racer, index, ordered) => ({
+            ...racer,
+            current_position: index + 1,
+            gap_to_leader: index === 0 ? 0 : Math.max(racer.total_time - ordered[0]!.total_time, 0),
+        }))
+
+    return {
+        race_id: String(race.id || activeRaceId),
+        race_name: String(context.race_name || 'Race Master Pro Session'),
+        status: race.status || 'setup',
+        total_laps: Number(race.total_laps || 0),
+        elapsed_time: 0,
+        racers: liveRacers,
+    }
+}
 
 export function RaceProvider({ children }: { children: ReactNode }) {
     const [liveRace, setLiveRace] = useState<LiveRaceState | null>(null)
@@ -47,7 +122,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             return {
                 ...prev,
                 racers: prev.racers.map(r =>
-                    r.racer_profile_id === racerProfileId ? { ...r, ...updates } : r
+                    r.racer_profile_id === racerProfileId ? { ...r, ...updates } : r,
                 ),
             }
         })
@@ -59,7 +134,43 @@ export function RaceProvider({ children }: { children: ReactNode }) {
         }
     }, [])
 
-    // Auto-connect WebSocket on mount
+    const refreshRaceState = useCallback(async (raceId?: string | null) => {
+        try {
+            let activeRaceId = String(raceId || liveRace?.race_id || '')
+
+            if (!activeRaceId) {
+                const wizardResponse = await apiFetch('/api/setup/wizard')
+                if (!wizardResponse.ok) {
+                    setLiveRace(null)
+                    return
+                }
+                const wizardPayload = await wizardResponse.json()
+                activeRaceId = String(wizardPayload?.race_context?.race_id || '')
+            }
+
+            if (!activeRaceId) {
+                setLiveRace(null)
+                return
+            }
+
+            const [stateResponse, lapsResponse] = await Promise.all([
+                apiFetch(`/api/races/${activeRaceId}/state`),
+                apiFetch(`/api/laps?race_id=${encodeURIComponent(activeRaceId)}`),
+            ])
+
+            if (!stateResponse.ok) {
+                setLiveRace(null)
+                return
+            }
+
+            const statePayload = await stateResponse.json() as RuntimeStateResponse
+            const lapsPayload = lapsResponse.ok ? await lapsResponse.json() as LapRecordResponse[] : []
+            setLiveRace(buildLiveRace(statePayload, activeRaceId, Array.isArray(lapsPayload) ? lapsPayload : []))
+        } catch {
+            setLiveRace(null)
+        }
+    }, [liveRace?.race_id])
+
     useEffect(() => {
         const wsUrl = backendWsUrl('organizer')
 
@@ -75,7 +186,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                 setConnectionStatus('connected')
             }
 
-            ws.onmessage = (event) => {
+            ws.onmessage = event => {
                 try {
                     const msg = JSON.parse(event.data)
                     handleWsMessage(msg)
@@ -95,7 +206,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             }
         }
 
-        function handleWsMessage(msg: { type: string; data: Record<string, unknown> }) {
+        function handleWsMessage(msg: { type: string, data: Record<string, unknown> }) {
             switch (msg.type) {
                 case 'raceUpdate':
                     if (msg.data.race) {
@@ -110,15 +221,21 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                         )
                     }
                     break
+                case 'raceStart':
+                case 'racePause':
+                case 'raceResume':
+                case 'raceFinish':
+                case 'lapComplete':
+                    void refreshRaceState(String(msg.data?.race_id || liveRace?.race_id || ''))
+                    break
                 case 'pong':
-                    // heartbeat received
                     break
             }
         }
 
+        void refreshRaceState()
         connect()
 
-        // Heartbeat ping every 30s
         const pingInterval = setInterval(() => {
             if (wsRef.current?.readyState === WebSocket.OPEN) {
                 wsRef.current.send(JSON.stringify({ type: 'ping' }))
@@ -130,7 +247,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             clearInterval(pingInterval)
             ws?.close()
         }
-    }, [updateRacerPosition])
+    }, [liveRace?.race_id, refreshRaceState, updateRacerPosition])
 
     return (
         <RaceContext.Provider value={{
@@ -143,13 +260,12 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             toggleTrack,
             wsRef,
             sendWsMessage,
+            refreshRaceState,
         }}>
             {children}
         </RaceContext.Provider>
     )
 }
-
-// ── Hook ───────────────────────────────────────────────────
 
 export function useRaceContext(): RaceContextValue {
     const ctx = useContext(RaceContext)

--- a/scripts/run_race_master_pro.sh
+++ b/scripts/run_race_master_pro.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+APP_ROOT="$REPO_ROOT/ros_ws/src/j5_perception/race-master-pro"
+BACKEND_ROOT="$APP_ROOT/backend"
+FRONTEND_ROOT="$APP_ROOT/frontend"
+
+MODE="standalone"
+HOST="0.0.0.0"
+API_PORT="8080"
+UI_PORT="5173"
+PI_IP=""
+ROS_SETUP=""
+DOCTOR_MODE="false"
+VENV_DIR="$BACKEND_ROOT/.venv"
+VENV_PYTHON="$VENV_DIR/bin/python"
+
+find_python_bin() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+  return 1
+}
+
+source_setup_bash() {
+  local setup_file="$1"
+  local restore_nounset="false"
+  if [[ ! -f "$setup_file" ]]; then
+    echo "Missing setup script: $setup_file"
+    return 1
+  fi
+  if [[ $- == *u* ]]; then
+    restore_nounset="true"
+    set +u
+  fi
+  # shellcheck disable=SC1090
+  source "$setup_file"
+  local source_status=$?
+  if [[ "$restore_nounset" == "true" ]]; then
+    set -u
+  fi
+  return "$source_status"
+}
+
+is_port_in_use() {
+  local host="$1"
+  local port="$2"
+  local python_bin="${PYTHON_BIN:-$(find_python_bin || true)}"
+  if [[ -z "$python_bin" ]]; then
+    return 2
+  fi
+  "$python_bin" - "$host" "$port" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((host, port))
+    except OSError:
+        raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+}
+
+ensure_port_available() {
+  local name="$1"
+  local host="$2"
+  local port="$3"
+  if is_port_in_use "$host" "$port"; then
+    echo "$name port $port is already in use on $host."
+    exit 1
+  fi
+}
+
+ensure_process_running() {
+  local pid="$1"
+  local name="$2"
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "$name failed to stay running. Review the logs above and retry."
+    exit 1
+  fi
+}
+
+apply_defaults() {
+  if [[ -z "$PI_IP" ]]; then
+    PI_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+  fi
+  if [[ -z "$PI_IP" ]]; then
+    PI_IP="localhost"
+  fi
+}
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--mode standalone|ros2] [--host 0.0.0.0] [--api-port 8080] [--ui-port 5173] [--pi-ip <LAN_IP>] [--ros-setup /path/to/install/setup.bash] [--doctor]
+
+Starts the Race Master Pro FastAPI backend plus the Vite walkthrough UI.
+- standalone: start backend + Vite UI only
+- ros2: source ROS setup before launch so CLI/tools are available for wizard checks
+- doctor: print dependency/path diagnostics and exit
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) MODE="$2"; shift 2 ;;
+    --host) HOST="$2"; shift 2 ;;
+    --api-port) API_PORT="$2"; shift 2 ;;
+    --ui-port) UI_PORT="$2"; shift 2 ;;
+    --pi-ip) PI_IP="$2"; shift 2 ;;
+    --ros-setup) ROS_SETUP="$2"; shift 2 ;;
+    --doctor) DOCTOR_MODE="true"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1"; usage; exit 1 ;;
+  esac
+done
+
+for cmd in npm; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing dependency: '$cmd' is not on PATH."
+    exit 2
+  fi
+done
+
+PYTHON_BIN="$(find_python_bin || true)"
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "Python is required but neither 'python3' nor 'python' was found on PATH."
+  exit 2
+fi
+
+if [[ "$MODE" != "standalone" && "$MODE" != "ros2" ]]; then
+  echo "--mode must be standalone or ros2"
+  exit 1
+fi
+
+apply_defaults
+
+if [[ "$DOCTOR_MODE" == "true" ]]; then
+  echo "[run_race_master_pro] doctor: app_root=$APP_ROOT"
+  echo "[run_race_master_pro] doctor: python=$PYTHON_BIN"
+  echo "[run_race_master_pro] doctor: npm=$(command -v npm || echo missing)"
+  echo "[run_race_master_pro] doctor: ros2=$(command -v ros2 || echo missing)"
+  echo "[run_race_master_pro] doctor: api_port=$API_PORT ui_port=$UI_PORT host=$HOST"
+  exit 0
+fi
+
+if [[ "$MODE" == "ros2" ]]; then
+  if [[ -z "$ROS_SETUP" ]]; then
+    if [[ -f "$HOME/alive/j5/ros_ws/install/setup.bash" ]]; then
+      ROS_SETUP="$HOME/alive/j5/ros_ws/install/setup.bash"
+    elif [[ -f "$HOME/j5/ros_ws/install/setup.bash" ]]; then
+      ROS_SETUP="$HOME/j5/ros_ws/install/setup.bash"
+    elif [[ -f "$REPO_ROOT/ros_ws/install/setup.bash" ]]; then
+      ROS_SETUP="$REPO_ROOT/ros_ws/install/setup.bash"
+    fi
+  fi
+  if [[ -n "$ROS_SETUP" && -f "$ROS_SETUP" ]]; then
+    if [[ -f "/opt/ros/iron/setup.bash" ]]; then
+      source_setup_bash "/opt/ros/iron/setup.bash"
+    fi
+    source_setup_bash "$ROS_SETUP"
+  fi
+fi
+
+cleanup() {
+  if [[ -n "${UI_PID:-}" ]]; then kill "$UI_PID" 2>/dev/null || true; fi
+  if [[ -n "${API_PID:-}" ]]; then kill "$API_PID" 2>/dev/null || true; fi
+}
+trap cleanup EXIT INT TERM
+
+ensure_port_available "API" "$HOST" "$API_PORT"
+ensure_port_available "UI" "$HOST" "$UI_PORT"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+"$VENV_PYTHON" -m pip install -r "$BACKEND_ROOT/requirements.txt" >/dev/null
+
+export VITE_API_BASE_URL="http://$PI_IP:$API_PORT"
+export VITE_WS_URL="ws://$PI_IP:$API_PORT/ws"
+
+(
+  cd "$BACKEND_ROOT"
+  "$VENV_PYTHON" -m uvicorn app.main:app --host "$HOST" --port "$API_PORT"
+) &
+API_PID=$!
+
+(
+  cd "$FRONTEND_ROOT"
+  if [[ ! -d node_modules ]]; then
+    npm install >/dev/null
+  fi
+  npm run dev -- --host "$HOST" --port "$UI_PORT"
+) &
+UI_PID=$!
+
+sleep 2
+ensure_process_running "$API_PID" "Backend"
+ensure_process_running "$UI_PID" "Frontend"
+
+echo "Race Master Pro started"
+echo "- Mode: $MODE"
+echo "- Backend (local): http://localhost:$API_PORT"
+echo "- Backend (LAN):   http://$PI_IP:$API_PORT"
+echo "- Frontend (LAN):  http://$PI_IP:$UI_PORT"
+echo "- WebSocket (LAN): ws://$PI_IP:$API_PORT/ws"
+echo "- Wizard UI:       open Settings tab in the Vite app to verify/start/pause/resume race services"
+if [[ "$MODE" == "ros2" && -n "$ROS_SETUP" ]]; then
+  echo "- ROS setup:       $ROS_SETUP"
+fi
+
+echo "Press Ctrl+C to stop all processes."
+wait

--- a/scripts/run_racemanager.sh
+++ b/scripts/run_racemanager.sh
@@ -128,6 +128,7 @@ Starts race manager backend + frontend and optional bridge.
 - ros2: bridge subscribes to ROS 2 topic (requires a source-built ROS 2 workspace)
 - print-systemd: print a ready-to-run systemd setup snippet and exit
 - doctor: only run dependency/path checks and print diagnostics
+- default UI port is 3000 (Next.js). Use --ui-port 5173 only if you want legacy Vite-style port numbering.
 USAGE
 }
 
@@ -323,6 +324,10 @@ echo "- Mode: $MODE"
 echo "- Backend: http://localhost:$API_PORT"
 echo "- Frontend (local): http://localhost:$UI_PORT"
 echo "- Frontend (LAN):   http://$PI_IP:$UI_PORT"
+if [[ "$UI_PORT" != "5173" ]]; then
+  echo "- Legacy note:      port 5173 belongs to the older race-master-pro Vite app, not this Next.js UI"
+  echo "- To use 5173:      rerun with --ui-port 5173"
+fi
 echo "- API (LAN):        http://$PI_IP:$API_PORT"
 echo "- WS (LAN):         ws://$PI_IP:$API_PORT/ws"
 if [[ "$MODE" == "ros2" ]]; then


### PR DESCRIPTION
### Motivation
- Provide a one-command developer launcher for Race Master Pro (backend + Vite UI) to simplify local/dev startup and ROS2 workflows.
- Improve frontend live-race synchronization by fetching authoritative runtime state and lap data rather than relying solely on WS incremental messages.
- Surface small UX/docs clarifications and add missing race-control paths (finish) across the settings and bottom bar components.

### Description
- Added `scripts/run_race_master_pro.sh` to start the FastAPI backend and Vite-based frontend with flags for `--mode`, `--host`, `--api-port`, `--ui-port`, `--pi-ip`, `--ros-setup`, and `--doctor` and with basic port/process checks and optional ROS sourcing.
- Updated `apps/racemanager/README.md` and `ros_ws/src/j5_perception/race-master-pro/README.md` with startup notes and the new one-command launcher documentation.
- Reworked the frontend race store (`raceStore.tsx`) to introduce `refreshRaceState` and a `buildLiveRace` helper that aggregates `/api/races/:id/state` and `/api/laps` into a `LiveRaceState`, added `apiFetch` usage, and wired WS events to trigger `refreshRaceState` on important lifecycle messages (`raceStart`, `racePause`, `raceResume`, `raceFinish`, `lapComplete`).
- Updated UI components to call the new API-driven controls: `BottomBar.tsx` now uses `apiFetch` endpoints to `start|pause|resume|finish` races and calls `refreshRaceState` on success, and `SettingsPanel.tsx` now invokes `refreshRaceState` after wizard operations and adds a `finish` action/button.
- Minor update to `scripts/run_racemanager.sh` help output to clarify the default Next.js UI port (3000) vs legacy Vite port (5173).

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2360916483239ee4bfb8c86309e5)