### PR TITLE
Improve connectivity checks, preview readiness, and UI preview/track handling

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -91,33 +91,33 @@ _SETUP_STEPS = [
         "id": "backend_service",
         "title": "Race Master backend API",
         "description": "Backend must be reachable to drive setup + live controls.",
-        "check_commands": ["curl -sf {backend_url}/health"],
+        "check_commands": ["GET {backend_url}/health or /docs or /openapi.json"],
         "connect_command": "cd backend && source .venv/bin/activate && python -m app.main",
         "stop_command": "pkill -f 'python -m app.main' || true",
         "manual_connect": True,
         "stop_commands": ["pkill -f python -m app.main"],
-        "help": "If this fails, start the backend on the configured host/port and confirm GET /health returns 200.",
+        "help": "If this fails, start the backend on the configured host/port and confirm at least one of /health, /docs, or /openapi.json returns HTTP 200.",
     },
     {
         "id": "vision_preview",
         "title": "Camera preview stream",
         "description": "Preview and track-image capture endpoint from the Pi.",
-        "check_commands": ["curl -sf {preview_url}/health"],
+        "check_commands": ["GET {preview_url}/ready or /snapshot.jpg or /health"],
         "connect_command": "python scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091",
         "stop_command": "pkill -f pi_preflight.py || true",
         "manual_connect": True,
         "stop_commands": ["pkill -f pi_preflight.py"],
-        "help": "Start the preview service to restore the Computer Vision feed without re-initializing the race, then verify {preview_url}/health is reachable.",
+        "help": "Start the preview service to restore the Computer Vision feed, then verify {preview_url}/ready or a captured {preview_url}/snapshot.jpg is reachable.",
     },
     {
         "id": "websocket_endpoint",
         "title": "WebSocket endpoint",
         "description": "Realtime events require a reachable WS endpoint based on backend_url.",
         "check_commands": [],
-        "connect_command": "Set VITE_WS_URL=ws://<backend-host>:<backend-port>/ws (or NEXT_PUBLIC_WS_URL for Next.js), restart the UI, then verify",
+        "connect_command": "Optional: set VITE_API_BASE_URL=http://<backend-host>:<backend-port> and VITE_WS_URL=ws://<backend-host>:<backend-port>/ws before starting Vite; if omitted the UI auto-falls back to current-host:8080",
         "stop_command": "echo 'No persistent process to stop for websocket endpoint'",
         "stop_commands": ["echo No persistent process to stop for websocket endpoint"],
-        "help": "For the Vite frontend set VITE_WS_URL and VITE_API_BASE_URL; for the Next.js demo use NEXT_PUBLIC_WS_URL and NEXT_PUBLIC_API_BASE. Both must point at the FastAPI service.",
+        "help": "These env vars are frontend startup config, not runtime shell commands. They should point to the FastAPI backend host/port (usually :8080), not the Vite dev server (:5173).",
     },
     {
         "id": "race_state",
@@ -189,6 +189,7 @@ def _validate_setup_config(config: dict) -> dict:
         parsed = urlparse(str(merged.get(field, "")).strip())
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             raise HTTPException(400, f"Invalid URL for {field}")
+        merged[field] = f"{parsed.scheme}://{parsed.netloc}"
 
     merged["pi_host"] = pi_host
     merged["pi_user"] = pi_user
@@ -272,25 +273,37 @@ async def _check_tcp_port(host: str, port: int):
 
 
 async def _check_http_health(url: str):
-    health_url = f"{url.rstrip('/')}/health"
-    try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            response = await client.get(health_url)
-        return {
-            "command": f"GET {health_url}",
-            "ok": response.status_code == 200,
-            "stdout": response.text.strip(),
-            "stderr": (
-                "" if response.status_code == 200 else f"HTTP {response.status_code}"
-            ),
-        }
-    except Exception as exc:
-        return {
-            "command": f"GET {health_url}",
-            "ok": False,
-            "stdout": "",
-            "stderr": str(exc),
-        }
+    return await _check_http_endpoints(url, ["/health"])
+
+
+async def _check_http_endpoints(url: str, paths: list[str]):
+    base = url.rstrip("/")
+    errors: list[str] = []
+    timeout = httpx.Timeout(connect=2.0, read=2.0, write=2.0, pool=2.0)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        for path in paths:
+            endpoint = f"{base}{path}"
+            try:
+                async with client.stream("GET", endpoint) as response:
+                    if response.status_code == 200:
+                        content_type = response.headers.get("content-type", "").strip()
+                        summary = content_type or "HTTP 200"
+                        return {
+                            "command": f"GET {endpoint}",
+                            "ok": True,
+                            "stdout": summary,
+                            "stderr": "",
+                        }
+                    errors.append(f"{endpoint} -> HTTP {response.status_code}")
+            except Exception as exc:
+                errors.append(f"{endpoint} -> {exc}")
+    first_endpoint = f"{base}{paths[0]}"
+    return {
+        "command": f"GET {first_endpoint}",
+        "ok": False,
+        "stdout": "",
+        "stderr": "; ".join(errors),
+    }
 
 
 async def _check_ws_port(url: str):
@@ -343,10 +356,18 @@ async def _build_setup_status():
             checks.append(await _check_tcp_port(pi_host, 22))
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "backend_service":
-            checks = [await _check_http_health(config["backend_url"])]
+            checks = [
+                await _check_http_endpoints(
+                    config["backend_url"], ["/health", "/docs", "/openapi.json"]
+                )
+            ]
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "vision_preview":
-            checks = [await _check_http_health(config["preview_url"])]
+            checks = [
+                await _check_http_endpoints(
+                    config["preview_url"], ["/ready", "/snapshot.jpg", "/health"]
+                )
+            ]
             check_ok = all(item["ok"] for item in checks)
         elif step["id"] == "websocket_endpoint":
             ws_result = await _check_ws_port(config["backend_url"])

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl, getLatestSnapshotUrl, getSelectedTrackId, getTrackPhotoUrl, parseTrackRecord, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
+import { TRACK_OVERLAY_EVENT, apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl, getLatestSnapshotUrl, getSelectedTrackId, getTrackPhotoUrl, parseTrackRecord, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
 import { useRaceContext } from '@/stores/raceStore'
 import TrackCanvas from '@/components/track/TrackCanvas'
 import type { Track, TrackPoint } from '@/types'
@@ -40,6 +40,17 @@ const defaultConfig = {
     event_name: 'Weekend Session',
     total_laps: 20,
     racer_names: 'Racer 1, Racer 2',
+}
+
+function normalizeBaseUrl(value: string): string {
+    const raw = value.trim()
+    if (!raw) return ''
+    try {
+        const parsed = new URL(raw)
+        return `${parsed.protocol}//${parsed.host}`
+    } catch {
+        return raw.replace(/\/$/, '')
+    }
 }
 
 export default function SettingsPanel() {
@@ -122,6 +133,19 @@ export default function SettingsPanel() {
         void loadWizard()
         void loadTracks()
     }, [])
+
+    useEffect(() => {
+        const handleOverlayUpdate = () => {
+            const selectedId = getSelectedTrackId() || selectedTrackId
+            if (!selectedId) {
+                setTrackPhotoUrlState(getLatestSnapshotUrl())
+                return
+            }
+            setTrackPhotoUrlState(getTrackPhotoUrl(selectedId) || getLatestSnapshotUrl())
+        }
+        window.addEventListener(TRACK_OVERLAY_EVENT, handleOverlayUpdate)
+        return () => window.removeEventListener(TRACK_OVERLAY_EVENT, handleOverlayUpdate)
+    }, [selectedTrackId])
 
     const frontendApiUrl = configuredApiBaseUrl() ?? `same-origin /api → fallback ${backendBaseUrl()}`
     const frontendWsUrl = backendWsUrl('organizer')
@@ -262,7 +286,7 @@ export default function SettingsPanel() {
 
     const useLatestCapture = () => {
         const latest = getLatestSnapshotUrl()
-        const previewBase = config.preview_url.trim().replace(/\/$/, '')
+        const previewBase = normalizeBaseUrl(config.preview_url)
         const fallback = previewBase ? `${previewBase}/snapshot.jpg?t=${Date.now()}` : ''
         setTrackPhotoUrlState(latest || fallback)
     }
@@ -349,7 +373,13 @@ export default function SettingsPanel() {
                                 <ul className="mt-3 space-y-1 text-xs">
                                     {step.checks.map(check => (
                                         <li key={check.command} className={check.ok ? 'text-emerald-300' : 'text-rose-300'}>
-                                            {check.ok ? '✓' : '✗'} {check.command}
+                                            <p>{check.ok ? '✓' : '✗'} {check.command}</p>
+                                            {!check.ok && check.stderr ? (
+                                                <p className="ml-4 text-[11px] text-rose-200 break-words">{check.stderr}</p>
+                                            ) : null}
+                                            {check.ok && check.stdout ? (
+                                                <p className="ml-4 text-[11px] text-emerald-100 break-words">{check.stdout}</p>
+                                            ) : null}
                                         </li>
                                     ))}
                                 </ul>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch, getSelectedTrackId, setLatestSnapshotUrl, setTrackPhotoUrl } from '@/lib/utils'
+import { apiFetch, getSelectedTrackId, parseTrackRecord, setLatestSnapshotUrl, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -8,15 +8,69 @@ function defaultPreviewBaseUrl(): string {
     return `http://${window.location.hostname}:8091`
 }
 
+function normalizePreviewBaseUrl(value: string): string {
+    const raw = value.trim()
+    if (!raw) return ''
+    try {
+        const parsed = new URL(raw)
+        return `${parsed.protocol}//${parsed.host}`
+    } catch {
+        return raw.replace(/\/$/, '')
+    }
+}
+
 export default function VisionPanel() {
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
+    const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
     const [statusError, setStatusError] = useState(false)
     const [capturing, setCapturing] = useState(false)
     const [raceContext, setRaceContext] = useState<Record<string, unknown>>({})
+    const [activeTrackName, setActiveTrackName] = useState('')
 
-    const normalizedBaseUrl = useMemo(() => previewBaseUrl.trim().replace(/\/$/, ''), [previewBaseUrl])
+    const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
     const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
+
+    const ensureSelectedTrack = async () => {
+        const existingTrackId = getSelectedTrackId()
+        if (existingTrackId) {
+            return existingTrackId
+        }
+        try {
+            const response = await apiFetch('/api/tracks')
+            if (!response.ok) return ''
+            const payload = await response.json()
+            const tracks = Array.isArray(payload)
+                ? payload.map(item => parseTrackRecord(item as Record<string, unknown>))
+                : []
+            const firstTrack = tracks[0]
+            if (!firstTrack?.id) return ''
+            setSelectedTrackId(firstTrack.id)
+            return firstTrack.id
+        } catch {
+            return ''
+        }
+    }
+
+    const refreshTrackLabel = async () => {
+        const selectedTrackId = await ensureSelectedTrack()
+        if (!selectedTrackId) {
+            setActiveTrackName('')
+            return
+        }
+        try {
+            const response = await apiFetch('/api/tracks')
+            if (!response.ok) return
+            const payload = await response.json()
+            const tracks = Array.isArray(payload)
+                ? payload.map(item => parseTrackRecord(item as Record<string, unknown>))
+                : []
+            const selected = tracks.find(track => track.id === selectedTrackId)
+            setActiveTrackName(selected?.name || '')
+        } catch {
+            // ignore if lookup fails
+        }
+    }
 
     const refreshWizardContext = async () => {
         try {
@@ -30,7 +84,8 @@ export default function VisionPanel() {
     }
 
     useEffect(() => {
-        refreshWizardContext()
+        void refreshWizardContext()
+        void refreshTrackLabel()
     }, [])
 
     const onCapture = async (event: FormEvent) => {
@@ -51,10 +106,15 @@ export default function VisionPanel() {
 
             setStatusMessage(payload.message || 'Snapshot captured successfully.')
             const snapshotUrl = `${normalizedBaseUrl}/snapshot.jpg?t=${Date.now()}`
-            const selectedTrackId = getSelectedTrackId()
+            const selectedTrackId = await ensureSelectedTrack()
             setLatestSnapshotUrl(snapshotUrl)
             if (selectedTrackId) {
                 setTrackPhotoUrl(selectedTrackId, snapshotUrl)
+                setStatusMessage(payload.message || 'Snapshot captured and linked to selected track.')
+                setStatusError(false)
+            } else {
+                setStatusMessage('Snapshot captured, but no track is selected yet. Select/create a track in Settings and use "Use Latest Capture".')
+                setStatusError(true)
             }
             const raceId = String(raceContext.race_id || '')
             if (raceId) {
@@ -111,6 +171,9 @@ export default function VisionPanel() {
                     Capture the track image here after the setup wizard in Settings marks connectivity as connected. Once
                     captured, return here to start object tracking and monitor lap-count logs.
                 </p>
+                <p className="text-xs text-amber-300">
+                    Keep the camera stream open in only one viewer at a time. Viewing <code>/stream.mjpg</code> in multiple places can drop the camera connection.
+                </p>
                 <div className="rounded border border-slate-700 bg-slate-950 p-3">
                     <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Start camera feed only</p>
                     <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
@@ -124,14 +187,36 @@ export default function VisionPanel() {
                         camera uses a different device.
                     </p>
                 </div>
+                <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-1">
+                    <p><strong>Race flow:</strong> 1) Initialize race in Settings, 2) capture track photo here, 3) map spline in Settings, 4) return to Dashboard for overlays, 5) start tracking here, 6) use Race Start/Pause/Resume/Finish in Settings.</p>
+                    <p>
+                        Active track for auto-linking captures: <strong>{activeTrackName || 'None selected'}</strong>
+                    </p>
+                </div>
             </div>
 
             <div className="race-card p-4 space-y-3">
-                <img
-                    src={streamUrl}
-                    alt="Live camera preview"
-                    className="w-full rounded border border-slate-700 bg-black"
-                />
+                <div className="flex flex-wrap items-center gap-2">
+                    <button
+                        type="button"
+                        className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                        onClick={() => setPreviewEnabled(prev => !prev)}
+                    >
+                        {previewEnabled ? 'Hide Live Preview' : 'Show Live Preview'}
+                    </button>
+                    <p className="text-xs text-[var(--color-text-secondary)]">Use this only while capturing the track image, then hide it before opening other camera consumers.</p>
+                </div>
+                {previewEnabled ? (
+                    <img
+                        src={streamUrl}
+                        alt="Live camera preview"
+                        className="w-full rounded border border-slate-700 bg-black"
+                    />
+                ) : (
+                    <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
+                        Live preview is paused to avoid multiple stream consumers.
+                    </div>
+                )}
 
                 <form onSubmit={onCapture} className="flex flex-wrap items-center gap-2">
                     <button

--- a/ros_ws/src/j5_perception/race-master-pro/scripts/pi_preflight.py
+++ b/ros_ws/src/j5_perception/race-master-pro/scripts/pi_preflight.py
@@ -142,10 +142,9 @@ def is_required_check(check: CheckResult, *, preview_only: bool) -> bool:
 def camera_source_to_cv2_index(camera_source: str):
     if camera_source.isdigit():
         return int(camera_source)
-    if camera_source.startswith("/dev/video"):
-        suffix = camera_source.removeprefix("/dev/video")
-        if suffix.isdigit():
-            return int(suffix)
+    # Keep explicit device paths (e.g. /dev/video0) as strings so OpenCV
+    # opens that exact node instead of remapping to a potentially different
+    # numeric camera index.
     return camera_source
 
 
@@ -242,6 +241,65 @@ def run_preview_server(
         def do_GET(self) -> None:  # noqa: N802
             if self.path in ("/", "/index.html"):
                 self._send_html()
+                return
+            if self.path == "/ready":
+
+                def probe_camera_once() -> tuple[bool, str]:
+                    source = camera_source_to_cv2_index(camera_source)
+                    cap = cv2.VideoCapture(source)
+                    if not cap.isOpened():
+                        return False, f"unable to open camera source {camera_source}"
+                    ok, frame = cap.read()
+                    cap.release()
+                    if not ok or frame is None:
+                        return False, "camera opened but no frame available"
+                    with frame_lock:
+                        stream_state["latest_frame"] = frame.copy()
+                    return True, "camera opened and frame acquired"
+
+                with frame_lock:
+                    latest_frame = stream_state["latest_frame"]
+                    active_streams = stream_state["active_streams"]
+
+                if latest_frame is not None and active_streams > 0:
+                    payload = json.dumps(
+                        {
+                            "ok": True,
+                            "message": "frame buffered from active preview stream",
+                        }
+                    ).encode("utf-8")
+                    self.send_response(HTTPStatus.OK)
+                elif latest_frame is not None:
+                    ok, message = probe_camera_once()
+                    payload = json.dumps({"ok": ok, "message": message}).encode("utf-8")
+                    self.send_response(
+                        HTTPStatus.OK if ok else HTTPStatus.SERVICE_UNAVAILABLE
+                    )
+                elif capture_file.exists():
+                    payload = json.dumps(
+                        {"ok": True, "message": f"snapshot available at {capture_file}"}
+                    ).encode("utf-8")
+                    self.send_response(HTTPStatus.OK)
+                elif active_streams > 0:
+                    payload = json.dumps(
+                        {
+                            "ok": False,
+                            "message": "preview stream active but no frame buffered yet",
+                        }
+                    ).encode("utf-8")
+                    self.send_response(HTTPStatus.SERVICE_UNAVAILABLE)
+                else:
+                    ok, message = probe_camera_once()
+                    payload = json.dumps({"ok": ok, "message": message}).encode("utf-8")
+                    self.send_response(
+                        HTTPStatus.OK if ok else HTTPStatus.SERVICE_UNAVAILABLE
+                    )
+
+                self._set_cors_headers()
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
                 return
             if self.path == "/snapshot.jpg":
                 if not capture_file.exists():


### PR DESCRIPTION
### Motivation
- Make setup/connectivity checks more resilient by probing multiple HTTP endpoints and normalizing configured base URLs to avoid false negatives. 
- Prevent multiple consumers from destabilizing the camera feed and make the preview UI and Pi preview server report readiness more clearly. 
- Improve UX around auto-linking captured snapshots to tracks and surface diagnostics from connectivity checks in the UI.

### Description
- Backend: replace single `/health` probe with `_check_http_endpoints` that tries multiple paths and returns a content-type summary on success, and normalize `backend_url`/`preview_url` to `scheme://netloc` in `_validate_setup_config`; update `backend_service` and `vision_preview` setup steps to check several endpoints. 
- Backend: add `_check_http_endpoints` implementation using `httpx` streaming with timeouts and aggregated error messages, and update caller usages; adjust setup step help text and connect instructions for websockets. 
- Pi preview script: keep explicit `/dev/videoN` device paths as strings so OpenCV opens the exact node, and add a `/ready` HTTP endpoint that probes camera availability and buffered frames to report readiness as JSON. 
- Frontend (SettingsPanel): add `normalizeBaseUrl` to canonicalize configured URLs, listen for `TRACK_OVERLAY_EVENT` to update track photo previews, and show check `stdout`/`stderr` messages inline. 
- Frontend (VisionPanel): add `normalizePreviewBaseUrl`, toggleable live preview to avoid multiple stream consumers, auto-select the first track if none is selected (`ensureSelectedTrack`), show active track name, and improve capture messaging when no track is selected.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4871b89388323b2edb9968434c549)