### PR TITLE
Add CRUD API, dashboard, track mapping, and event persistence for Race Manager

### DIFF
--- a/apps/racemanager/README.md
+++ b/apps/racemanager/README.md
@@ -36,6 +36,73 @@ Quickstart for the service (from the repo root):
 The UI should point to the same HTTP/websocket endpoints (e.g.,
 `NEXT_PUBLIC_API_BASE`, `NEXT_PUBLIC_WS_URL`).
 
+## Local MongoDB on Raspberry Pi (instead of Atlas)
+If the Raspberry Pi already runs MongoDB, use that instance directly for race setup, live lap events, and dashboard reads.
+
+1. Start MongoDB on the Pi and confirm it answers a ping:
+   ```bash
+   sudo systemctl enable --now mongod
+   sudo systemctl status mongod --no-pager
+   mongosh --eval 'db.adminCommand({ ping: 1 })'
+   ```
+2. Create an application database/user if you have not done so yet:
+   ```bash
+   mongosh <<'EOF'
+   use j5_racing
+   db.createUser({
+     user: 'race_api',
+     pwd: 'change-me',
+     roles: [{ role: 'readWrite', db: 'j5_racing' }]
+   })
+   EOF
+   ```
+3. Point the service `.env` at the Pi database:
+   ```env
+   ATLAS_URI=mongodb://race_api:change-me@<pi-ip>:27017/j5_racing?authSource=j5_racing
+   RACE_DB_NAME=j5_racing
+   LAPS_COLLECTION=laps_live
+   WS_PUBLIC_URL=ws://<pi-ip>:4000/ws
+   HTTP_PORT=4000
+   ```
+4. Run the FastAPI service; it will use the Mongo repository when `ATLAS_URI` is set.
+
+## Race setup additions for camera-based object tracking
+Add these items to the operator checklist before live heats:
+
+1. Capture the current track photo from the overhead camera and save it with the track record.
+2. Mark the track mask, the start line, the finish line, and every required checkpoint/sector on the captured image.
+3. Create or update racers, then create physical car records with labels such as `carId`, number, paint color, and vision hints.
+4. Create the race entries that map each `carId` to exactly one racer for the current race.
+5. Start tracking only after the preview, database connection, and race-entry mapping all verify cleanly.
+6. Stream validated events (`checkpoint_crossing`, `lap_count`, `incident`, `finish_crossing`) into the API so the dashboard can repaint in real time.
+
+## Suggested Mongo collections for setup + live control
+- `tracks`: layout geometry, calibration, mask polygon, start/finish/checkpoints, snapshot metadata.
+- `cameras`: source, preview URL, calibration blobs, capture history.
+- `cars`: physical car metadata and appearance/model hints.
+- `racers`: racer profiles.
+- `races`: event metadata plus `entries` linking racers to cars.
+- `laps_live`: authoritative lap and checkpoint stream for the active race.
+- `telemetry_archive` / `incidents`: historical telemetry, off-track events, penalties, and replay diagnostics.
+
+## API resources for CRUD + dashboard visualization
+For the full setup workflow, expose or extend these resources:
+
+- `POST/GET/PUT/DELETE /api/tracks` for track image geometry and checkpoints.
+- `POST/GET/PUT/DELETE /api/cameras` for camera configuration and captured snapshots.
+- `POST/GET/PUT/DELETE /api/racers` for racer roster management.
+- `POST/GET/PUT/DELETE /api/cars` for physical car metadata and tracker hints.
+- `POST/GET/PUT/DELETE /api/races` for the race definition and `entries` mapping cars to racers.
+- `GET /api/races/{raceId}/dashboard` for the dashboard hydration payload.
+- `POST /api/races/{raceId}/events` for validated realtime events from the bridge/perception layer.
+- Websocket events: `lap`, `leaderboard`, `race_status`, `checkpoint`, `car_state`, `incident`.
+
+## Dashboard update pattern
+1. Perception/tracking publishes candidate car positions and crossing events.
+2. Bridge/API validates track order and lap rules, then persists the accepted result in MongoDB.
+3. API emits websocket deltas to the UI.
+4. Frontend updates the track canvas, leaderboard, racer cards, lap counter, and incident feed without a full page reload.
+
 ## Data flow (live + replay)
 1. **Lap counter node (ROS 2)** publishes validated laps: `{ carId, gateTime, lapTimeMs, headingOk, onTrack, minLapTimeOk }`.
 2. **Bridge** (`bridge/`) subscribes to the lap topic, attaches `raceId`/`seasonId`, and posts to `service/ingest` (HTTP or gRPC). Reject laps that fail anti-cheat flags. The bridge can also stream laps detected from prerecorded videos into the same endpoint with `source="replay"`.

--- a/apps/racemanager/service/main.py
+++ b/apps/racemanager/service/main.py
@@ -1,15 +1,40 @@
 """FastAPI race manager service for standalone and ROS-fed deployments."""
 
+from __future__ import annotations
+
+import uuid
 from datetime import datetime
 
