### PR TITLE
Improve setup health checks and enhance Vision panel preview & track linking

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -114,10 +114,10 @@ _SETUP_STEPS = [
         "title": "WebSocket endpoint",
         "description": "Realtime events require a reachable WS endpoint based on backend_url.",
         "check_commands": [],
-        "connect_command": "Set VITE_WS_URL=ws://<backend-host>:<backend-port>/ws (or NEXT_PUBLIC_WS_URL for Next.js), restart the UI, then verify",
+        "connect_command": "Optional: set VITE_API_BASE_URL=http://<backend-host>:<backend-port> and VITE_WS_URL=ws://<backend-host>:<backend-port>/ws before starting Vite; if omitted the UI auto-falls back to current-host:8080",
         "stop_command": "echo 'No persistent process to stop for websocket endpoint'",
         "stop_commands": ["echo No persistent process to stop for websocket endpoint"],
-        "help": "For the Vite frontend set VITE_WS_URL and VITE_API_BASE_URL; for the Next.js demo use NEXT_PUBLIC_WS_URL and NEXT_PUBLIC_API_BASE. Both must point at the FastAPI service.",
+        "help": "These env vars are frontend startup config, not runtime shell commands. They should point to the FastAPI backend host/port (usually :8080), not the Vite dev server (:5173).",
     },
     {
         "id": "race_state",
@@ -272,25 +272,34 @@ async def _check_tcp_port(host: str, port: int):
 
 
 async def _check_http_health(url: str):
-    health_url = f"{url.rstrip('/')}/health"
-    try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            response = await client.get(health_url)
-        return {
-            "command": f"GET {health_url}",
-            "ok": response.status_code == 200,
-            "stdout": response.text.strip(),
-            "stderr": (
-                "" if response.status_code == 200 else f"HTTP {response.status_code}"
-            ),
-        }
-    except Exception as exc:
-        return {
-            "command": f"GET {health_url}",
-            "ok": False,
-            "stdout": "",
-            "stderr": str(exc),
-        }
+    return await _check_http_endpoints(url, ["/health"])
+
+
+async def _check_http_endpoints(url: str, paths: list[str]):
+    base = url.rstrip("/")
+    errors: list[str] = []
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        for path in paths:
+            endpoint = f"{base}{path}"
+            try:
+                response = await client.get(endpoint)
+                if response.status_code == 200:
+                    return {
+                        "command": f"GET {endpoint}",
+                        "ok": True,
+                        "stdout": response.text.strip(),
+                        "stderr": "",
+                    }
+                errors.append(f"{endpoint} -> HTTP {response.status_code}")
+            except Exception as exc:
+                errors.append(f"{endpoint} -> {exc}")
+    first_endpoint = f"{base}{paths[0]}"
+    return {
+        "command": f"GET {first_endpoint}",
+        "ok": False,
+        "stdout": "",
+        "stderr": "; ".join(errors),
+    }
 
 
 async def _check_ws_port(url: str):
@@ -343,10 +352,18 @@ async def _build_setup_status():
             checks.append(await _check_tcp_port(pi_host, 22))
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "backend_service":
-            checks = [await _check_http_health(config["backend_url"])]
+            checks = [
+                await _check_http_endpoints(
+                    config["backend_url"], ["/health", "/docs", "/openapi.json"]
+                )
+            ]
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "vision_preview":
-            checks = [await _check_http_health(config["preview_url"])]
+            checks = [
+                await _check_http_endpoints(
+                    config["preview_url"], ["/health", "/stream.mjpg", "/snapshot.jpg"]
+                )
+            ]
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "websocket_endpoint":
             ws_result = await _check_ws_port(config["backend_url"])

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch, getSelectedTrackId, setLatestSnapshotUrl, setTrackPhotoUrl } from '@/lib/utils'
+import { apiFetch, getSelectedTrackId, parseTrackRecord, setLatestSnapshotUrl, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -10,13 +10,56 @@ function defaultPreviewBaseUrl(): string {
 
 export default function VisionPanel() {
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
+    const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
     const [statusError, setStatusError] = useState(false)
     const [capturing, setCapturing] = useState(false)
     const [raceContext, setRaceContext] = useState<Record<string, unknown>>({})
+    const [activeTrackName, setActiveTrackName] = useState('')
 
     const normalizedBaseUrl = useMemo(() => previewBaseUrl.trim().replace(/\/$/, ''), [previewBaseUrl])
     const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
+
+    const ensureSelectedTrack = async () => {
+        const existingTrackId = getSelectedTrackId()
+        if (existingTrackId) {
+            return existingTrackId
+        }
+        try {
+            const response = await apiFetch('/api/tracks')
+            if (!response.ok) return ''
+            const payload = await response.json()
+            const tracks = Array.isArray(payload)
+                ? payload.map(item => parseTrackRecord(item as Record<string, unknown>))
+                : []
+            const firstTrack = tracks[0]
+            if (!firstTrack?.id) return ''
+            setSelectedTrackId(firstTrack.id)
+            return firstTrack.id
+        } catch {
+            return ''
+        }
+    }
+
+    const refreshTrackLabel = async () => {
+        const selectedTrackId = await ensureSelectedTrack()
+        if (!selectedTrackId) {
+            setActiveTrackName('')
+            return
+        }
+        try {
+            const response = await apiFetch('/api/tracks')
+            if (!response.ok) return
+            const payload = await response.json()
+            const tracks = Array.isArray(payload)
+                ? payload.map(item => parseTrackRecord(item as Record<string, unknown>))
+                : []
+            const selected = tracks.find(track => track.id === selectedTrackId)
+            setActiveTrackName(selected?.name || '')
+        } catch {
+            // ignore if lookup fails
+        }
+    }
 
     const refreshWizardContext = async () => {
         try {
@@ -30,7 +73,8 @@ export default function VisionPanel() {
     }
 
     useEffect(() => {
-        refreshWizardContext()
+        void refreshWizardContext()
+        void refreshTrackLabel()
     }, [])
 
     const onCapture = async (event: FormEvent) => {
@@ -51,10 +95,15 @@ export default function VisionPanel() {
 
             setStatusMessage(payload.message || 'Snapshot captured successfully.')
             const snapshotUrl = `${normalizedBaseUrl}/snapshot.jpg?t=${Date.now()}`
-            const selectedTrackId = getSelectedTrackId()
+            const selectedTrackId = await ensureSelectedTrack()
             setLatestSnapshotUrl(snapshotUrl)
             if (selectedTrackId) {
                 setTrackPhotoUrl(selectedTrackId, snapshotUrl)
+                setStatusMessage(payload.message || 'Snapshot captured and linked to selected track.')
+                setStatusError(false)
+            } else {
+                setStatusMessage('Snapshot captured, but no track is selected yet. Select/create a track in Settings and use "Use Latest Capture".')
+                setStatusError(true)
             }
             const raceId = String(raceContext.race_id || '')
             if (raceId) {
@@ -111,6 +160,9 @@ export default function VisionPanel() {
                     Capture the track image here after the setup wizard in Settings marks connectivity as connected. Once
                     captured, return here to start object tracking and monitor lap-count logs.
                 </p>
+                <p className="text-xs text-amber-300">
+                    Keep the camera stream open in only one viewer at a time. Viewing <code>/stream.mjpg</code> in multiple places can drop the camera connection.
+                </p>
                 <div className="rounded border border-slate-700 bg-slate-950 p-3">
                     <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Start camera feed only</p>
                     <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
@@ -124,14 +176,36 @@ export default function VisionPanel() {
                         camera uses a different device.
                     </p>
                 </div>
+                <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-1">
+                    <p><strong>Race flow:</strong> 1) Initialize race in Settings, 2) capture track photo here, 3) map spline in Settings, 4) return to Dashboard for overlays, 5) start tracking here, 6) use Race Start/Pause/Resume/Finish in Settings.</p>
+                    <p>
+                        Active track for auto-linking captures: <strong>{activeTrackName || 'None selected'}</strong>
+                    </p>
+                </div>
             </div>
 
             <div className="race-card p-4 space-y-3">
-                <img
-                    src={streamUrl}
-                    alt="Live camera preview"
-                    className="w-full rounded border border-slate-700 bg-black"
-                />
+                <div className="flex flex-wrap items-center gap-2">
+                    <button
+                        type="button"
+                        className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                        onClick={() => setPreviewEnabled(prev => !prev)}
+                    >
+                        {previewEnabled ? 'Hide Live Preview' : 'Show Live Preview'}
+                    </button>
+                    <p className="text-xs text-[var(--color-text-secondary)]">Use this only while capturing the track image, then hide it before opening other camera consumers.</p>
+                </div>
+                {previewEnabled ? (
+                    <img
+                        src={streamUrl}
+                        alt="Live camera preview"
+                        className="w-full rounded border border-slate-700 bg-black"
+                    />
+                ) : (
+                    <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
+                        Live preview is paused to avoid multiple stream consumers.
+                    </div>
+                )}
 
                 <form onSubmit={onCapture} className="flex flex-wrap items-center gap-2">
                     <button


### PR DESCRIPTION
### Motivation
- Make service readiness checks more robust by allowing multiple HTTP endpoints per service and improving error reporting for setup diagnostics.
- Reduce accidental simultaneous consumers of the MJPEG stream and improve UX around capturing and auto-linking track photos in the Vision panel.
- Clarify frontend environment variable guidance for websocket/API configuration during development.

### Description
- Replaced `_check_http_health` with `_check_http_endpoints` in `app/main.py` to iterate multiple paths, return the first successful endpoint, and aggregate errors when none succeed, and updated usages for `backend_service` and `vision_preview` to check several endpoints each. 
- Adjusted the websocket step text in the setup steps to clarify `VITE_API_BASE_URL`/`VITE_WS_URL` usage and fallback behavior. 
- In `VisionPanel.tsx` added `previewEnabled` state and a toggle to show/hide the live MJPEG preview to avoid multiple stream consumers, plus explanatory UI text and a race flow panel showing the active track name. 
- Added `ensureSelectedTrack` / `refreshTrackLabel` logic and use of `parseTrackRecord`/`setSelectedTrackId` so captured snapshots are auto-linked to a selected track where possible and user messages reflect linking success/failure. 
- Improved capture flow to await track selection, set latest snapshot and track photo URL, post a log entry to the race if present, and refresh wizard context after capture.

### Testing
- Ran frontend type checks and build smoke (`tsc --noEmit` and `pnpm build`) which completed successfully. 
- Executed backend sanity tests via `pytest -q` and basic health-check calls against local dev services which passed. 
- Performed manual UI smoke verification of the Vision panel preview toggle and capture flow in a local dev environment which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4871b89388323b2edb9968434c549)