### PR TITLE
Improve setup health checks and enhance vision/settings UI with detailed outputs and safer live preview

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -91,33 +91,33 @@ _SETUP_STEPS = [
         "id": "backend_service",
         "title": "Race Master backend API",
         "description": "Backend must be reachable to drive setup + live controls.",
-        "check_commands": ["curl -sf {backend_url}/health"],
+        "check_commands": ["GET {backend_url}/health or /docs or /openapi.json"],
         "connect_command": "cd backend && source .venv/bin/activate && python -m app.main",
         "stop_command": "pkill -f 'python -m app.main' || true",
         "manual_connect": True,
         "stop_commands": ["pkill -f python -m app.main"],
-        "help": "If this fails, start the backend on the configured host/port and confirm GET /health returns 200.",
+        "help": "If this fails, start the backend on the configured host/port and confirm at least one of /health, /docs, or /openapi.json returns HTTP 200.",
     },
     {
         "id": "vision_preview",
         "title": "Camera preview stream",
         "description": "Preview and track-image capture endpoint from the Pi.",
-        "check_commands": ["curl -sf {preview_url}/health"],
+        "check_commands": ["GET {preview_url}/health or /stream.mjpg or /snapshot.jpg"],
         "connect_command": "python scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091",
         "stop_command": "pkill -f pi_preflight.py || true",
         "manual_connect": True,
         "stop_commands": ["pkill -f pi_preflight.py"],
-        "help": "Start the preview service to restore the Computer Vision feed without re-initializing the race, then verify {preview_url}/health is reachable.",
+        "help": "Start the preview service to restore the Computer Vision feed, then verify at least one of {preview_url}/health, /stream.mjpg, or /snapshot.jpg is reachable.",
     },
     {
         "id": "websocket_endpoint",
         "title": "WebSocket endpoint",
         "description": "Realtime events require a reachable WS endpoint based on backend_url.",
         "check_commands": [],
-        "connect_command": "Set VITE_WS_URL=ws://<backend-host>:<backend-port>/ws (or NEXT_PUBLIC_WS_URL for Next.js), restart the UI, then verify",
+        "connect_command": "Optional: set VITE_API_BASE_URL=http://<backend-host>:<backend-port> and VITE_WS_URL=ws://<backend-host>:<backend-port>/ws before starting Vite; if omitted the UI auto-falls back to current-host:8080",
         "stop_command": "echo 'No persistent process to stop for websocket endpoint'",
         "stop_commands": ["echo No persistent process to stop for websocket endpoint"],
-        "help": "For the Vite frontend set VITE_WS_URL and VITE_API_BASE_URL; for the Next.js demo use NEXT_PUBLIC_WS_URL and NEXT_PUBLIC_API_BASE. Both must point at the FastAPI service.",
+        "help": "These env vars are frontend startup config, not runtime shell commands. They should point to the FastAPI backend host/port (usually :8080), not the Vite dev server (:5173).",
     },
     {
         "id": "race_state",
@@ -272,25 +272,34 @@ async def _check_tcp_port(host: str, port: int):
 
 
 async def _check_http_health(url: str):
-    health_url = f"{url.rstrip('/')}/health"
-    try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            response = await client.get(health_url)
-        return {
-            "command": f"GET {health_url}",
-            "ok": response.status_code == 200,
-            "stdout": response.text.strip(),
-            "stderr": (
-                "" if response.status_code == 200 else f"HTTP {response.status_code}"
-            ),
-        }
-    except Exception as exc:
-        return {
-            "command": f"GET {health_url}",
-            "ok": False,
-            "stdout": "",
-            "stderr": str(exc),
-        }
+    return await _check_http_endpoints(url, ["/health"])
+
+
+async def _check_http_endpoints(url: str, paths: list[str]):
+    base = url.rstrip("/")
+    errors: list[str] = []
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        for path in paths:
+            endpoint = f"{base}{path}"
+            try:
+                response = await client.get(endpoint)
+                if response.status_code == 200:
+                    return {
+                        "command": f"GET {endpoint}",
+                        "ok": True,
+                        "stdout": response.text.strip(),
+                        "stderr": "",
+                    }
+                errors.append(f"{endpoint} -> HTTP {response.status_code}")
+            except Exception as exc:
+                errors.append(f"{endpoint} -> {exc}")
+    first_endpoint = f"{base}{paths[0]}"
+    return {
+        "command": f"GET {first_endpoint}",
+        "ok": False,
+        "stdout": "",
+        "stderr": "; ".join(errors),
+    }
 
 
 async def _check_ws_port(url: str):
@@ -343,10 +352,18 @@ async def _build_setup_status():
             checks.append(await _check_tcp_port(pi_host, 22))
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "backend_service":
-            checks = [await _check_http_health(config["backend_url"])]
+            checks = [
+                await _check_http_endpoints(
+                    config["backend_url"], ["/health", "/docs", "/openapi.json"]
+                )
+            ]
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "vision_preview":
-            checks = [await _check_http_health(config["preview_url"])]
+            checks = [
+                await _check_http_endpoints(
+                    config["preview_url"], ["/health", "/stream.mjpg", "/snapshot.jpg"]
+                )
+            ]
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "websocket_endpoint":
             ws_result = await _check_ws_port(config["backend_url"])

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -349,7 +349,13 @@ export default function SettingsPanel() {
                                 <ul className="mt-3 space-y-1 text-xs">
                                     {step.checks.map(check => (
                                         <li key={check.command} className={check.ok ? 'text-emerald-300' : 'text-rose-300'}>
-                                            {check.ok ? '✓' : '✗'} {check.command}
+                                            <p>{check.ok ? '✓' : '✗'} {check.command}</p>
+                                            {!check.ok && check.stderr ? (
+                                                <p className="ml-4 text-[11px] text-rose-200 break-words">{check.stderr}</p>
+                                            ) : null}
+                                            {check.ok && check.stdout ? (
+                                                <p className="ml-4 text-[11px] text-emerald-100 break-words">{check.stdout}</p>
+                                            ) : null}
                                         </li>
                                     ))}
                                 </ul>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch, getSelectedTrackId, setLatestSnapshotUrl, setTrackPhotoUrl } from '@/lib/utils'
+import { apiFetch, getSelectedTrackId, parseTrackRecord, setLatestSnapshotUrl, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -10,13 +10,56 @@ function defaultPreviewBaseUrl(): string {
 
 export default function VisionPanel() {
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
+    const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
     const [statusError, setStatusError] = useState(false)
     const [capturing, setCapturing] = useState(false)
     const [raceContext, setRaceContext] = useState<Record<string, unknown>>({})
+    const [activeTrackName, setActiveTrackName] = useState('')
 
     const normalizedBaseUrl = useMemo(() => previewBaseUrl.trim().replace(/\/$/, ''), [previewBaseUrl])
     const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
+
+    const ensureSelectedTrack = async () => {
+        const existingTrackId = getSelectedTrackId()
+        if (existingTrackId) {
+            return existingTrackId
+        }
+        try {
+            const response = await apiFetch('/api/tracks')
+            if (!response.ok) return ''
+            const payload = await response.json()
+            const tracks = Array.isArray(payload)
+                ? payload.map(item => parseTrackRecord(item as Record<string, unknown>))
+                : []
+            const firstTrack = tracks[0]
+            if (!firstTrack?.id) return ''
+            setSelectedTrackId(firstTrack.id)
+            return firstTrack.id
+        } catch {
+            return ''
+        }
+    }
+
+    const refreshTrackLabel = async () => {
+        const selectedTrackId = await ensureSelectedTrack()
+        if (!selectedTrackId) {
+            setActiveTrackName('')
+            return
+        }
+        try {
+            const response = await apiFetch('/api/tracks')
+            if (!response.ok) return
+            const payload = await response.json()
+            const tracks = Array.isArray(payload)
+                ? payload.map(item => parseTrackRecord(item as Record<string, unknown>))
+                : []
+            const selected = tracks.find(track => track.id === selectedTrackId)
+            setActiveTrackName(selected?.name || '')
+        } catch {
+            // ignore if lookup fails
+        }
+    }
 
     const refreshWizardContext = async () => {
         try {
@@ -30,7 +73,8 @@ export default function VisionPanel() {
     }
 
     useEffect(() => {
-        refreshWizardContext()
+        void refreshWizardContext()
+        void refreshTrackLabel()
     }, [])
 
     const onCapture = async (event: FormEvent) => {
@@ -51,10 +95,15 @@ export default function VisionPanel() {
 
             setStatusMessage(payload.message || 'Snapshot captured successfully.')
             const snapshotUrl = `${normalizedBaseUrl}/snapshot.jpg?t=${Date.now()}`
-            const selectedTrackId = getSelectedTrackId()
+            const selectedTrackId = await ensureSelectedTrack()
             setLatestSnapshotUrl(snapshotUrl)
             if (selectedTrackId) {
                 setTrackPhotoUrl(selectedTrackId, snapshotUrl)
+                setStatusMessage(payload.message || 'Snapshot captured and linked to selected track.')
+                setStatusError(false)
+            } else {
+                setStatusMessage('Snapshot captured, but no track is selected yet. Select/create a track in Settings and use "Use Latest Capture".')
+                setStatusError(true)
             }
             const raceId = String(raceContext.race_id || '')
             if (raceId) {
@@ -111,6 +160,9 @@ export default function VisionPanel() {
                     Capture the track image here after the setup wizard in Settings marks connectivity as connected. Once
                     captured, return here to start object tracking and monitor lap-count logs.
                 </p>
+                <p className="text-xs text-amber-300">
+                    Keep the camera stream open in only one viewer at a time. Viewing <code>/stream.mjpg</code> in multiple places can drop the camera connection.
+                </p>
                 <div className="rounded border border-slate-700 bg-slate-950 p-3">
                     <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Start camera feed only</p>
                     <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
@@ -124,14 +176,36 @@ export default function VisionPanel() {
                         camera uses a different device.
                     </p>
                 </div>
+                <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-1">
+                    <p><strong>Race flow:</strong> 1) Initialize race in Settings, 2) capture track photo here, 3) map spline in Settings, 4) return to Dashboard for overlays, 5) start tracking here, 6) use Race Start/Pause/Resume/Finish in Settings.</p>
+                    <p>
+                        Active track for auto-linking captures: <strong>{activeTrackName || 'None selected'}</strong>
+                    </p>
+                </div>
             </div>
 
             <div className="race-card p-4 space-y-3">
-                <img
-                    src={streamUrl}
-                    alt="Live camera preview"
-                    className="w-full rounded border border-slate-700 bg-black"
-                />
+                <div className="flex flex-wrap items-center gap-2">
+                    <button
+                        type="button"
+                        className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                        onClick={() => setPreviewEnabled(prev => !prev)}
+                    >
+                        {previewEnabled ? 'Hide Live Preview' : 'Show Live Preview'}
+                    </button>
+                    <p className="text-xs text-[var(--color-text-secondary)]">Use this only while capturing the track image, then hide it before opening other camera consumers.</p>
+                </div>
+                {previewEnabled ? (
+                    <img
+                        src={streamUrl}
+                        alt="Live camera preview"
+                        className="w-full rounded border border-slate-700 bg-black"
+                    />
+                ) : (
+                    <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
+                        Live preview is paused to avoid multiple stream consumers.
+                    </div>
+                )}
 
                 <form onSubmit={onCapture} className="flex flex-wrap items-center gap-2">
                     <button


### PR DESCRIPTION
### Motivation
- Make service/preview connectivity checks more robust by allowing multiple health endpoints to be probed and returning richer error information.
- Surface check diagnostics in the Settings UI so users can see stdout/stderr for failing checks.
- Avoid accidental multi-consumer camera connections by hiding the live MJPEG preview by default and provide explicit controls and messaging in the Vision panel.

### Description
- Refactored backend health checks in `backend/app/main.py` by extracting `_check_http_endpoints(url, paths)` and using it for backend and preview checks to try multiple endpoints (`/health`, `/docs`, `/openapi.json`, `/stream.mjpg`, `/snapshot.jpg`).
- Updated `_check_http_health` to delegate to the new `_check_http_endpoints` implementation and adjusted setup step `check_commands` and `help` strings to reflect multiple acceptable endpoints.
- Kept existing TCP/WS checks but exposed clearer `command` and combined stderr messages when multiple endpoints fail.
- Updated Settings frontend `SettingsPanel.tsx` to render per-check `stdout`/`stderr` details under each check command and changed the check line layout for better readability.
- Updated Vision frontend `VisionPanel.tsx` to add a preview show/hide toggle (`previewEnabled`), active-track lookup and auto-link behavior for captured snapshots (`ensureSelectedTrack` + `refreshTrackLabel`), clearer status messages when no track is selected, and UI guidance to avoid opening multiple stream consumers.
- Adjusted imports in `VisionPanel.tsx` to include utilities used for parsing/setting track state.

### Testing
- Ran frontend TypeScript build (`npm run build`) to validate the TypeScript changes and UI compilation, and the build completed successfully.
- Performed a local frontend dev smoke check (started Vite and exercised the Vision and Settings panels) to verify toggling preview, capture flow, and check rendering; no runtime errors observed.
- No backend unit tests were added; exercised the updated setup check logic locally by invoking the setup status endpoints and confirmed multi-endpoint probing returns expected success/failure results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4871b89388323b2edb9968434c549)