-from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import (
+    Depends,
+    FastAPI,
+    HTTPException,
+    Response,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.responses import JSONResponse
 
 from .config import Settings, get_settings
 from .repository import RaceRepository, get_repository
-from .schemas import LapIngest, LapResponse, LeaderboardResponse
+from .schemas import (
+    CarRecord,
+    CarUpsert,
+    DashboardEntry,
+    LapIngest,
+    LapResponse,
+    LeaderboardResponse,
+    RaceDashboardResponse,
+    RaceEventIngest,
+    RaceRecord,
+    RaceUpsert,
+    RacerRecord,
+    RacerUpsert,
+    TrackRecord,
+    TrackUpsert,
+)
 
-app = FastAPI(title="J5 Race Manager", version="0.2.0")
+app = FastAPI(title="J5 Race Manager", version="0.3.0")
 
 
 class ConnectionManager:
@@ -51,14 +76,97 @@ class RepoProvider:
         return self._repo
 
 
+repo_provider = RepoProvider()
+ws_manager = ConnectionManager()
+
+
 def calculate_speed_kph(track_distance_m: float, lap_time_ms: int) -> float:
     if lap_time_ms <= 0:
         raise ValueError("lap_time_ms must be positive")
     return round((track_distance_m / lap_time_ms) * 3600, 3)
 
 
-repo_provider = RepoProvider()
-ws_manager = ConnectionManager()
+def _create_entity(kind: str, payload: dict, repository: RaceRepository) -> dict:
+    record = {"id": str(uuid.uuid4()), **payload}
+    return repository.create_entity(kind, record)
+
+
+def _list_entities(kind: str, repository: RaceRepository) -> list[dict]:
+    return repository.list_entities(kind)
+
+
+def _get_entity_or_404(kind: str, entity_id: str, repository: RaceRepository) -> dict:
+    record = repository.get_entity(kind, entity_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"{kind[:-1].title()} not found")
+    return record
+
+
+def _update_entity_or_404(
+    kind: str, entity_id: str, payload: dict, repository: RaceRepository
+) -> dict:
+    updated = repository.update_entity(kind, entity_id, payload)
+    if updated is None:
+        raise HTTPException(status_code=404, detail=f"{kind[:-1].title()} not found")
+    return updated
+
+
+def _delete_entity_or_404(
+    kind: str, entity_id: str, repository: RaceRepository
+) -> Response:
+    if not repository.delete_entity(kind, entity_id):
+        raise HTTPException(status_code=404, detail=f"{kind[:-1].title()} not found")
+    return Response(status_code=204)
+
+
+def build_dashboard(race_id: str, repository: RaceRepository) -> RaceDashboardResponse:
+    race = repository.get_entity("races", race_id)
+    if race is None:
+        raise HTTPException(status_code=404, detail="Race not found")
+
+    track = None
+    if race.get("trackId"):
+        track = repository.get_entity("tracks", race["trackId"])
+
+    cars = {item["id"]: item for item in repository.list_entities("cars")}
+    racers = {item["id"]: item for item in repository.list_entities("racers")}
+    leaderboard = repository.leaderboard(race_id)
+    lb_by_car = {entry.carId: entry for entry in leaderboard.leaderboard}
+    entries: list[DashboardEntry] = []
+
+    for entry in race.get("entries", []):
+        car = cars.get(entry.get("carId"), {})
+        racer = racers.get(entry.get("racerId"), {})
+        stats = lb_by_car.get(entry.get("carId"))
+        entries.append(
+            DashboardEntry(
+                carId=entry.get("carId", ""),
+                racerId=entry.get("racerId"),
+                carName=car.get("name", entry.get("carId", "Unassigned Car")),
+                racerName=racer.get("name", "Unassigned Racer"),
+                carNumber=car.get("carNumber", ""),
+                paintColor=car.get("paintColor", "#4ade80"),
+                trackerId=entry.get("trackerId"),
+                currentLap=stats.lapCount if stats else 0,
+                bestLapMs=stats.bestLapMs if stats else None,
+                avgSpeedKph=stats.avgSpeedKph if stats else None,
+                gapToLeaderMs=stats.gapToLeaderMs if stats else 0,
+                totalTimeMs=stats.totalTimeMs if stats else 0,
+            )
+        )
+
+    return RaceDashboardResponse(
+        race=RaceRecord(**race),
+        track=TrackRecord(**track) if track else None,
+        leaderboard=leaderboard,
+        entries=entries,
+        recentEvents=repository.list_events(race_id),
+    )
+
+
+async def broadcast_dashboard(race_id: str, repository: RaceRepository) -> None:
+    dashboard = build_dashboard(race_id, repository)
+    await ws_manager.broadcast_json({"type": "dashboard", "payload": dashboard.dict()})
 
 
 @app.get("/health")
@@ -99,6 +207,8 @@ async def ingest_lap(
     await ws_manager.broadcast_json(
         {"type": "leaderboard", "payload": leaderboard.dict()}
     )
+    if repository.get_entity("races", payload.raceId) is not None:
+        await broadcast_dashboard(payload.raceId, repository)
     return LapResponse(
         insertedId=inserted_id, speedKph=speed, isValid=payload.validity.is_valid
     )
@@ -113,6 +223,190 @@ def race_leaderboard(
         return repository.leaderboard(race_id)
     except Exception as exc:  # pragma: no cover
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/api/tracks", response_model=list[TrackRecord])
+def list_tracks(
+    repository: RaceRepository = Depends(repo_provider),
+) -> list[TrackRecord]:
+    return [TrackRecord(**item) for item in _list_entities("tracks", repository)]
+
+
+@app.post("/api/tracks", response_model=TrackRecord, status_code=201)
+def create_track(
+    payload: TrackUpsert, repository: RaceRepository = Depends(repo_provider)
+) -> TrackRecord:
+    return TrackRecord(**_create_entity("tracks", payload.dict(), repository))
+
+
+@app.get("/api/tracks/{track_id}", response_model=TrackRecord)
+def get_track(
+    track_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> TrackRecord:
+    return TrackRecord(**_get_entity_or_404("tracks", track_id, repository))
+
+
+@app.put("/api/tracks/{track_id}", response_model=TrackRecord)
+def update_track(
+    track_id: str,
+    payload: TrackUpsert,
+    repository: RaceRepository = Depends(repo_provider),
+) -> TrackRecord:
+    return TrackRecord(
+        **_update_entity_or_404("tracks", track_id, payload.dict(), repository)
+    )
+
+
+@app.delete("/api/tracks/{track_id}", status_code=204)
+def delete_track(
+    track_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> Response:
+    return _delete_entity_or_404("tracks", track_id, repository)
+
+
+@app.get("/api/cars", response_model=list[CarRecord])
+def list_cars(repository: RaceRepository = Depends(repo_provider)) -> list[CarRecord]:
+    return [CarRecord(**item) for item in _list_entities("cars", repository)]
+
+
+@app.post("/api/cars", response_model=CarRecord, status_code=201)
+def create_car(
+    payload: CarUpsert, repository: RaceRepository = Depends(repo_provider)
+) -> CarRecord:
+    return CarRecord(**_create_entity("cars", payload.dict(), repository))
+
+
+@app.get("/api/cars/{car_id}", response_model=CarRecord)
+def get_car(
+    car_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> CarRecord:
+    return CarRecord(**_get_entity_or_404("cars", car_id, repository))
+
+
+@app.put("/api/cars/{car_id}", response_model=CarRecord)
+def update_car(
+    car_id: str,
+    payload: CarUpsert,
+    repository: RaceRepository = Depends(repo_provider),
+) -> CarRecord:
+    return CarRecord(
+        **_update_entity_or_404("cars", car_id, payload.dict(), repository)
+    )
+
+
+@app.delete("/api/cars/{car_id}", status_code=204)
+def delete_car(
+    car_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> Response:
+    return _delete_entity_or_404("cars", car_id, repository)
+
+
+@app.get("/api/racers", response_model=list[RacerRecord])
+def list_racers(
+    repository: RaceRepository = Depends(repo_provider),
+) -> list[RacerRecord]:
+    return [RacerRecord(**item) for item in _list_entities("racers", repository)]
+
+
+@app.post("/api/racers", response_model=RacerRecord, status_code=201)
+def create_racer(
+    payload: RacerUpsert, repository: RaceRepository = Depends(repo_provider)
+) -> RacerRecord:
+    return RacerRecord(**_create_entity("racers", payload.dict(), repository))
+
+
+@app.get("/api/racers/{racer_id}", response_model=RacerRecord)
+def get_racer(
+    racer_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> RacerRecord:
+    return RacerRecord(**_get_entity_or_404("racers", racer_id, repository))
+
+
+@app.put("/api/racers/{racer_id}", response_model=RacerRecord)
+def update_racer(
+    racer_id: str,
+    payload: RacerUpsert,
+    repository: RaceRepository = Depends(repo_provider),
+) -> RacerRecord:
+    return RacerRecord(
+        **_update_entity_or_404("racers", racer_id, payload.dict(), repository)
+    )
+
+
+@app.delete("/api/racers/{racer_id}", status_code=204)
+def delete_racer(
+    racer_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> Response:
+    return _delete_entity_or_404("racers", racer_id, repository)
+
+
+@app.get("/api/races", response_model=list[RaceRecord])
+def list_races(repository: RaceRepository = Depends(repo_provider)) -> list[RaceRecord]:
+    return [RaceRecord(**item) for item in _list_entities("races", repository)]
+
+
+@app.post("/api/races", response_model=RaceRecord, status_code=201)
+def create_race(
+    payload: RaceUpsert, repository: RaceRepository = Depends(repo_provider)
+) -> RaceRecord:
+    return RaceRecord(**_create_entity("races", payload.dict(), repository))
+
+
+@app.get("/api/races/{race_id}", response_model=RaceRecord)
+def get_race(
+    race_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> RaceRecord:
+    return RaceRecord(**_get_entity_or_404("races", race_id, repository))
+
+
+@app.put("/api/races/{race_id}", response_model=RaceRecord)
+def update_race(
+    race_id: str,
+    payload: RaceUpsert,
+    repository: RaceRepository = Depends(repo_provider),
+) -> RaceRecord:
+    updated = RaceRecord(
+        **_update_entity_or_404("races", race_id, payload.dict(), repository)
+    )
+    return updated
+
+
+@app.delete("/api/races/{race_id}", status_code=204)
+def delete_race(
+    race_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> Response:
+    return _delete_entity_or_404("races", race_id, repository)
+
+
+@app.post("/api/races/{race_id}/events", status_code=201)
+async def create_race_event(
+    race_id: str,
+    payload: RaceEventIngest,
+    repository: RaceRepository = Depends(repo_provider),
+) -> dict:
+    _get_entity_or_404("races", race_id, repository)
+    event_id = repository.insert_event(race_id, payload)
+    event_payload = {
+        "id": event_id,
+        "raceId": race_id,
+        "type": payload.type,
+        "carId": payload.carId,
+        "racerId": payload.racerId,
+        "checkpointId": payload.checkpointId,
+        "lapNumber": payload.lapNumber,
+        "payload": payload.payload,
+        "timestamp": payload.timestamp.isoformat(),
+    }
+    await ws_manager.broadcast_json({"type": "event", "payload": event_payload})
+    await broadcast_dashboard(race_id, repository)
+    return event_payload
+
+
+@app.get("/api/races/{race_id}/dashboard", response_model=RaceDashboardResponse)
+def get_dashboard(
+    race_id: str, repository: RaceRepository = Depends(repo_provider)
+) -> RaceDashboardResponse:
+    return build_dashboard(race_id, repository)
 
 
 @app.websocket("/ws")

--- a/apps/racemanager/service/repository.py
+++ b/apps/racemanager/service/repository.py
@@ -1,4 +1,4 @@
-"""Repository helpers for laps and standings.
+"""Repository helpers for laps, CRUD resources, events, and dashboard backing data.
 
 Supports either MongoDB (`backend="mongo"`) or SQLite (`backend="sqlite"`).
 SQLite is the default for local standalone deployments.
@@ -6,13 +6,14 @@ SQLite is the default for local standalone deployments.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
-from .schemas import LapIngest, LeaderboardEntry, LeaderboardResponse
+from .schemas import LeaderboardEntry, LeaderboardResponse, LapIngest, RaceEventIngest
 
 
 class RaceRepository(ABC):
@@ -22,6 +23,36 @@ class RaceRepository(ABC):
 
     @abstractmethod
     def leaderboard(self, race_id: str) -> LeaderboardResponse:
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_entity(self, kind: str, record: dict) -> dict:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_entities(
+        self, kind: str, filters: Optional[dict] = None, *, limit: Optional[int] = None
+    ) -> list[dict]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_entity(self, kind: str, entity_id: str) -> dict | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_entity(self, kind: str, entity_id: str, record: dict) -> dict | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_entity(self, kind: str, entity_id: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def insert_event(self, race_id: str, event: RaceEventIngest) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_events(self, race_id: str, *, limit: int = 20) -> list[dict]:
         raise NotImplementedError
 
 
@@ -56,6 +87,33 @@ class SQLiteRaceRepository(RaceRepository):
         )
         self.conn.execute(
             """
+            CREATE TABLE IF NOT EXISTS entities (
+                kind TEXT NOT NULL,
+                id TEXT NOT NULL,
+                data_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY(kind, id)
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS race_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                race_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                car_id TEXT,
+                racer_id TEXT,
+                checkpoint_id TEXT,
+                lap_number INTEGER,
+                payload_json TEXT NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_laps_race_car
             ON laps_live (race_id, car_id)
             """
@@ -64,6 +122,18 @@ class SQLiteRaceRepository(RaceRepository):
             """
             CREATE INDEX IF NOT EXISTS idx_laps_race_timestamp
             ON laps_live (race_id, timestamp)
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_entities_kind
+            ON entities (kind, updated_at DESC)
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_events_race_timestamp
+            ON race_events (race_id, timestamp DESC)
             """
         )
         self.conn.commit()
@@ -108,7 +178,7 @@ class SQLiteRaceRepository(RaceRepository):
                     AVG(speed_kph) as avgSpeedKph,
                     SUM(lap_time_ms) as totalTimeMs
                 FROM laps_live
-                WHERE race_id = ?
+                WHERE race_id = ? AND is_valid = 1
                 GROUP BY car_id
                 ORDER BY totalTimeMs ASC
                 """,
@@ -118,6 +188,130 @@ class SQLiteRaceRepository(RaceRepository):
         leaderboard = self._attach_gaps(rows)
         entries = [LeaderboardEntry(**entry) for entry in leaderboard]
         return LeaderboardResponse(raceId=race_id, leaderboard=entries, asOf=now)
+
+    def create_entity(self, kind: str, record: dict) -> dict:
+        now = datetime.utcnow().isoformat()
+        payload = {
+            **record,
+            "createdAt": record.get("createdAt", now),
+            "updatedAt": now,
+        }
+        self.conn.execute(
+            """
+            INSERT INTO entities (kind, id, data_json, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                kind,
+                payload["id"],
+                json.dumps(payload),
+                payload["createdAt"],
+                payload["updatedAt"],
+            ),
+        )
+        self.conn.commit()
+        return payload
+
+    def list_entities(
+        self, kind: str, filters: Optional[dict] = None, *, limit: Optional[int] = None
+    ) -> list[dict]:
+        sql = "SELECT data_json FROM entities WHERE kind = ? ORDER BY updated_at DESC"
+        params: list[object] = [kind]
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        rows = [json.loads(row[0]) for row in self.conn.execute(sql, params)]
+        if not filters:
+            return rows
+        return [
+            row
+            for row in rows
+            if all(row.get(key) == value for key, value in filters.items())
+        ]
+
+    def get_entity(self, kind: str, entity_id: str) -> dict | None:
+        row = self.conn.execute(
+            "SELECT data_json FROM entities WHERE kind = ? AND id = ?",
+            (kind, entity_id),
+        ).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def update_entity(self, kind: str, entity_id: str, record: dict) -> dict | None:
+        existing = self.get_entity(kind, entity_id)
+        if not existing:
+            return None
+        updated = {
+            **existing,
+            **record,
+            "id": entity_id,
+            "createdAt": existing.get("createdAt", datetime.utcnow().isoformat()),
+            "updatedAt": datetime.utcnow().isoformat(),
+        }
+        self.conn.execute(
+            """
+            UPDATE entities
+            SET data_json = ?, updated_at = ?
+            WHERE kind = ? AND id = ?
+            """,
+            (json.dumps(updated), updated["updatedAt"], kind, entity_id),
+        )
+        self.conn.commit()
+        return updated
+
+    def delete_entity(self, kind: str, entity_id: str) -> bool:
+        cursor = self.conn.execute(
+            "DELETE FROM entities WHERE kind = ? AND id = ?",
+            (kind, entity_id),
+        )
+        self.conn.commit()
+        return cursor.rowcount > 0
+
+    def insert_event(self, race_id: str, event: RaceEventIngest) -> str:
+        cursor = self.conn.execute(
+            """
+            INSERT INTO race_events (
+                race_id, event_type, car_id, racer_id, checkpoint_id, lap_number, payload_json, timestamp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                race_id,
+                event.type,
+                event.carId,
+                event.racerId,
+                event.checkpointId,
+                event.lapNumber,
+                json.dumps(event.payload),
+                event.timestamp.isoformat(),
+            ),
+        )
+        self.conn.commit()
+        return str(cursor.lastrowid)
+
+    def list_events(self, race_id: str, *, limit: int = 20) -> list[dict]:
+        rows = self.conn.execute(
+            """
+            SELECT id, race_id, event_type, car_id, racer_id, checkpoint_id, lap_number, payload_json, timestamp
+            FROM race_events
+            WHERE race_id = ?
+            ORDER BY timestamp DESC
+            LIMIT ?
+            """,
+            (race_id, limit),
+        )
+        return [
+            {
+                "id": str(row["id"]),
+                "raceId": row["race_id"],
+                "type": row["event_type"],
+                "carId": row["car_id"],
+                "racerId": row["racer_id"],
+                "checkpointId": row["checkpoint_id"],
+                "lapNumber": row["lap_number"],
+                "payload": json.loads(row["payload_json"]),
+                "timestamp": row["timestamp"],
+            }
+            for row in rows
+        ]
 
     @staticmethod
     def _attach_gaps(rows: Iterable[sqlite3.Row]) -> list[dict]:
@@ -138,13 +332,21 @@ class MongoRaceRepository(RaceRepository):
         from pymongo import ASCENDING, MongoClient
 
         self._client = MongoClient(uri)
-        self._laps = self._client[db_name][laps_collection]
+        self._db = self._client[db_name]
+        self._laps = self._db[laps_collection]
+        self._events = self._db["race_events"]
         self._laps.create_index(
             [("raceId", ASCENDING), ("carId", ASCENDING)], background=True
         )
         self._laps.create_index(
             [("raceId", ASCENDING), ("timestamp", ASCENDING)], background=True
         )
+        self._events.create_index(
+            [("raceId", ASCENDING), ("timestamp", ASCENDING)], background=True
+        )
+
+    def _collection(self, kind: str):
+        return self._db[kind]
 
     def insert_lap(self, lap: LapIngest, speed_kph: float) -> str:
         payload = lap.dict()
@@ -155,7 +357,7 @@ class MongoRaceRepository(RaceRepository):
     def leaderboard(self, race_id: str) -> LeaderboardResponse:
         now = datetime.utcnow()
         pipeline: List[dict] = [
-            {"$match": {"raceId": race_id}},
+            {"$match": {"raceId": race_id, "isValid": True}},
             {
                 "$group": {
                     "_id": "$carId",
@@ -171,6 +373,60 @@ class MongoRaceRepository(RaceRepository):
         entries = self._attach_gaps(rows)
         models = [LeaderboardEntry(**entry) for entry in entries]
         return LeaderboardResponse(raceId=race_id, leaderboard=models, asOf=now)
+
+    def create_entity(self, kind: str, record: dict) -> dict:
+        now = datetime.utcnow().isoformat()
+        payload = {
+            **record,
+            "createdAt": record.get("createdAt", now),
+            "updatedAt": now,
+        }
+        self._collection(kind).insert_one(payload)
+        return payload
+
+    def list_entities(
+        self, kind: str, filters: Optional[dict] = None, *, limit: Optional[int] = None
+    ) -> list[dict]:
+        cursor = (
+            self._collection(kind).find(filters or {}, {"_id": 0}).sort("updatedAt", -1)
+        )
+        if limit is not None:
+            cursor = cursor.limit(limit)
+        return list(cursor)
+
+    def get_entity(self, kind: str, entity_id: str) -> dict | None:
+        return self._collection(kind).find_one({"id": entity_id}, {"_id": 0})
+
+    def update_entity(self, kind: str, entity_id: str, record: dict) -> dict | None:
+        existing = self.get_entity(kind, entity_id)
+        if not existing:
+            return None
+        updated = {
+            **existing,
+            **record,
+            "id": entity_id,
+            "createdAt": existing.get("createdAt", datetime.utcnow().isoformat()),
+            "updatedAt": datetime.utcnow().isoformat(),
+        }
+        self._collection(kind).replace_one({"id": entity_id}, updated, upsert=False)
+        return updated
+
+    def delete_entity(self, kind: str, entity_id: str) -> bool:
+        result = self._collection(kind).delete_one({"id": entity_id})
+        return result.deleted_count > 0
+
+    def insert_event(self, race_id: str, event: RaceEventIngest) -> str:
+        payload = event.dict()
+        payload.update({"raceId": race_id})
+        result = self._events.insert_one(payload)
+        return str(result.inserted_id)
+
+    def list_events(self, race_id: str, *, limit: int = 20) -> list[dict]:
+        return list(
+            self._events.find({"raceId": race_id}, {"_id": 0})
+            .sort("timestamp", -1)
+            .limit(limit)
+        )
 
     @staticmethod
     def _attach_gaps(rows: Iterable[dict]) -> list[dict]:

--- a/apps/racemanager/service/schemas.py
+++ b/apps/racemanager/service/schemas.py
@@ -1,11 +1,96 @@
-"""Pydantic models for lap ingestion and responses."""
+"""Pydantic models for race manager CRUD, event ingestion, and dashboard responses."""
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, validator
+
+
+class Point(BaseModel):
+    x: float
+    y: float
+
+
+class LineGate(BaseModel):
+    a: Point
+    b: Point
+    label: Optional[str] = None
+
+
+class CheckpointSpec(BaseModel):
+    id: str
+    name: str
+    type: Literal["start", "finish", "checkpoint", "sector"] = "checkpoint"
+    position: Point
+    order: int = 0
+
+
+class TrackUpsert(BaseModel):
+    name: str
+    lengthM: Optional[float] = Field(default=None, gt=0)
+    imageUrl: Optional[str] = None
+    layoutPoints: list[Point] = Field(default_factory=list)
+    maskPolygon: list[Point] = Field(default_factory=list)
+    startGate: Optional[LineGate] = None
+    finishGate: Optional[LineGate] = None
+    checkpoints: list[CheckpointSpec] = Field(default_factory=list)
+    calibration: dict[str, Any] = Field(default_factory=dict)
+
+
+class TrackRecord(TrackUpsert):
+    id: str
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class CarUpsert(BaseModel):
+    name: str
+    carNumber: str = ""
+    paintColor: str = "#4ade80"
+    trackerHint: Optional[str] = None
+    photoUrl: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class CarRecord(CarUpsert):
+    id: str
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class RacerUpsert(BaseModel):
+    name: str
+    team: Optional[str] = None
+    badgeColor: Optional[str] = None
+
+
+class RacerRecord(RacerUpsert):
+    id: str
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class RaceEntry(BaseModel):
+    carId: str
+    racerId: str
+    gridSlot: Optional[int] = None
+    trackerId: Optional[str] = None
+
+
+class RaceUpsert(BaseModel):
+    name: str
+    trackId: Optional[str] = None
+    totalLaps: int = Field(default=10, ge=1)
+    status: Literal["setup", "active", "paused", "finished"] = "setup"
+    entries: list[RaceEntry] = Field(default_factory=list)
+
+
+class RaceRecord(RaceUpsert):
+    id: str
+    createdAt: datetime
+    updatedAt: datetime
 
 
 class Validity(BaseModel):
@@ -50,6 +135,23 @@ class LapIngest(BaseModel):
         return normalized
 
 
+class RaceEventIngest(BaseModel):
+    type: Literal[
+        "lap_count",
+        "checkpoint_crossing",
+        "off_track",
+        "finish_crossing",
+        "car_assignment_changed",
+        "incident",
+    ]
+    carId: Optional[str] = None
+    racerId: Optional[str] = None
+    checkpointId: Optional[str] = None
+    lapNumber: Optional[int] = Field(default=None, ge=0)
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
 class LapResponse(BaseModel):
     insertedId: str
     speedKph: float
@@ -69,3 +171,26 @@ class LeaderboardResponse(BaseModel):
     raceId: str
     leaderboard: list[LeaderboardEntry]
     asOf: datetime
+
+
+class DashboardEntry(BaseModel):
+    carId: str
+    racerId: Optional[str] = None
+    carName: str
+    racerName: str
+    carNumber: str = ""
+    paintColor: str = "#4ade80"
+    trackerId: Optional[str] = None
+    currentLap: int = 0
+    bestLapMs: Optional[int] = None
+    avgSpeedKph: Optional[float] = None
+    gapToLeaderMs: int = 0
+    totalTimeMs: int = 0
+
+
+class RaceDashboardResponse(BaseModel):
+    race: RaceRecord
+    track: Optional[TrackRecord] = None
+    leaderboard: LeaderboardResponse
+    entries: list[DashboardEntry]
+    recentEvents: list[RaceEventIngest | dict[str, Any]]

--- a/apps/racemanager/ui/pages/index.tsx
+++ b/apps/racemanager/ui/pages/index.tsx
@@ -1,33 +1,385 @@
 import Head from 'next/head';
+import { useEffect, useMemo, useState } from 'react';
 import styles from '../styles/Home.module.css';
 
 const apiBase = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:4000';
 const wsUrl = process.env.NEXT_PUBLIC_WS_URL ?? 'ws://localhost:4000/ws';
 
+type Point = { x: number; y: number };
+type LineGate = { a: Point; b: Point; label?: string | null };
+type Checkpoint = { id: string; name: string; type: string; position: Point; order: number };
+type Track = {
+  id: string;
+  name: string;
+  imageUrl?: string | null;
+  layoutPoints: Point[];
+  maskPolygon: Point[];
+  startGate?: LineGate | null;
+  finishGate?: LineGate | null;
+  checkpoints: Checkpoint[];
+};
+type Race = { id: string; name: string; totalLaps: number; status: string };
+type LeaderboardEntry = {
+  carId: string;
+  lapCount: number;
+  bestLapMs: number;
+  avgSpeedKph: number;
+  totalTimeMs: number;
+  gapToLeaderMs: number;
+};
+type DashboardEntry = {
+  carId: string;
+  racerId?: string | null;
+  carName: string;
+  racerName: string;
+  carNumber: string;
+  paintColor: string;
+  trackerId?: string | null;
+  currentLap: number;
+  bestLapMs?: number | null;
+  avgSpeedKph?: number | null;
+  gapToLeaderMs: number;
+  totalTimeMs: number;
+};
+type RaceEvent = {
+  id: string;
+  type: string;
+  carId?: string | null;
+  racerId?: string | null;
+  checkpointId?: string | null;
+  lapNumber?: number | null;
+  timestamp: string;
+  payload?: Record<string, unknown>;
+};
+type Dashboard = {
+  race: Race;
+  track?: Track | null;
+  leaderboard: { leaderboard: LeaderboardEntry[] };
+  entries: DashboardEntry[];
+  recentEvents: RaceEvent[];
+};
+
+const formatMs = (value?: number | null) => {
+  if (!value) return '—';
+  const seconds = value / 1000;
+  return `${seconds.toFixed(2)}s`;
+};
+
+const formatGap = (value?: number | null) => {
+  if (!value) return 'Leader';
+  return `+${(value / 1000).toFixed(2)}s`;
+};
+
+function useTrackBounds(track?: Track | null) {
+  return useMemo(() => {
+    const points: Point[] = [];
+    if (track?.layoutPoints?.length) points.push(...track.layoutPoints);
+    if (track?.maskPolygon?.length) points.push(...track.maskPolygon);
+    if (track?.checkpoints?.length) points.push(...track.checkpoints.map((item) => item.position));
+    if (track?.startGate) points.push(track.startGate.a, track.startGate.b);
+    if (track?.finishGate) points.push(track.finishGate.a, track.finishGate.b);
+
+    if (!points.length) {
+      return { minX: 0, minY: 0, width: 100, height: 100 };
+    }
+
+    const xs = points.map((point) => point.x);
+    const ys = points.map((point) => point.y);
+    const minX = Math.min(...xs);
+    const minY = Math.min(...ys);
+    const maxX = Math.max(...xs);
+    const maxY = Math.max(...ys);
+    return {
+      minX,
+      minY,
+      width: Math.max(maxX - minX, 1),
+      height: Math.max(maxY - minY, 1),
+    };
+  }, [track]);
+}
+
+function TrackPreview({ track, entries }: { track?: Track | null; entries: DashboardEntry[] }) {
+  const bounds = useTrackBounds(track);
+  const scalePoint = (point: Point) => ({
+    x: ((point.x - bounds.minX) / bounds.width) * 100,
+    y: ((point.y - bounds.minY) / bounds.height) * 100,
+  });
+
+  const polyline = track?.layoutPoints?.length
+    ? track.layoutPoints.map((point) => {
+        const scaled = scalePoint(point);
+        return `${scaled.x},${scaled.y}`;
+      }).join(' ')
+    : '';
+
+  const polygon = track?.maskPolygon?.length
+    ? track.maskPolygon.map((point) => {
+        const scaled = scalePoint(point);
+        return `${scaled.x},${scaled.y}`;
+      }).join(' ')
+    : '';
+
+  return (
+    <div className={styles.trackCard}>
+      <div className={styles.panelHeader}>
+        <div>
+          <h2>Track & checkpoints</h2>
+          <p>Start/finish geometry, checkpoints, and live race entries for the selected race.</p>
+        </div>
+        {track?.imageUrl ? <a href={track.imageUrl} target="_blank" rel="noreferrer">Track photo</a> : null}
+      </div>
+      <div className={styles.trackViewport}>
+        <svg viewBox="0 0 100 100" className={styles.trackSvg} preserveAspectRatio="none">
+          {polygon ? <polygon points={polygon} className={styles.maskPolygon} /> : null}
+          {polyline ? <polyline points={polyline} className={styles.layoutPolyline} /> : null}
+          {track?.startGate ? (() => {
+            const a = scalePoint(track.startGate.a);
+            const b = scalePoint(track.startGate.b);
+            return <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} className={styles.startGate} />;
+          })() : null}
+          {track?.finishGate ? (() => {
+            const a = scalePoint(track.finishGate.a);
+            const b = scalePoint(track.finishGate.b);
+            return <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} className={styles.finishGate} />;
+          })() : null}
+          {track?.checkpoints?.map((checkpoint) => {
+            const point = scalePoint(checkpoint.position);
+            return (
+              <g key={checkpoint.id}>
+                <circle cx={point.x} cy={point.y} r="2.2" className={styles.checkpointDot} />
+                <text x={point.x + 2.5} y={point.y - 2.5} className={styles.checkpointLabel}>
+                  {checkpoint.name}
+                </text>
+              </g>
+            );
+          })}
+          {entries.map((entry, index) => {
+            const checkpoint = track?.checkpoints?.[index % Math.max(track?.checkpoints?.length || 1, 1)];
+            const point = checkpoint ? scalePoint(checkpoint.position) : { x: 10 + index * 10, y: 80 - index * 8 };
+            return (
+              <g key={`${entry.carId}-${entry.racerId || 'na'}`}>
+                <circle cx={point.x} cy={point.y} r="3.2" fill={entry.paintColor || '#4ade80'} className={styles.entryDot} />
+                <text x={point.x} y={point.y + 8} textAnchor="middle" className={styles.entryLabel}>
+                  #{entry.carNumber || entry.carId}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+        {!track ? <div className={styles.emptyTrack}>Create a track with geometry/checkpoints to render the race map.</div> : null}
+      </div>
+    </div>
+  );
+}
+
 export default function Home() {
+  const [races, setRaces] = useState<Race[]>([]);
+  const [selectedRaceId, setSelectedRaceId] = useState<string>('');
+  const [dashboard, setDashboard] = useState<Dashboard | null>(null);
+  const [connectionState, setConnectionState] = useState<'connecting' | 'connected' | 'disconnected'>('connecting');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadRaces() {
+      const response = await fetch(`${apiBase}/api/races`);
+      if (!response.ok || cancelled) return;
+      const payload = await response.json() as Race[];
+      setRaces(payload);
+      if (!selectedRaceId && payload[0]?.id) {
+        setSelectedRaceId(payload[0].id);
+      }
+    }
+
+    void loadRaces();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedRaceId]);
+
+  useEffect(() => {
+    if (!selectedRaceId) return;
+    let cancelled = false;
+    async function loadDashboard() {
+      const response = await fetch(`${apiBase}/api/races/${selectedRaceId}/dashboard`);
+      if (!response.ok || cancelled) return;
+      const payload = await response.json() as Dashboard;
+      setDashboard(payload);
+    }
+
+    void loadDashboard();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedRaceId]);
+
+  useEffect(() => {
+    const socket = new WebSocket(wsUrl);
+    setConnectionState('connecting');
+
+    socket.onopen = () => setConnectionState('connected');
+    socket.onclose = () => setConnectionState('disconnected');
+    socket.onerror = () => setConnectionState('disconnected');
+    socket.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data) as { type?: string; payload?: Dashboard & { raceId?: string } };
+        if (message.type === 'dashboard' && message.payload?.race?.id === selectedRaceId) {
+          setDashboard(message.payload as Dashboard);
+        }
+        if ((message.type === 'lap' || message.type === 'event' || message.type === 'leaderboard') && selectedRaceId) {
+          void fetch(`${apiBase}/api/races/${selectedRaceId}/dashboard`)
+            .then((response) => response.ok ? response.json() : null)
+            .then((payload) => {
+              if (payload) setDashboard(payload as Dashboard);
+            });
+        }
+      } catch {
+        // ignore malformed payloads
+      }
+    };
+
+    const keepAlive = window.setInterval(() => {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send('ping');
+      }
+    }, 15000);
+
+    return () => {
+      window.clearInterval(keepAlive);
+      socket.close();
+    };
+  }, [selectedRaceId]);
+
   return (
     <div className={styles.container}>
       <Head>
         <title>Race Manager UI</title>
         <meta
           name="description"
-          content="Simple placeholder UI for Race Manager API connectivity"
+          content="Realtime dashboard for race setup, CRUD-backed race data, and websocket lap updates"
         />
       </Head>
 
       <main className={styles.main}>
-        <h1 className={styles.title}>Race Manager UI</h1>
-        <p className={styles.description}>
-          Set <code>NEXT_PUBLIC_API_BASE</code> and <code>NEXT_PUBLIC_WS_URL</code> to
-          point at your FastAPI service. Defaults are
-          <span className={styles.inlineValue}>{apiBase}</span> and
-          <span className={styles.inlineValue}>{wsUrl}</span>.
-        </p>
-        <p className={styles.description}>
-          Subscribe to websocket events (<code>lap</code>, <code>leaderboard</code>,
-          <code>race_status</code>, <code>championship</code>) and render your own
-          leaderboard experience here.
-        </p>
+        <header className={styles.hero}>
+          <div>
+            <h1 className={styles.title}>Race Manager Dashboard</h1>
+            <p className={styles.description}>
+              API: <code>{apiBase}</code> · WebSocket: <code>{wsUrl}</code>
+            </p>
+          </div>
+          <div className={styles.connectionBadge} data-state={connectionState}>
+            {connectionState}
+          </div>
+        </header>
+
+        <section className={styles.toolbar}>
+          <label className={styles.selectorLabel}>
+            Active race
+            <select value={selectedRaceId} onChange={(event) => setSelectedRaceId(event.target.value)}>
+              <option value="">Select a race</option>
+              {races.map((race) => (
+                <option key={race.id} value={race.id}>
+                  {race.name} · {race.status} · {race.totalLaps} laps
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className={styles.toolbarText}>
+            Use the API to CRUD tracks/cars/racers/races, then watch lap + checkpoint events refresh this dashboard in real time.
+          </div>
+        </section>
+
+        {!dashboard ? (
+          <section className={styles.emptyState}>
+            <h2>No dashboard loaded</h2>
+            <p>Create race records through the new CRUD API (`/api/tracks`, `/api/cars`, `/api/racers`, `/api/races`) and select a race to visualize it here.</p>
+          </section>
+        ) : (
+          <div className={styles.grid}>
+            <TrackPreview track={dashboard.track} entries={dashboard.entries} />
+
+            <section className={styles.panel}>
+              <div className={styles.panelHeader}>
+                <div>
+                  <h2>{dashboard.race.name}</h2>
+                  <p>{dashboard.race.status} · {dashboard.race.totalLaps} total laps</p>
+                </div>
+              </div>
+              <div className={styles.entryList}>
+                {dashboard.entries.map((entry) => (
+                  <article key={`${entry.carId}-${entry.racerId || 'na'}`} className={styles.entryCard}>
+                    <div className={styles.entryIdentity}>
+                      <span className={styles.colorSwatch} style={{ backgroundColor: entry.paintColor }} />
+                      <div>
+                        <strong>{entry.racerName}</strong>
+                        <p>{entry.carName} · #{entry.carNumber || entry.carId}</p>
+                      </div>
+                    </div>
+                    <dl className={styles.entryStats}>
+                      <div><dt>Lap</dt><dd>{entry.currentLap}</dd></div>
+                      <div><dt>Best</dt><dd>{formatMs(entry.bestLapMs)}</dd></div>
+                      <div><dt>Gap</dt><dd>{formatGap(entry.gapToLeaderMs)}</dd></div>
+                      <div><dt>Avg speed</dt><dd>{entry.avgSpeedKph ? `${entry.avgSpeedKph.toFixed(1)} kph` : '—'}</dd></div>
+                    </dl>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className={styles.panel}>
+              <div className={styles.panelHeader}>
+                <div>
+                  <h2>Leaderboard</h2>
+                  <p>Validated lap counts and total race time from persisted backend state.</p>
+                </div>
+              </div>
+              <div className={styles.tableWrapper}>
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>Car</th>
+                      <th>Laps</th>
+                      <th>Best</th>
+                      <th>Avg speed</th>
+                      <th>Gap</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashboard.leaderboard.leaderboard.map((entry) => (
+                      <tr key={entry.carId}>
+                        <td>{entry.carId}</td>
+                        <td>{entry.lapCount}</td>
+                        <td>{formatMs(entry.bestLapMs)}</td>
+                        <td>{entry.avgSpeedKph.toFixed(1)} kph</td>
+                        <td>{formatGap(entry.gapToLeaderMs)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section className={styles.panel}>
+              <div className={styles.panelHeader}>
+                <div>
+                  <h2>Recent events</h2>
+                  <p>Checkpoint, lap-count, incident, and finish events streamed from the API.</p>
+                </div>
+              </div>
+              <div className={styles.eventList}>
+                {dashboard.recentEvents.map((event) => (
+                  <article key={event.id} className={styles.eventItem}>
+                    <div>
+                      <strong>{event.type}</strong>
+                      <p>{event.carId || '—'} · {event.checkpointId || 'no checkpoint'} · lap {event.lapNumber ?? '—'}</p>
+                    </div>
+                    <time>{new Date(event.timestamp).toLocaleTimeString()}</time>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/apps/racemanager/ui/styles/Home.module.css
+++ b/apps/racemanager/ui/styles/Home.module.css
@@ -1,36 +1,323 @@
 .container {
   min-height: 100vh;
   padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  background: #08111f;
+  color: #eef2ff;
 }
 
 .main {
+  max-width: 1400px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
+}
+
+.hero,
+.toolbar,
+.panel,
+.trackCard,
+.emptyState {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.35);
+}
+
+.hero,
+.toolbar {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  text-align: center;
+  padding: 1.25rem 1.5rem;
+  gap: 1rem;
 }
 
 .title {
   margin: 0;
-  line-height: 1.15;
-  font-size: 3rem;
+  line-height: 1.1;
+  font-size: 2.6rem;
 }
 
 .description {
-  margin: 0;
-  font-size: 1.1rem;
-  max-width: 40rem;
+  margin: 0.5rem 0 0;
+  color: #cbd5e1;
 }
 
-.inlineValue {
-  margin: 0 0.4rem;
-  padding: 0.2rem 0.4rem;
-  border-radius: 0.35rem;
-  background: #f4f4f4;
-  border: 1px solid #e2e2e2;
+.description code {
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+}
+
+.connectionBadge {
+  text-transform: capitalize;
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.connectionBadge[data-state='connected'] {
+  background: rgba(34, 197, 94, 0.14);
+  color: #86efac;
+}
+
+.connectionBadge[data-state='connecting'] {
+  background: rgba(250, 204, 21, 0.14);
+  color: #fde68a;
+}
+
+.connectionBadge[data-state='disconnected'] {
+  background: rgba(248, 113, 113, 0.12);
+  color: #fca5a5;
+}
+
+.selectorLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-weight: 600;
+}
+
+.selectorLabel select {
+  min-width: 320px;
+  background: #020617;
+  color: #eef2ff;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+}
+
+.toolbarText {
+  color: #cbd5e1;
+  max-width: 46rem;
+}
+
+.emptyState {
+  padding: 2rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  gap: 1.25rem;
+}
+
+.trackCard,
+.panel {
+  padding: 1.1rem;
+}
+
+.trackCard {
+  grid-row: span 2;
+}
+
+.panelHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.panelHeader h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.panelHeader p {
+  margin: 0.35rem 0 0;
+  color: #94a3b8;
+}
+
+.panelHeader a {
+  color: #93c5fd;
+}
+
+.trackViewport {
+  position: relative;
+  min-height: 420px;
+  border-radius: 18px;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(8, 17, 31, 0.95)),
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.18), transparent 45%);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.trackSvg {
+  width: 100%;
+  height: 100%;
+  min-height: 420px;
+}
+
+.maskPolygon {
+  fill: rgba(59, 130, 246, 0.08);
+  stroke: rgba(125, 211, 252, 0.55);
+  stroke-width: 0.5;
+}
+
+.layoutPolyline {
+  fill: none;
+  stroke: rgba(226, 232, 240, 0.85);
+  stroke-width: 0.9;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.startGate,
+.finishGate {
+  stroke-width: 1.25;
+  stroke-linecap: round;
+}
+
+.startGate {
+  stroke: #22c55e;
+}
+
+.finishGate {
+  stroke: #f97316;
+}
+
+.checkpointDot {
+  fill: #facc15;
+}
+
+.checkpointLabel,
+.entryLabel {
+  fill: #e2e8f0;
+  font-size: 3.2px;
+}
+
+.entryDot {
+  stroke: rgba(255, 255, 255, 0.85);
+  stroke-width: 0.55;
+}
+
+.emptyTrack {
+  position: absolute;
+  inset: auto 1rem 1rem 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.72);
+  color: #cbd5e1;
+}
+
+.entryList,
+.eventList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.entryCard,
+.eventItem {
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  background: rgba(2, 6, 23, 0.38);
+}
+
+.entryIdentity {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.entryIdentity p,
+.eventItem p {
+  margin: 0.2rem 0 0;
+  color: #94a3b8;
+}
+
+.colorSwatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+}
+
+.entryStats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem 1rem;
+  margin: 0.85rem 0 0;
+}
+
+.entryStats div {
+  border-top: 1px solid rgba(148, 163, 184, 0.08);
+  padding-top: 0.55rem;
+}
+
+.entryStats dt {
+  color: #94a3b8;
+  font-size: 0.8rem;
+}
+
+.entryStats dd {
+  margin: 0.15rem 0 0;
+  font-weight: 700;
+}
+
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 0.8rem 0.55rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.table th {
+  color: #94a3b8;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.eventItem {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.eventItem time {
+  color: #cbd5e1;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 1080px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .trackCard {
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 720px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .hero,
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .selectorLabel select {
+    min-width: 0;
+    width: 100%;
+  }
 }

--- a/docs/race_manager.md
+++ b/docs/race_manager.md
@@ -89,9 +89,104 @@ Flow covered end-to-end:
 1. ROS2 prerequisites and package visibility
 2. Headless Raspberry Pi connectivity
 3. Backend API health
-4. Camera preview + track image capture
-5. Race initialization data (event/race/racers/laps)
-6. Tracking start + lap log monitoring
-7. Pause/snapshot/resume controls with state restoration
+4. MongoDB reachability on the Pi or LAN host
+5. Camera preview + track image capture
+6. Track markup: start line, finish line, and checkpoints
+7. Car identity mapping: camera track IDs -> physical cars -> racers
+8. Race initialization data (event/race/racers/laps)
+9. Tracking start + lap log monitoring
+10. Pause/snapshot/resume controls with state restoration
 
-State is persisted server-side so laps counted, racer metadata, and setup context can be restored after pause/resume.
+State is persisted server-side so laps counted, racer metadata, setup context, checkpoint geometry, and car-to-racer assignments can be restored after pause/resume.
+
+### Expanded setup wizard checklist for camera-based race control
+Add the following operator tasks to the race setup flow before pressing **Start Tracking**:
+
+1. **Connect to MongoDB on the Pi**
+   - Confirm MongoDB is running locally on the Raspberry Pi (`mongodb://localhost:27017`) or on a reachable LAN host.
+   - Save the connection in the API service `.env` using `ATLAS_URI`/`MONGO_URI` style wiring, for example `mongodb://race:secret@<pi-ip>:27017/j5_racing?authSource=admin`.
+   - Verify connectivity with `mongosh` and then through the backend `/health` endpoint before creating race records.
+2. **Capture the track photo from the camera**
+   - Use the Computer Vision preview to capture and persist the latest overhead image for the current venue.
+   - Store the image path/URL and camera calibration values with the track record so future sessions can be reloaded without repeating calibration from scratch.
+3. **Mark the racing geometry on the captured image**
+   - Draw the outer/inner track boundary or mask.
+   - Mark the **start line** and **finish line** (or a single bidirectional gate if the implementation uses one crossing line with direction validation).
+   - Add **checkpoints / sector gates** around the lap so the tracker can verify that each car completed a full loop in order before a lap event is accepted.
+4. **Register cars and bind them to racers for this race**
+   - Create or reuse racer profiles.
+   - Create a per-race car roster with fields such as `carId`, `displayName`, `paintColor`, `numberTag`, and optional appearance embedding metadata from the camera model.
+   - Bind each detected tracker identity to a car, and each car to a racer entry in the current race. This mapping should be editable before the green flag and lock once the race starts unless an operator explicitly overrides it.
+5. **Start object tracking with validation rules enabled**
+   - Require ordered checkpoint traversal, on-track mask validation, forward direction at the finish gate, and minimum lap time checks before incrementing lap count.
+   - Emit lap, sector, off-track, re-identification, and finish events into the API so the dashboard stays synchronized.
+6. **Drive real-time dashboard updates**
+   - Subscribe the dashboard to websocket events (`lap`, `leaderboard`, `race_status`, `car_state`, `checkpoint`, `incident`).
+   - Refresh the track map, lap counter, racer cards, and leaderboard as soon as the API persists or validates a new event.
+
+### MongoDB on Raspberry Pi setup steps
+When MongoDB is installed on the Pi instead of Atlas, use the local deployment as the source of truth for race state:
+
+1. **Start and verify MongoDB**
+   ```bash
+   sudo systemctl enable --now mongod
+   sudo systemctl status mongod --no-pager
+   mongosh --eval 'db.adminCommand({ ping: 1 })'
+   ```
+2. **Create the race database and application user**
+   ```bash
+   mongosh <<'EOF'
+   use j5_racing
+   db.createUser({
+     user: 'race_api',
+     pwd: 'change-me',
+     roles: [{ role: 'readWrite', db: 'j5_racing' }]
+   })
+   EOF
+   ```
+3. **Point the race manager service at the Pi database**
+   ```env
+   ATLAS_URI=mongodb://race_api:change-me@<pi-ip>:27017/j5_racing?authSource=j5_racing
+   RACE_DB_NAME=j5_racing
+   LAPS_COLLECTION=laps_live
+   ```
+4. **Seed the core collections before first use**
+   - `tracks`: geometry, calibration, mask, start/finish/checkpoints, dashboard overlay metadata.
+   - `cars`: physical cars and vision-identification hints.
+   - `racers`: people entered in the event.
+   - `races`: the active race plus the per-race car/racer assignments.
+   - `laps_live`, `telemetry_archive`, and `incidents`: streaming race events.
+
+### Suggested API resources for visualization + CRUD
+The API should expose CRUD and visualization payloads that line up with the setup steps above:
+
+- `POST/GET/PUT/DELETE /api/tracks`
+  - Include `layout_points`, `mask_polygon`, `start_gate`, `finish_gate`, and `checkpoints`.
+- `POST/GET/PUT/DELETE /api/cameras`
+  - Store camera source, calibration, snapshot URL, and preview metadata.
+- `POST/GET/PUT/DELETE /api/racers`
+  - Manage racer profiles used across multiple races.
+- `POST/GET/PUT/DELETE /api/cars`
+  - Manage physical car metadata and appearance tags used by the tracker.
+- `POST/GET/PUT/DELETE /api/races`
+  - Persist the race definition, lap target, and `entries: [{ racerId, carId, gridSlot, trackerHint }]`.
+- `POST /api/races/{raceId}/tracking/start` and `POST /api/races/{raceId}/tracking/stop`
+  - Toggle the perception pipeline for the configured camera.
+- `POST /api/races/{raceId}/events`
+  - Accept realtime `lap_count`, `checkpoint_crossing`, `off_track`, `finish_crossing`, and `car_assignment_changed` events.
+- `GET /api/races/{raceId}/dashboard`
+  - Return the aggregated payload needed by the frontend: race clock, leaderboard, track positions, checkpoint status, and recent incidents.
+
+### How dashboard visuals should update
+Use the backend as the only writer of authoritative race state, then broadcast deltas to the UI:
+
+1. Perception emits detections and candidate crossings.
+2. API validates checkpoint order and lap rules, then writes the accepted state change into MongoDB.
+3. API publishes a websocket message with the updated `dashboard` and the incremental event.
+4. Frontend store updates:
+   - **Track canvas**: move each car marker, highlight crossed checkpoints, and paint the active start/finish gate.
+   - **Leaderboard**: update lap count, last lap, best lap, gap to leader, and race position.
+   - **Racer cards**: show car color/number, tracker confidence, penalties/incidents, and camera health.
+   - **Control state**: disable reconfiguration actions after the race starts unless the operator pauses the session.
+
+That setup gives you a clear race-day sequence: connect services -> capture track -> mark geometry -> assign cars/racers -> start tracking -> validate laps -> broadcast live dashboard updates.

--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -320,6 +320,9 @@ After the wizard finishes:
 - Open `preflight_summary.json` and use `wizard.track.meters_per_pixel` as your baseline calibration value.
 - If you used `--apply-backend`, keep the printed Race/Track/Camera IDs for API debugging and race operations.
 - Verify racers and lap count in the UI match the wizard values before live heats.
+- Before pressing **Start Tracking**, capture the latest track photo, mark the start line / finish line / checkpoints, and confirm each detected car is mapped to the correct racer entry for this race.
+- If MongoDB is running on the Pi, verify `mongosh --eval 'db.adminCommand({ ping: 1 })'` succeeds and point the backend service at `mongodb://<pi-ip>:27017/j5_racing` (or your configured authenticated URI) so setup records and live events persist outside local SQLite.
+- Treat the dashboard as a consumer of validated backend state: the API should persist checkpoint/lap/incident events first, then fan them out over websocket so the track map, leaderboard, and racer cards stay in sync.
 
 If snapshot capture says `ffmpeg not installed`, install it on Raspberry Pi:
 

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/analytics/Analytics.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/analytics/Analytics.tsx
@@ -1,12 +1,143 @@
+import { useEffect, useMemo, useState } from 'react'
+import { apiFetch, formatLapTime } from '@/lib/utils'
+import { useRaceContext } from '@/stores/raceStore'
+import type { Track } from '@/types'
+
+interface TrackRecordRow {
+    id: string
+    lap_time: number
+    racer_name: string
+    racer_number: string
+    recorded_at?: string
+}
+
+function parseTrack(raw: Record<string, unknown>): Track {
+    return {
+        id: String(raw.id || ''),
+        name: String(raw.name || 'Track'),
+        scale: String(raw.scale || '1:24'),
+        track_distance: raw.track_distance == null ? null : Number(raw.track_distance),
+        layout_points: [],
+        boundary_polygon: [],
+        created_at: raw.created_at ? String(raw.created_at) : undefined,
+    }
+}
+
 export default function Analytics() {
+    const { liveRace } = useRaceContext()
+    const [tracks, setTracks] = useState<Track[]>([])
+    const [selectedTrackId, setSelectedTrackId] = useState('')
+    const [records, setRecords] = useState<TrackRecordRow[]>([])
+    const [status, setStatus] = useState('')
+
+    useEffect(() => {
+        const loadTracks = async () => {
+            try {
+                const response = await apiFetch('/api/tracks')
+                if (!response.ok) throw new Error('Failed to load tracks')
+                const payload = await response.json()
+                const parsed = Array.isArray(payload)
+                    ? payload.map(item => parseTrack(item as Record<string, unknown>))
+                    : []
+                setTracks(parsed)
+                if (!selectedTrackId && parsed[0]?.id) {
+                    setSelectedTrackId(parsed[0].id)
+                }
+            } catch (error) {
+                setStatus(error instanceof Error ? error.message : 'Unable to load tracks.')
+            }
+        }
+        void loadTracks()
+    }, [selectedTrackId])
+
+    useEffect(() => {
+        if (!selectedTrackId) return
+        const loadRecords = async () => {
+            try {
+                const response = await apiFetch(`/api/analytics/track/${selectedTrackId}/records`)
+                if (!response.ok) throw new Error('Failed to load track records')
+                const payload = await response.json()
+                setRecords(Array.isArray(payload) ? payload as TrackRecordRow[] : [])
+                setStatus('')
+            } catch (error) {
+                setStatus(error instanceof Error ? error.message : 'Unable to load track records.')
+            }
+        }
+        void loadRecords()
+    }, [selectedTrackId])
+
+    const liveStats = useMemo(() => {
+        const racers = liveRace?.racers || []
+        if (racers.length === 0) return null
+        const bestLap = racers
+            .map(racer => racer.best_lap_time)
+            .filter((value): value is number => value != null)
+            .sort((a, b) => a - b)[0] || null
+        const averageGap = racers.length > 1
+            ? racers.slice(1).reduce((sum, racer) => sum + racer.gap_to_leader, 0) / (racers.length - 1)
+            : 0
+        return {
+            racers: racers.length,
+            leader: racers[0]?.name || '—',
+            bestLap,
+            averageGap,
+        }
+    }, [liveRace?.racers])
+
     return (
         <div className="fade-in space-y-4">
-            <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Analytics</h2>
-            <div className="race-card p-8 text-center">
-                <div className="text-4xl mb-3">📊</div>
-                <p className="text-[var(--color-text-secondary)]">
-                    Lap time analysis, track records, and performance trends will appear here after completing races.
+            <div>
+                <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Analytics</h2>
+                <p className="text-sm text-[var(--color-text-secondary)]">
+                    Track records, live race pacing, and simple lag/performance diagnostics pulled from the existing backend analytics endpoints.
                 </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-4">
+                <div className="race-card"><p className="text-xs text-[var(--color-text-muted)]">Live racers</p><p className="mt-2 text-2xl font-semibold">{liveStats?.racers ?? 0}</p></div>
+                <div className="race-card"><p className="text-xs text-[var(--color-text-muted)]">Current leader</p><p className="mt-2 text-2xl font-semibold">{liveStats?.leader || '—'}</p></div>
+                <div className="race-card"><p className="text-xs text-[var(--color-text-muted)]">Session best lap</p><p className="mt-2 text-2xl font-semibold">{liveStats?.bestLap ? formatLapTime(liveStats.bestLap * 1000) : '—'}</p></div>
+                <div className="race-card"><p className="text-xs text-[var(--color-text-muted)]">Avg gap</p><p className="mt-2 text-2xl font-semibold">{liveStats ? `${(liveStats.averageGap / 1000).toFixed(2)}s` : '—'}</p></div>
+            </div>
+
+            <div className="race-card space-y-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                        <h3 className="text-base font-semibold">Track records</h3>
+                        <p className="text-xs text-[var(--color-text-secondary)]">Top lap records for the selected track.</p>
+                    </div>
+                    <select className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white" value={selectedTrackId} onChange={event => setSelectedTrackId(event.target.value)}>
+                        <option value="">Select a track</option>
+                        {tracks.map(track => <option key={track.id} value={track.id}>{track.name}</option>)}
+                    </select>
+                </div>
+
+                {status ? <p className="text-sm text-[var(--color-text-secondary)]">{status}</p> : null}
+
+                <div className="overflow-x-auto">
+                    <table className="min-w-full text-sm">
+                        <thead>
+                            <tr className="text-left text-[var(--color-text-muted)]">
+                                <th className="pb-2">Pos</th>
+                                <th className="pb-2">Racer</th>
+                                <th className="pb-2">Number</th>
+                                <th className="pb-2">Lap</th>
+                                <th className="pb-2">Recorded</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {records.map((record, index) => (
+                                <tr key={record.id} className="border-t border-white/6">
+                                    <td className="py-2">{index + 1}</td>
+                                    <td className="py-2">{record.racer_name}</td>
+                                    <td className="py-2">#{record.racer_number || '—'}</td>
+                                    <td className="py-2 font-semibold">{formatLapTime(record.lap_time * 1000)}</td>
+                                    <td className="py-2 text-[var(--color-text-secondary)]">{record.recorded_at ? new Date(record.recorded_at).toLocaleString() : '—'}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/championship/ChampionshipView.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/championship/ChampionshipView.tsx
@@ -1,12 +1,210 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { apiFetch } from '@/lib/utils'
+import type { Championship, Season } from '@/types'
+
+interface StandingRow {
+    racer_id: string
+    racer_name: string
+    racer_number: string
+    total_points: number
+    wins: number
+    podiums: number
+    races_completed: number
+}
+
+const seasonDefaults = { name: '', year: new Date().getFullYear(), status: 'active' as Season['status'] }
+const championshipDefaults = { season_id: '', name: '', points_system: '{"1":25,"2":18,"3":15}', status: 'active' as Championship['status'] }
+
+function normalizeChampionship(raw: Record<string, unknown>): Championship {
+    let pointsSystem: Record<number, number> = {}
+    if (typeof raw.points_system === 'string') {
+        try {
+            pointsSystem = JSON.parse(raw.points_system as string) as Record<number, number>
+        } catch {
+            pointsSystem = {}
+        }
+    } else if (raw.points_system && typeof raw.points_system === 'object') {
+        pointsSystem = raw.points_system as Record<number, number>
+    }
+
+    return {
+        id: String(raw.id || ''),
+        season_id: String(raw.season_id || ''),
+        name: String(raw.name || 'Championship'),
+        points_system: pointsSystem,
+        status: (raw.status as Championship['status']) || 'active',
+        created_at: raw.created_at ? String(raw.created_at) : undefined,
+    }
+}
+
 export default function ChampionshipView() {
+    const [seasons, setSeasons] = useState<Season[]>([])
+    const [championships, setChampionships] = useState<Championship[]>([])
+    const [selectedChampionshipId, setSelectedChampionshipId] = useState('')
+    const [seasonForm, setSeasonForm] = useState(seasonDefaults)
+    const [championshipForm, setChampionshipForm] = useState(championshipDefaults)
+    const [standings, setStandings] = useState<StandingRow[]>([])
+    const [status, setStatus] = useState('')
+
+    const selectedChampionship = useMemo(
+        () => championships.find(championship => championship.id === selectedChampionshipId) || null,
+        [championships, selectedChampionshipId],
+    )
+
+    const loadData = async () => {
+        try {
+            const [seasonsResponse, championshipsResponse] = await Promise.all([
+                apiFetch('/api/seasons'),
+                apiFetch('/api/championships'),
+            ])
+            if (!seasonsResponse.ok || !championshipsResponse.ok) throw new Error('Failed to load championship data')
+            const seasonsPayload = await seasonsResponse.json() as Season[]
+            const championshipsPayload = await championshipsResponse.json()
+            const normalized = Array.isArray(championshipsPayload)
+                ? championshipsPayload.map(item => normalizeChampionship(item as Record<string, unknown>))
+                : []
+            setSeasons(seasonsPayload)
+            setChampionships(normalized)
+            if (!selectedChampionshipId && normalized[0]?.id) {
+                setSelectedChampionshipId(normalized[0].id)
+            }
+            if (!championshipForm.season_id && seasonsPayload[0]?.id) {
+                setChampionshipForm(prev => ({ ...prev, season_id: seasonsPayload[0].id }))
+            }
+            setStatus('')
+        } catch (error) {
+            setStatus(error instanceof Error ? error.message : 'Unable to load championships.')
+        }
+    }
+
+    useEffect(() => {
+        void loadData()
+    }, [])
+
+    useEffect(() => {
+        if (!selectedChampionshipId) {
+            setStandings([])
+            return
+        }
+        const loadStandings = async () => {
+            try {
+                const response = await apiFetch(`/api/analytics/championship/${selectedChampionshipId}/standings`)
+                if (!response.ok) throw new Error('Failed to load standings')
+                const payload = await response.json()
+                setStandings(Array.isArray(payload) ? payload as StandingRow[] : [])
+                setStatus('')
+            } catch (error) {
+                setStatus(error instanceof Error ? error.message : 'Unable to load standings.')
+            }
+        }
+        void loadStandings()
+    }, [selectedChampionshipId])
+
+    const submitSeason = async (event: FormEvent) => {
+        event.preventDefault()
+        try {
+            const response = await apiFetch('/api/seasons', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(seasonForm),
+            })
+            if (!response.ok) throw new Error('Failed to create season')
+            setSeasonForm(seasonDefaults)
+            setStatus('Season created.')
+            await loadData()
+        } catch (error) {
+            setStatus(error instanceof Error ? error.message : 'Unable to create season.')
+        }
+    }
+
+    const submitChampionship = async (event: FormEvent) => {
+        event.preventDefault()
+        try {
+            const response = await apiFetch('/api/championships', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(championshipForm),
+            })
+            if (!response.ok) throw new Error('Failed to create championship')
+            setChampionshipForm(prev => ({ ...championshipDefaults, season_id: prev.season_id }))
+            setStatus('Championship created.')
+            await loadData()
+        } catch (error) {
+            setStatus(error instanceof Error ? error.message : 'Unable to create championship.')
+        }
+    }
+
     return (
         <div className="fade-in space-y-4">
-            <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Championship</h2>
-            <div className="race-card p-8 text-center">
-                <div className="text-4xl mb-3">🏆</div>
-                <p className="text-[var(--color-text-secondary)]">
-                    Season standings, championship points, and race results. Create a season in Settings to get started.
+            <div>
+                <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Championship</h2>
+                <p className="text-sm text-[var(--color-text-secondary)]">
+                    Manage seasons and championships, then review the live points table using the backend standings endpoint.
                 </p>
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-[320px_320px_1fr]">
+                <form className="race-card space-y-3" onSubmit={submitSeason}>
+                    <h3 className="text-base font-semibold">Create season</h3>
+                    <input className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={seasonForm.name} onChange={event => setSeasonForm(prev => ({ ...prev, name: event.target.value }))} placeholder="Season name" required />
+                    <input className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" type="number" value={seasonForm.year} onChange={event => setSeasonForm(prev => ({ ...prev, year: Number(event.target.value) }))} placeholder="Year" required />
+                    <button className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500" type="submit">Add Season</button>
+                </form>
+
+                <form className="race-card space-y-3" onSubmit={submitChampionship}>
+                    <h3 className="text-base font-semibold">Create championship</h3>
+                    <select className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white" value={championshipForm.season_id} onChange={event => setChampionshipForm(prev => ({ ...prev, season_id: event.target.value }))} required>
+                        <option value="">Select season</option>
+                        {seasons.map(season => <option key={season.id} value={season.id}>{season.name} ({season.year})</option>)}
+                    </select>
+                    <input className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={championshipForm.name} onChange={event => setChampionshipForm(prev => ({ ...prev, name: event.target.value }))} placeholder="Championship name" required />
+                    <textarea className="min-h-[110px] w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={championshipForm.points_system} onChange={event => setChampionshipForm(prev => ({ ...prev, points_system: event.target.value }))} />
+                    <button className="rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500" type="submit">Add Championship</button>
+                </form>
+
+                <div className="race-card space-y-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                            <h3 className="text-base font-semibold">Standings</h3>
+                            <p className="text-xs text-[var(--color-text-secondary)]">
+                                {selectedChampionship ? `${selectedChampionship.name} standings` : 'Select a championship to load standings.'}
+                            </p>
+                        </div>
+                        <select className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white" value={selectedChampionshipId} onChange={event => setSelectedChampionshipId(event.target.value)}>
+                            <option value="">Select championship</option>
+                            {championships.map(championship => <option key={championship.id} value={championship.id}>{championship.name}</option>)}
+                        </select>
+                    </div>
+
+                    {status ? <p className="text-sm text-[var(--color-text-secondary)]">{status}</p> : null}
+
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full text-sm">
+                            <thead>
+                                <tr className="text-left text-[var(--color-text-muted)]">
+                                    <th className="pb-2">Pos</th>
+                                    <th className="pb-2">Racer</th>
+                                    <th className="pb-2">Points</th>
+                                    <th className="pb-2">Wins</th>
+                                    <th className="pb-2">Podiums</th>
+                                    <th className="pb-2">Races</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {standings.map((row, index) => (
+                                    <tr key={row.racer_id} className="border-t border-white/6">
+                                        <td className="py-2">{index + 1}</td>
+                                        <td className="py-2">{row.racer_name} <span className="text-[var(--color-text-secondary)]">#{row.racer_number || '—'}</span></td>
+                                        <td className="py-2 font-semibold">{row.total_points ?? 0}</td>
+                                        <td className="py-2">{row.wins ?? 0}</td>
+                                        <td className="py-2">{row.podiums ?? 0}</td>
+                                        <td className="py-2">{row.races_completed ?? 0}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/dashboard/Dashboard.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,9 +1,50 @@
+import { useEffect, useMemo, useState } from 'react'
 import { useRaceContext } from '@/stores/raceStore'
 import Leaderboard from './Leaderboard'
 import TrackCanvas from '@/components/track/TrackCanvas'
+import type { Track } from '@/types'
+import {
+    TRACK_OVERLAY_EVENT,
+    apiFetch,
+    getSelectedTrackId,
+    getTrackPhotoUrl,
+    parseTrackRecord,
+} from '@/lib/utils'
 
 export default function Dashboard() {
     const { liveRace, showTrack } = useRaceContext()
+    const [track, setTrack] = useState<Track | null>(null)
+    const [trackPhotoUrl, setTrackPhotoUrl] = useState('')
+
+    useEffect(() => {
+        let cancelled = false
+
+        const loadTrack = async () => {
+            const selectedTrackId = getSelectedTrackId()
+            const listResponse = await apiFetch('/api/tracks')
+            if (!listResponse.ok || cancelled) return
+            const listPayload = await listResponse.json()
+            const tracks = Array.isArray(listPayload)
+                ? listPayload.map((item) => parseTrackRecord(item as Record<string, unknown>))
+                : []
+            const nextTrack = tracks.find((item) => item.id === selectedTrackId) || tracks[0] || null
+            setTrack(nextTrack)
+            setTrackPhotoUrl(nextTrack ? getTrackPhotoUrl(nextTrack.id) : '')
+        }
+
+        void loadTrack()
+
+        const handleOverlayChange = () => {
+            void loadTrack()
+        }
+        window.addEventListener(TRACK_OVERLAY_EVENT, handleOverlayChange)
+        return () => {
+            cancelled = true
+            window.removeEventListener(TRACK_OVERLAY_EVENT, handleOverlayChange)
+        }
+    }, [])
+
+    const checkpoints = useMemo(() => [], [])
 
     if (!liveRace) {
         return (
@@ -21,18 +62,32 @@ export default function Dashboard() {
 
     return (
         <div className="h-full flex flex-col gap-4 fade-in">
-            {/* Track Map (toggleable) */}
             {showTrack && (
-                <div className="race-card" style={{ minHeight: 200, maxHeight: '35%' }}>
+                <div className="race-card" style={{ minHeight: 260, maxHeight: '42%' }}>
+                    <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                            <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                                {track?.name || 'Track preview'}
+                            </h3>
+                            <p className="text-xs text-[var(--color-text-secondary)]">
+                                Saved spline path is drawn over the captured track photo. Racer dots follow camera updates when available, and otherwise interpolate along the spline.
+                            </p>
+                        </div>
+                        {track?.layout_points.length ? (
+                            <span className="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-semibold text-blue-300">
+                                {track.layout_points.length} spline points
+                            </span>
+                        ) : null}
+                    </div>
                     <TrackCanvas
                         racers={liveRace.racers}
-                        layoutPoints={[]}
-                        checkpoints={[]}
+                        layoutPoints={track?.layout_points || []}
+                        checkpoints={checkpoints}
+                        backgroundImageUrl={trackPhotoUrl || undefined}
                     />
                 </div>
             )}
 
-            {/* Leaderboard */}
             <div className="flex-1 min-h-0">
                 <Leaderboard racers={liveRace.racers} totalLaps={liveRace.total_laps} />
             </div>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/racers/RacerManager.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/racers/RacerManager.tsx
@@ -1,12 +1,192 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { apiFetch, stringToColor } from '@/lib/utils'
+import { useRaceContext } from '@/stores/raceStore'
+import type { RacerProfile } from '@/types'
+
+interface RacerSummary {
+    total_races?: number
+    avg_position?: number | null
+    all_time_best_lap?: number | null
+    career_avg_lap?: number | null
+    total_points?: number | null
+    dnf_count?: number | null
+    wins?: number | null
+    podiums?: number | null
+}
+
+const emptyForm = {
+    id: '',
+    name: '',
+    number: '',
+    vehicle_description: '',
+}
+
 export default function RacerManager() {
+    const { liveRace } = useRaceContext()
+    const [racers, setRacers] = useState<RacerProfile[]>([])
+    const [summaries, setSummaries] = useState<Record<string, RacerSummary>>({})
+    const [form, setForm] = useState(emptyForm)
+    const [status, setStatus] = useState('')
+    const [loading, setLoading] = useState(true)
+
+    const activeRacerIds = useMemo(
+        () => new Set((liveRace?.racers || []).map(racer => racer.racer_profile_id)),
+        [liveRace?.racers],
+    )
+
+    const loadRacers = async () => {
+        setLoading(true)
+        try {
+            const response = await apiFetch('/api/racers')
+            if (!response.ok) throw new Error('Failed to load racers')
+            const payload = await response.json() as RacerProfile[]
+            setRacers(payload)
+            const summaryPairs = await Promise.all(
+                payload.map(async racer => {
+                    const summaryResponse = await apiFetch(`/api/analytics/racer/${racer.id}/summary`)
+                    const summary = summaryResponse.ok ? await summaryResponse.json() as RacerSummary : {}
+                    return [racer.id, summary] as const
+                }),
+            )
+            setSummaries(Object.fromEntries(summaryPairs))
+            setStatus('')
+        } catch (error) {
+            setStatus(error instanceof Error ? error.message : 'Unable to load racers.')
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    useEffect(() => {
+        void loadRacers()
+    }, [])
+
+    const submitRacer = async (event: FormEvent) => {
+        event.preventDefault()
+        const payload = {
+            name: form.name,
+            number: form.number,
+            vehicle_description: form.vehicle_description || null,
+            profile_pic: null,
+        }
+        try {
+            const response = await apiFetch(form.id ? `/api/racers/${form.id}` : '/api/racers', {
+                method: form.id ? 'PUT' : 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            })
+            if (!response.ok) throw new Error(`Failed to ${form.id ? 'update' : 'create'} racer`)
+            setForm(emptyForm)
+            setStatus(form.id ? 'Racer updated.' : 'Racer created.')
+            await loadRacers()
+        } catch (error) {
+            setStatus(error instanceof Error ? error.message : 'Unable to save racer.')
+        }
+    }
+
+    const editRacer = (racer: RacerProfile) => {
+        setForm({
+            id: racer.id,
+            name: racer.name,
+            number: racer.number,
+            vehicle_description: racer.vehicle_description || '',
+        })
+    }
+
+    const deleteRacer = async (racerId: string) => {
+        try {
+            const response = await apiFetch(`/api/racers/${racerId}`, { method: 'DELETE' })
+            if (!response.ok) throw new Error('Failed to delete racer')
+            if (form.id === racerId) setForm(emptyForm)
+            setStatus('Racer deleted.')
+            await loadRacers()
+        } catch (error) {
+            setStatus(error instanceof Error ? error.message : 'Unable to delete racer.')
+        }
+    }
+
     return (
         <div className="fade-in space-y-4">
-            <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Racers</h2>
-            <div className="race-card p-8 text-center">
-                <div className="text-4xl mb-3">👤</div>
-                <p className="text-[var(--color-text-secondary)]">
-                    Manage racer profiles, view behavioral metrics, and compare drivers across races and seasons.
-                </p>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Racers</h2>
+                    <p className="text-sm text-[var(--color-text-secondary)]">
+                        Create racer profiles, edit car/racer metadata, and compare career summaries alongside the current live race roster.
+                    </p>
+                </div>
+                <button className="rounded bg-slate-700 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-600" onClick={() => void loadRacers()}>
+                    Refresh
+                </button>
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-[340px_1fr]">
+                <form className="race-card space-y-3" onSubmit={submitRacer}>
+                    <div>
+                        <h3 className="text-base font-semibold">{form.id ? 'Edit racer' : 'Create racer'}</h3>
+                        <p className="text-xs text-[var(--color-text-secondary)]">
+                            Use this tab to keep racer identities, numbers, and vehicle descriptions aligned with the live race setup.
+                        </p>
+                    </div>
+                    <input className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={form.name} onChange={event => setForm(prev => ({ ...prev, name: event.target.value }))} placeholder="Racer name" required />
+                    <input className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={form.number} onChange={event => setForm(prev => ({ ...prev, number: event.target.value }))} placeholder="Racer number" />
+                    <textarea className="min-h-[110px] w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={form.vehicle_description} onChange={event => setForm(prev => ({ ...prev, vehicle_description: event.target.value }))} placeholder="Vehicle / car notes" />
+                    <div className="flex flex-wrap gap-2">
+                        <button className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500" type="submit">
+                            {form.id ? 'Save Racer' : 'Add Racer'}
+                        </button>
+                        <button className="rounded bg-slate-700 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-600" type="button" onClick={() => setForm(emptyForm)}>
+                            Reset
+                        </button>
+                    </div>
+                    {status ? <p className="text-xs text-[var(--color-text-secondary)]">{status}</p> : null}
+                </form>
+
+                <div className="space-y-4">
+                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        {racers.map(racer => {
+                            const summary = summaries[racer.id] || {}
+                            const isLive = activeRacerIds.has(racer.id)
+                            return (
+                                <article key={racer.id} className="race-card space-y-3">
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div className="flex items-center gap-3">
+                                            <span
+                                                className="inline-flex h-9 w-9 items-center justify-center rounded-full text-sm font-bold text-white"
+                                                style={{ backgroundColor: stringToColor(racer.name) }}
+                                            >
+                                                {racer.number || racer.name.slice(0, 1).toUpperCase()}
+                                            </span>
+                                            <div>
+                                                <h3 className="font-semibold text-[var(--color-text-primary)]">{racer.name}</h3>
+                                                <p className="text-xs text-[var(--color-text-secondary)]">
+                                                    #{racer.number || '—'} {isLive ? '· Live now' : '· Not on track'}
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <div className="flex gap-2">
+                                            <button className="rounded bg-slate-700 px-2 py-1 text-xs font-semibold text-white hover:bg-slate-600" onClick={() => editRacer(racer)}>Edit</button>
+                                            <button className="rounded bg-rose-700 px-2 py-1 text-xs font-semibold text-white hover:bg-rose-600" onClick={() => void deleteRacer(racer.id)}>Delete</button>
+                                        </div>
+                                    </div>
+                                    <p className="text-sm text-[var(--color-text-secondary)] min-h-[40px]">
+                                        {racer.vehicle_description || 'No vehicle description saved yet.'}
+                                    </p>
+                                    <dl className="grid grid-cols-2 gap-2 text-xs">
+                                        <div className="rounded bg-slate-900/70 p-2"><dt className="text-[var(--color-text-muted)]">Points</dt><dd className="font-semibold">{summary.total_points ?? 0}</dd></div>
+                                        <div className="rounded bg-slate-900/70 p-2"><dt className="text-[var(--color-text-muted)]">Wins</dt><dd className="font-semibold">{summary.wins ?? 0}</dd></div>
+                                        <div className="rounded bg-slate-900/70 p-2"><dt className="text-[var(--color-text-muted)]">Podiums</dt><dd className="font-semibold">{summary.podiums ?? 0}</dd></div>
+                                        <div className="rounded bg-slate-900/70 p-2"><dt className="text-[var(--color-text-muted)]">Best lap</dt><dd className="font-semibold">{summary.all_time_best_lap ? `${summary.all_time_best_lap.toFixed(3)}s` : '—'}</dd></div>
+                                    </dl>
+                                </article>
+                            )
+                        })}
+                    </div>
+                    {!loading && racers.length === 0 ? (
+                        <div className="race-card p-8 text-center text-[var(--color-text-secondary)]">
+                            No racers found yet. Add the first racer using the form on the left.
+                        </div>
+                    ) : null}
+                </div>
             </div>
         </div>
     )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl } from '@/lib/utils'
+import { apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl, getLatestSnapshotUrl, getSelectedTrackId, getTrackPhotoUrl, parseTrackRecord, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
 import { useRaceContext } from '@/stores/raceStore'
+import TrackCanvas from '@/components/track/TrackCanvas'
+import type { Track, TrackPoint } from '@/types'
 
 interface SetupCheckResult {
     command: string
@@ -46,6 +48,51 @@ export default function SettingsPanel() {
     const [busyStepId, setBusyStepId] = useState<string | null>(null)
     const [error, setError] = useState('')
     const [config, setConfig] = useState(defaultConfig)
+    const [tracks, setTracks] = useState<Track[]>([])
+    const [selectedTrackId, setSelectedTrackIdState] = useState('')
+    const [trackName, setTrackName] = useState('Main Track')
+    const [trackPhotoUrl, setTrackPhotoUrlState] = useState('')
+    const [editorPoints, setEditorPoints] = useState<TrackPoint[]>([])
+
+    const selectedTrack = useMemo(
+        () => tracks.find(track => track.id === selectedTrackId) || null,
+        [selectedTrackId, tracks],
+    )
+
+    const applyTrackSelection = (track: Track | null) => {
+        if (!track) {
+            setSelectedTrackIdState('')
+            setTrackName('Main Track')
+            setTrackPhotoUrlState(getLatestSnapshotUrl())
+            setEditorPoints([])
+            return
+        }
+        setSelectedTrackIdState(track.id)
+        setSelectedTrackId(track.id)
+        setTrackName(track.name)
+        setEditorPoints(track.layout_points)
+        setTrackPhotoUrlState(getTrackPhotoUrl(track.id) || getLatestSnapshotUrl())
+    }
+
+    const loadTracks = async () => {
+        try {
+            const response = await apiFetch('/api/tracks')
+            if (!response.ok) throw new Error('Failed to load tracks')
+            const payload = await response.json()
+            const parsed = Array.isArray(payload)
+                ? payload.map(item => parseTrackRecord(item as Record<string, unknown>))
+                : []
+            setTracks(parsed)
+            const persistedTrackId = getSelectedTrackId()
+            const nextTrack = parsed.find(track => track.id === persistedTrackId)
+                || parsed.find(track => track.id === selectedTrackId)
+                || parsed[0]
+                || null
+            applyTrackSelection(nextTrack)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Unable to load track list.')
+        }
+    }
 
     const loadWizard = async () => {
         try {
@@ -72,7 +119,8 @@ export default function SettingsPanel() {
     }
 
     useEffect(() => {
-        loadWizard()
+        void loadWizard()
+        void loadTracks()
     }, [])
 
     const frontendApiUrl = configuredApiBaseUrl() ?? `same-origin /api → fallback ${backendBaseUrl()}`
@@ -159,6 +207,70 @@ export default function SettingsPanel() {
         }
     }
 
+    const createTrack = async () => {
+        try {
+            const response = await apiFetch('/api/tracks', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: trackName,
+                    scale: '1:24',
+                    track_distance: null,
+                    layout_points: JSON.stringify(editorPoints),
+                    boundary_polygon: JSON.stringify(selectedTrack?.boundary_polygon || []),
+                }),
+            })
+            if (!response.ok) throw new Error('Failed to create track')
+            const created = parseTrackRecord(await response.json() as Record<string, unknown>)
+            if (trackPhotoUrl) {
+                setTrackPhotoUrl(created.id, trackPhotoUrl)
+            }
+            setSelectedTrackId(created.id)
+            await loadTracks()
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Unable to create track.')
+        }
+    }
+
+    const saveTrackSpline = async () => {
+        if (!selectedTrackId) {
+            await createTrack()
+            return
+        }
+        try {
+            const response = await apiFetch(`/api/tracks/${selectedTrackId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: trackName,
+                    scale: selectedTrack?.scale || '1:24',
+                    track_distance: selectedTrack?.track_distance || null,
+                    layout_points: JSON.stringify(editorPoints),
+                    boundary_polygon: JSON.stringify(selectedTrack?.boundary_polygon || []),
+                }),
+            })
+            if (!response.ok) throw new Error('Failed to save track spline')
+            if (trackPhotoUrl) {
+                setTrackPhotoUrl(selectedTrackId, trackPhotoUrl)
+            }
+            await loadTracks()
+            setError('')
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Unable to save track spline.')
+        }
+    }
+
+    const useLatestCapture = () => {
+        const latest = getLatestSnapshotUrl()
+        const previewBase = config.preview_url.trim().replace(/\/$/, '')
+        const fallback = previewBase ? `${previewBase}/snapshot.jpg?t=${Date.now()}` : ''
+        setTrackPhotoUrlState(latest || fallback)
+    }
+
+    const undoSplinePoint = () => {
+        setEditorPoints(prev => prev.slice(0, -1))
+    }
+
     return (
         <div className="fade-in space-y-4">
             <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Settings · Race Setup Wizard</h2>
@@ -187,7 +299,7 @@ export default function SettingsPanel() {
                     <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" value={config.race_name} onChange={e => setConfig(prev => ({ ...prev, race_name: e.target.value }))} placeholder="Race name" />
                     <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm" type="number" min={1} value={config.total_laps} onChange={e => setConfig(prev => ({ ...prev, total_laps: Number(e.target.value) }))} placeholder="Total laps" />
                     <input className="rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm md:col-span-2" value={config.racer_names} onChange={e => setConfig(prev => ({ ...prev, racer_names: e.target.value }))} placeholder="Racer names (comma separated)" />
-                    <div className="md:col-span-2 flex gap-2">
+                    <div className="md:col-span-2 flex gap-2 flex-wrap">
                         <button className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500" type="submit">Save Config</button>
                         <button className="rounded bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500" type="button" onClick={initializeRace}>Initialize Race State</button>
                         <button className="rounded bg-slate-700 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-600" type="button" onClick={loadWizard}>Refresh</button>
@@ -207,7 +319,7 @@ export default function SettingsPanel() {
                 {currentStep ? (
                     <div className="space-y-1 text-xs text-[var(--color-text-secondary)]">
                         <p>Current blocking step: <strong>{currentStep.title}</strong> · Next command: <code>{currentStep.next_command}</code></p>
-                        <p>Recommended order: 1) save config, 2) verify Pi + backend, 3) initialize race state, 4) bring up preview/websocket before live tracking, 5) use Race Start / Pause / Resume / Finish controls.</p>
+                        <p>Recommended order: 1) save config, 2) verify Pi + backend, 3) initialize race state, 4) bring up preview/websocket before live tracking, 5) capture track photo, 6) draw spline, 7) use Race Start / Pause / Resume / Finish controls.</p>
                     </div>
                 ) : <p className="text-xs text-emerald-400">All setup steps are currently marked connected.</p>}
 
@@ -247,6 +359,87 @@ export default function SettingsPanel() {
                             {step.last_error ? <p className="mt-2 text-xs text-rose-300">Last error: {step.last_error}</p> : null}
                         </div>
                     ))}
+                </div>
+            </div>
+
+            <div className="race-card p-4 space-y-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                        <h3 className="text-base font-semibold">Track spline mapper</h3>
+                        <p className="text-xs text-[var(--color-text-secondary)]">
+                            Capture a track photo in the Computer Vision tab, then draw a centerline spline over that image. The Dashboard tab will reuse the same photo + spline so racer dots follow the mapped track.
+                        </p>
+                    </div>
+                    <button className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600" type="button" onClick={loadTracks}>Reload tracks</button>
+                </div>
+
+                <div className="grid gap-3 lg:grid-cols-[320px_1fr]">
+                    <div className="space-y-3">
+                        <label className="block text-sm text-[var(--color-text-secondary)]">
+                            Track
+                            <select
+                                className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+                                value={selectedTrackId}
+                                onChange={event => applyTrackSelection(tracks.find(track => track.id === event.target.value) || null)}
+                            >
+                                <option value="">Create/select a track</option>
+                                {tracks.map(track => (
+                                    <option key={track.id} value={track.id}>{track.name}</option>
+                                ))}
+                            </select>
+                        </label>
+
+                        <label className="block text-sm text-[var(--color-text-secondary)]">
+                            Track name
+                            <input
+                                className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+                                value={trackName}
+                                onChange={event => setTrackName(event.target.value)}
+                                placeholder="Main Track"
+                            />
+                        </label>
+
+                        <label className="block text-sm text-[var(--color-text-secondary)]">
+                            Track photo URL
+                            <input
+                                className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+                                value={trackPhotoUrl}
+                                onChange={event => setTrackPhotoUrlState(event.target.value)}
+                                placeholder="http://pi-ip:8091/snapshot.jpg"
+                            />
+                        </label>
+
+                        <div className="flex flex-wrap gap-2">
+                            <button className="rounded bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-500" type="button" onClick={useLatestCapture}>Use Latest Capture</button>
+                            <button className="rounded bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-500" type="button" onClick={saveTrackSpline}>Save Spline</button>
+                            <button className="rounded bg-emerald-600 px-3 py-2 text-xs font-semibold text-white hover:bg-emerald-500" type="button" onClick={createTrack}>New Track</button>
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
+                            <button className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600" type="button" onClick={undoSplinePoint} disabled={editorPoints.length === 0}>Undo Point</button>
+                            <button className="rounded bg-rose-700 px-3 py-2 text-xs font-semibold text-white hover:bg-rose-600" type="button" onClick={() => setEditorPoints([])} disabled={editorPoints.length === 0}>Clear Spline</button>
+                        </div>
+
+                        <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-300 space-y-1">
+                            <p><strong>How to use:</strong></p>
+                            <p>1. Capture the track photo in the Computer Vision tab.</p>
+                            <p>2. Click <strong>Use Latest Capture</strong>.</p>
+                            <p>3. Click around the lane centerline to place spline handles.</p>
+                            <p>4. Drag handles until the white path matches the real track.</p>
+                            <p>5. Save, then verify the Dashboard dots follow the spline with minimal lag.</p>
+                        </div>
+                    </div>
+
+                    <div className="rounded border border-slate-700 bg-slate-950/40 p-3">
+                        <TrackCanvas
+                            racers={[]}
+                            layoutPoints={editorPoints}
+                            checkpoints={[]}
+                            isEditMode
+                            onTrackUpdate={setEditorPoints}
+                            backgroundImageUrl={trackPhotoUrl || undefined}
+                        />
+                    </div>
                 </div>
             </div>
         </div>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react'
+import { useRef, useEffect, useCallback, useMemo, useState, type PointerEvent as ReactPointerEvent } from 'react'
 import type { LiveRacer, TrackPoint, Checkpoint } from '@/types'
 import { stringToColor } from '@/lib/utils'
 
@@ -8,6 +8,50 @@ interface TrackCanvasProps {
     checkpoints: Checkpoint[]
     isEditMode?: boolean
     onTrackUpdate?: (points: TrackPoint[]) => void
+    backgroundImageUrl?: string
+}
+
+function sampleSpline(points: TrackPoint[], segments = 18): TrackPoint[] {
+    if (points.length < 2) return points
+    const closed = points.length > 2
+    const result: TrackPoint[] = []
+    const total = closed ? points.length : points.length - 1
+
+    for (let i = 0; i < total; i++) {
+        const p0 = points[(i - 1 + points.length) % points.length] ?? points[0]!
+        const p1 = points[i]!
+        const p2 = points[(i + 1) % points.length] ?? points[points.length - 1]!
+        const p3 = points[(i + 2) % points.length] ?? points[points.length - 1]!
+
+        for (let step = 0; step < segments; step++) {
+            const t = step / segments
+            const t2 = t * t
+            const t3 = t2 * t
+            const x = 0.5 * (
+                (2 * p1.x)
+                + (-p0.x + p2.x) * t
+                + (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2
+                + (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3
+            )
+            const y = 0.5 * (
+                (2 * p1.y)
+                + (-p0.y + p2.y) * t
+                + (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2
+                + (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3
+            )
+            result.push({ x, y })
+        }
+    }
+
+    result.push(points[closed ? 0 : points.length - 1]!)
+    return result
+}
+
+function clampNormalized(point: TrackPoint): TrackPoint {
+    return {
+        x: Math.min(1, Math.max(0, point.x)),
+        y: Math.min(1, Math.max(0, point.y)),
+    }
 }
 
 export default function TrackCanvas({
@@ -15,9 +59,73 @@ export default function TrackCanvas({
     layoutPoints,
     checkpoints,
     isEditMode = false,
+    onTrackUpdate,
+    backgroundImageUrl,
 }: TrackCanvasProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null)
     const containerRef = useRef<HTMLDivElement>(null)
+    const backgroundImageRef = useRef<HTMLImageElement | null>(null)
+    const [dragIndex, setDragIndex] = useState<number | null>(null)
+
+    useEffect(() => {
+        if (!backgroundImageUrl) {
+            backgroundImageRef.current = null
+            return
+        }
+        const image = new Image()
+        image.crossOrigin = 'anonymous'
+        image.src = backgroundImageUrl
+        image.onload = () => {
+            backgroundImageRef.current = image
+        }
+        image.onerror = () => {
+            backgroundImageRef.current = null
+        }
+    }, [backgroundImageUrl])
+
+    const splinePoints = useMemo(() => sampleSpline(layoutPoints), [layoutPoints])
+
+    const pointToCanvas = useCallback((point: TrackPoint, width: number, height: number) => {
+        if (point.x >= 0 && point.x <= 1 && point.y >= 0 && point.y <= 1) {
+            return { x: point.x * width, y: point.y * height }
+        }
+        const image = backgroundImageRef.current
+        if (image && image.naturalWidth > 0 && image.naturalHeight > 0) {
+            return {
+                x: (point.x / image.naturalWidth) * width,
+                y: (point.y / image.naturalHeight) * height,
+            }
+        }
+        return point
+    }, [])
+
+    const canvasToPoint = useCallback((clientX: number, clientY: number) => {
+        const canvas = canvasRef.current
+        if (!canvas) return null
+        const rect = canvas.getBoundingClientRect()
+        if (!rect.width || !rect.height) return null
+        return clampNormalized({
+            x: (clientX - rect.left) / rect.width,
+            y: (clientY - rect.top) / rect.height,
+        })
+    }, [])
+
+    const findNearestIndex = useCallback((clientX: number, clientY: number) => {
+        const canvas = canvasRef.current
+        if (!canvas) return -1
+        const rect = canvas.getBoundingClientRect()
+        let bestIndex = -1
+        let bestDistance = Number.POSITIVE_INFINITY
+        layoutPoints.forEach((point, index) => {
+            const screen = pointToCanvas(point, rect.width, rect.height)
+            const distance = Math.hypot(screen.x - (clientX - rect.left), screen.y - (clientY - rect.top))
+            if (distance < bestDistance) {
+                bestDistance = distance
+                bestIndex = index
+            }
+        })
+        return bestDistance <= 18 ? bestIndex : -1
+    }, [layoutPoints, pointToCanvas])
 
     const draw = useCallback(() => {
         const canvas = canvasRef.current
@@ -31,123 +139,104 @@ export default function TrackCanvas({
         canvas.width = rect.width
         canvas.height = rect.height
 
-        const cx = rect.width / 2
-        const cy = rect.height / 2
-        const rx = (rect.width - 80) / 2
-        const ry = (rect.height - 40) / 2
-
-        // Clear
         ctx.clearRect(0, 0, canvas.width, canvas.height)
 
-        // Draw track surface (filled ellipse)
-        ctx.beginPath()
-        ctx.ellipse(cx, cy, rx + 18, ry + 18, 0, 0, Math.PI * 2)
-        ctx.fillStyle = 'rgba(255,255,255,0.02)'
-        ctx.fill()
+        if (backgroundImageRef.current) {
+            ctx.drawImage(backgroundImageRef.current, 0, 0, canvas.width, canvas.height)
+            ctx.fillStyle = 'rgba(5, 10, 22, 0.28)'
+            ctx.fillRect(0, 0, canvas.width, canvas.height)
+        } else {
+            ctx.fillStyle = 'rgba(255,255,255,0.02)'
+            ctx.fillRect(0, 0, canvas.width, canvas.height)
+        }
 
-        // Outer edge
-        ctx.beginPath()
-        ctx.ellipse(cx, cy, rx + 18, ry + 18, 0, 0, Math.PI * 2)
-        ctx.strokeStyle = 'rgba(255,255,255,0.15)'
-        ctx.lineWidth = 1.5
-        ctx.stroke()
-
-        // Inner edge
-        ctx.beginPath()
-        ctx.ellipse(cx, cy, rx - 18, ry - 18, 0, 0, Math.PI * 2)
-        ctx.strokeStyle = 'rgba(255,255,255,0.15)'
-        ctx.lineWidth = 1.5
-        ctx.stroke()
-
-        // Center line (track path)
-        ctx.beginPath()
-        ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2)
-        ctx.strokeStyle = 'rgba(255,255,255,0.06)'
-        ctx.lineWidth = 1
-        ctx.setLineDash([8, 6])
-        ctx.stroke()
-        ctx.setLineDash([])
-
-        // Start/finish line
-        const sfAngle = -Math.PI / 2 // top
-        const sfInnerX = cx + (rx - 18) * Math.cos(sfAngle)
-        const sfInnerY = cy + (ry - 18) * Math.sin(sfAngle)
-        const sfOuterX = cx + (rx + 18) * Math.cos(sfAngle)
-        const sfOuterY = cy + (ry + 18) * Math.sin(sfAngle)
-        ctx.beginPath()
-        ctx.moveTo(sfInnerX, sfInnerY)
-        ctx.lineTo(sfOuterX, sfOuterY)
-        ctx.strokeStyle = '#2ecc71'
-        ctx.lineWidth = 3
-        ctx.stroke()
-
-        // Draw checkpoints
-        checkpoints.forEach((cp) => {
-            if (cp.type === 'start' || cp.type === 'finish') return
-            const angle = Math.atan2(cp.position.y - cy, cp.position.x - cx)
-            const innerX = cx + (rx - 18) * Math.cos(angle)
-            const innerY = cy + (ry - 18) * Math.sin(angle)
-            const outerX = cx + (rx + 18) * Math.cos(angle)
-            const outerY = cy + (ry + 18) * Math.sin(angle)
+        if (splinePoints.length > 1) {
             ctx.beginPath()
-            ctx.moveTo(innerX, innerY)
-            ctx.lineTo(outerX, outerY)
-            ctx.strokeStyle = 'rgba(244, 208, 63, 0.5)'
-            ctx.lineWidth = 2
+            splinePoints.forEach((point, index) => {
+                const screen = pointToCanvas(point, canvas.width, canvas.height)
+                if (index === 0) ctx.moveTo(screen.x, screen.y)
+                else ctx.lineTo(screen.x, screen.y)
+            })
+            ctx.closePath()
+            ctx.strokeStyle = 'rgba(255,255,255,0.95)'
+            ctx.lineWidth = 3
+            ctx.shadowColor = 'rgba(74, 127, 247, 0.35)'
+            ctx.shadowBlur = 10
+            ctx.stroke()
+            ctx.shadowBlur = 0
+        }
+
+        layoutPoints.forEach((point, index) => {
+            const screen = pointToCanvas(point, canvas.width, canvas.height)
+            ctx.beginPath()
+            ctx.arc(screen.x, screen.y, 5, 0, Math.PI * 2)
+            ctx.fillStyle = index === dragIndex ? '#f4d03f' : '#4a7ff7'
+            ctx.fill()
+            ctx.strokeStyle = '#ffffff'
+            ctx.lineWidth = 1.2
             ctx.stroke()
         })
 
-        // Draw racers
-        racers.forEach((racer) => {
-            // Use track position if available, otherwise calculate from progress
-            let x: number, y: number
-            if (racer.track_position) {
-                x = racer.track_position.x
-                y = racer.track_position.y
-            } else {
-                // Estimate position based on lap progress
-                const totalProgress = (racer.current_lap + (racer.current_lap_time / (racer.best_lap_time || 60000))) / (racers.length > 0 ? Math.max(...racers.map(r => r.current_lap), 1) + 1 : 1)
-                const angle = -Math.PI / 2 + totalProgress * Math.PI * 2
-                x = cx + rx * Math.cos(angle)
-                y = cy + ry * Math.sin(angle)
-            }
+        checkpoints.forEach((checkpoint) => {
+            const point = pointToCanvas(checkpoint.position, canvas.width, canvas.height)
+            ctx.beginPath()
+            ctx.arc(point.x, point.y, 4.5, 0, Math.PI * 2)
+            ctx.fillStyle = checkpoint.type === 'finish' ? '#2ecc71' : '#f4d03f'
+            ctx.fill()
+            ctx.fillStyle = '#ffffff'
+            ctx.font = '11px Inter'
+            ctx.fillText(checkpoint.name, point.x + 8, point.y - 8)
+        })
 
+        const progressPoints = splinePoints.length > 1 ? splinePoints : layoutPoints
+        racers.forEach((racer, index) => {
+            let position: TrackPoint | null = null
+            const direct = racer.track_position
+            if (direct) {
+                position = direct
+            } else if (progressPoints.length > 0) {
+                const baselineLap = Math.max(...racers.map((item) => item.current_lap), 1)
+                const lapFraction = racer.best_lap_time && racer.best_lap_time > 0
+                    ? Math.min(racer.current_lap_time / racer.best_lap_time, 1)
+                    : 0
+                const predictiveLead = racer.status === 'racing' ? Math.min(0.05, lapFraction * 0.08) : 0
+                const progress = ((racer.current_lap + lapFraction + predictiveLead) % (baselineLap + 1)) / Math.max(baselineLap + 1, 1)
+                const sampleIndex = Math.min(progressPoints.length - 1, Math.max(0, Math.round(progress * (progressPoints.length - 1))))
+                position = progressPoints[sampleIndex]!
+            }
+            if (!position) return
+            const screen = pointToCanvas(position, canvas.width, canvas.height)
             const color = racer.color || stringToColor(racer.name)
 
-            // Glow
             ctx.beginPath()
-            ctx.arc(x, y, 10, 0, Math.PI * 2)
-            ctx.fillStyle = color + '30'
+            ctx.arc(screen.x, screen.y, 11, 0, Math.PI * 2)
+            ctx.fillStyle = `${color}30`
             ctx.fill()
 
-            // Dot
             ctx.beginPath()
-            ctx.arc(x, y, 6, 0, Math.PI * 2)
+            ctx.arc(screen.x, screen.y, 6.5, 0, Math.PI * 2)
             ctx.fillStyle = color
             ctx.fill()
             ctx.strokeStyle = '#fff'
-            ctx.lineWidth = 1.5
+            ctx.lineWidth = 1.4
             ctx.stroke()
 
-            // Number label
             ctx.fillStyle = '#fff'
             ctx.font = '10px Inter'
             ctx.textAlign = 'center'
-            ctx.fillText(`#${racer.number}`, x, y - 12)
+            ctx.fillText(`#${racer.number || index + 1}`, screen.x, screen.y - 12)
         })
 
-        // Edit mode indicator
         if (isEditMode) {
-            ctx.fillStyle = 'rgba(74, 127, 247, 0.08)'
-            ctx.fillRect(0, 0, canvas.width, canvas.height)
-            ctx.fillStyle = 'var(--color-accent-blue)'
+            ctx.fillStyle = 'rgba(5, 10, 22, 0.55)'
+            ctx.fillRect(0, canvas.height - 28, canvas.width, 28)
+            ctx.fillStyle = '#cbd5f5'
             ctx.font = '12px Inter'
             ctx.textAlign = 'center'
-            ctx.fillText('Click to place checkpoints', cx, canvas.height - 12)
+            ctx.fillText('Click to add spline points. Drag blue handles to reshape the path.', canvas.width / 2, canvas.height - 10)
         }
-    }, [racers, layoutPoints, checkpoints, isEditMode])
+    }, [checkpoints, dragIndex, isEditMode, layoutPoints, pointToCanvas, racers, splinePoints])
 
-    // Animation loop
     useEffect(() => {
         let animId: number
         const animate = () => {
@@ -158,11 +247,40 @@ export default function TrackCanvas({
         return () => cancelAnimationFrame(animId)
     }, [draw])
 
+    const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLCanvasElement>) => {
+        if (!isEditMode || !onTrackUpdate) return
+        const nearestIndex = findNearestIndex(event.clientX, event.clientY)
+        if (nearestIndex >= 0) {
+            setDragIndex(nearestIndex)
+            return
+        }
+        const point = canvasToPoint(event.clientX, event.clientY)
+        if (!point) return
+        onTrackUpdate([...layoutPoints, point])
+        setDragIndex(layoutPoints.length)
+    }, [canvasToPoint, findNearestIndex, isEditMode, layoutPoints, onTrackUpdate])
+
+    const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLCanvasElement>) => {
+        if (!isEditMode || dragIndex == null || !onTrackUpdate) return
+        const point = canvasToPoint(event.clientX, event.clientY)
+        if (!point) return
+        const next = layoutPoints.map((existing, index) => index === dragIndex ? point : existing)
+        onTrackUpdate(next)
+    }, [canvasToPoint, dragIndex, isEditMode, layoutPoints, onTrackUpdate])
+
+    const handlePointerUp = useCallback(() => {
+        setDragIndex(null)
+    }, [])
+
     return (
         <div ref={containerRef} className="w-full h-full relative" style={{ minHeight: 160 }}>
             <canvas
                 ref={canvasRef}
-                className="absolute inset-0 w-full h-full"
+                className="absolute inset-0 w-full h-full cursor-crosshair"
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp}
+                onPointerLeave={handlePointerUp}
             />
         </div>
     )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch } from '@/lib/utils'
+import { apiFetch, getSelectedTrackId, setLatestSnapshotUrl, setTrackPhotoUrl } from '@/lib/utils'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -50,6 +50,12 @@ export default function VisionPanel() {
             }
 
             setStatusMessage(payload.message || 'Snapshot captured successfully.')
+            const snapshotUrl = `${normalizedBaseUrl}/snapshot.jpg?t=${Date.now()}`
+            const selectedTrackId = getSelectedTrackId()
+            setLatestSnapshotUrl(snapshotUrl)
+            if (selectedTrackId) {
+                setTrackPhotoUrl(selectedTrackId, snapshotUrl)
+            }
             const raceId = String(raceContext.race_id || '')
             if (raceId) {
                 await apiFetch(`/api/races/${raceId}/logs`, {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
@@ -1,5 +1,11 @@
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import type { Track, TrackPoint } from '@/types'
+
+const TRACK_SELECTION_KEY = 'race-master-pro.selectedTrackId'
+const TRACK_PHOTO_KEY_PREFIX = 'race-master-pro.trackPhoto.'
+const LATEST_SNAPSHOT_KEY = 'race-master-pro.latestSnapshotUrl'
+export const TRACK_OVERLAY_EVENT = 'j5-track-overlay-updated'
 
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs))
@@ -88,7 +94,6 @@ export function backendBaseUrl(): string {
     return `http://${window.location.hostname}:8080`
 }
 
-
 function sameOriginWsBaseUrl(): string {
     return `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`
 }
@@ -125,4 +130,76 @@ export async function apiFetch(path: string, init?: RequestInit): Promise<Respon
         return response
     }
     return fetch(`${backendBaseUrl()}${normalizedPath}`, init)
+}
+
+export function parseTrackPointList(raw: unknown): TrackPoint[] {
+    if (Array.isArray(raw)) {
+        return raw
+            .map((point) => ({
+                x: Number((point as TrackPoint)?.x),
+                y: Number((point as TrackPoint)?.y),
+            }))
+            .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y))
+    }
+    if (typeof raw !== 'string') return []
+    try {
+        return parseTrackPointList(JSON.parse(raw))
+    } catch {
+        return []
+    }
+}
+
+export function parseTrackRecord(raw: Record<string, unknown>): Track {
+    return {
+        id: String(raw.id || ''),
+        name: String(raw.name || 'Track'),
+        scale: String(raw.scale || '1:24'),
+        track_distance: raw.track_distance == null ? null : Number(raw.track_distance),
+        layout_points: parseTrackPointList(raw.layout_points),
+        boundary_polygon: parseTrackPointList(raw.boundary_polygon),
+        created_at: raw.created_at ? String(raw.created_at) : undefined,
+    }
+}
+
+function getStorage(): Storage | null {
+    if (typeof window === 'undefined') return null
+    return window.localStorage
+}
+
+export function setSelectedTrackId(trackId: string): void {
+    const storage = getStorage()
+    if (!storage) return
+    storage.setItem(TRACK_SELECTION_KEY, trackId)
+    window.dispatchEvent(new CustomEvent(TRACK_OVERLAY_EVENT))
+}
+
+export function getSelectedTrackId(): string {
+    const storage = getStorage()
+    return storage?.getItem(TRACK_SELECTION_KEY) || ''
+}
+
+export function setTrackPhotoUrl(trackId: string, url: string): void {
+    const storage = getStorage()
+    if (!storage || !trackId) return
+    storage.setItem(`${TRACK_PHOTO_KEY_PREFIX}${trackId}`, url)
+    storage.setItem(LATEST_SNAPSHOT_KEY, url)
+    window.dispatchEvent(new CustomEvent(TRACK_OVERLAY_EVENT))
+}
+
+export function getTrackPhotoUrl(trackId: string): string {
+    const storage = getStorage()
+    if (!storage || !trackId) return ''
+    return storage.getItem(`${TRACK_PHOTO_KEY_PREFIX}${trackId}`) || ''
+}
+
+export function setLatestSnapshotUrl(url: string): void {
+    const storage = getStorage()
+    if (!storage) return
+    storage.setItem(LATEST_SNAPSHOT_KEY, url)
+    window.dispatchEvent(new CustomEvent(TRACK_OVERLAY_EVENT))
+}
+
+export function getLatestSnapshotUrl(): string {
+    const storage = getStorage()
+    return storage?.getItem(LATEST_SNAPSHOT_KEY) || ''
 }

--- a/ros_ws/src/j5_perception/race-master-pro/scripts/pi_preflight.py
+++ b/ros_ws/src/j5_perception/race-master-pro/scripts/pi_preflight.py
@@ -227,6 +227,7 @@ def run_preview_server(
       <button type='submit'>Capture Track Photo</button>
     </form>
     <p>Snapshot path: <code>{capture_file}</code></p>
+    <p>Latest snapshot URL: <code>/snapshot.jpg</code></p>
   </body>
 </html>
 """
@@ -241,6 +242,19 @@ def run_preview_server(
         def do_GET(self) -> None:  # noqa: N802
             if self.path in ("/", "/index.html"):
                 self._send_html()
+                return
+            if self.path == "/snapshot.jpg":
+                if not capture_file.exists():
+                    self.send_error(HTTPStatus.NOT_FOUND, "Snapshot not found")
+                    return
+                payload = capture_file.read_bytes()
+                self.send_response(HTTPStatus.OK)
+                self._set_cors_headers()
+                self.send_header("Content-Type", "image/jpeg")
+                self.send_header("Content-Length", str(len(payload)))
+                self.send_header("Cache-Control", "no-store")
+                self.end_headers()
+                self.wfile.write(payload)
                 return
             if self.path == "/stream.mjpg":
                 self.send_response(HTTPStatus.OK)


### PR DESCRIPTION
### Motivation
- Provide a persistent CRUD-backed race management API and realtime dashboard for local Pi and cloud deployments. 
- Support local MongoDB on Raspberry Pi and extend SQLite fallback with generic entity/event storage so tracker data and operator workflows persist. 
- Enable camera-based track mapping and a richer operator setup flow so perception can publish validated events to the API for realtime UI updates. 

### Description
- Added new CRUD endpoints under `/api/*` (tracks, cars, racers, races) and `/api/races/{raceId}/events` plus `/api/races/{raceId}/dashboard` and websocket dashboard broadcasts in `apps/racemanager/service/main.py`. 
- Extended repository abstractions in `service/repository.py` so both `SQLiteRaceRepository` and `MongoRaceRepository` support `entities`, `race_events`, and listing/getting/updating/deleting entities and events. 
- Expanded Pydantic schemas in `service/schemas.py` to include `Track`, `Car`, `Racer`, `Race` records and `RaceEventIngest` and dashboard models used by the API. 
- UI overhaul: new realtime dashboard, track preview/editor, track/cars/racers/races CRUD integration, websocket-driven refresh, and updated styles across `apps/racemanager/ui` and `ros_ws/src/j5_perception/race-master-pro/frontend` components including `TrackCanvas`, `SettingsPanel`, `VisionPanel`, `Analytics`, `ChampionshipView`, `RacerManager`, and utilities. 
- Pi preview/server improvements: snapshot endpoint and local snapshot URL handling in `pi_preflight.py`, plus README/docs updates describing Pi Mongo setup, operator checklist, suggested collections, and API resources. 

### Testing
- No automated tests were added or executed as part of this rollout; changes should be validated by running the service locally and exercising the new `/api` endpoints and websocket flows (e.g. via the updated UI or integration tests added later).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc672dce5483239002dacca4dbb4f9)