### PR TITLE
Add interactive track editor, checkpoint storage, live overlay improvements, and pause lap counting when race inactive

### DIFF
--- a/apps/racemanager/service/main.py
+++ b/apps/racemanager/service/main.py
@@ -182,6 +182,11 @@ async def ingest_lap(
     repository: RaceRepository = Depends(repo_provider),
 ) -> LapResponse:
     speed = calculate_speed_kph(payload.trackDistanceM, payload.lapTimeMs)
+    race = repository.get_entity("races", payload.raceId)
+    race_is_active = bool(race and race.get("status") == "active")
+    if not race_is_active:
+        payload.validity.minLapTimeOk = False
+
     try:
         inserted_id = repository.insert_lap(payload, speed)
         leaderboard = repository.leaderboard(payload.raceId)
@@ -199,6 +204,7 @@ async def ingest_lap(
                 "lapTimeMs": payload.lapTimeMs,
                 "speedKph": speed,
                 "isValid": payload.validity.is_valid,
+                "lapCounted": payload.validity.is_valid and race_is_active,
                 "source": payload.source,
                 "timestamp": payload.timestamp.isoformat(),
             },

--- a/apps/racemanager/ui/pages/index.tsx
+++ b/apps/racemanager/ui/pages/index.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { useEffect, useMemo, useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import styles from '../styles/Home.module.css';
 
 const apiBase = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:4000';
@@ -17,8 +17,9 @@ type Track = {
   startGate?: LineGate | null;
   finishGate?: LineGate | null;
   checkpoints: Checkpoint[];
+  calibration?: Record<string, unknown>;
 };
-type Race = { id: string; name: string; totalLaps: number; status: string };
+type Race = { id: string; name: string; totalLaps: number; status: string; trackId?: string | null };
 type LeaderboardEntry = {
   carId: string;
   lapCount: number;
@@ -59,6 +60,28 @@ type Dashboard = {
   recentEvents: RaceEvent[];
 };
 
+type TrackDraft = {
+  id?: string;
+  name: string;
+  imageUrl: string;
+  layoutPoints: Point[];
+  maskPolygon: Point[];
+  checkpoints: Checkpoint[];
+  startGate?: LineGate | null;
+  finishGate?: LineGate | null;
+  calibration: { startPosition?: Point; direction?: string };
+};
+
+type PlacementTool =
+  | 'layout'
+  | 'mask'
+  | 'checkpoint'
+  | 'start_a'
+  | 'start_b'
+  | 'finish_a'
+  | 'finish_b'
+  | 'start_position';
+
 const formatMs = (value?: number | null) => {
   if (!value) return '—';
   const seconds = value / 1000;
@@ -70,14 +93,48 @@ const formatGap = (value?: number | null) => {
   return `+${(value / 1000).toFixed(2)}s`;
 };
 
-function useTrackBounds(track?: Track | null) {
+const defaultDraft = (): TrackDraft => ({
+  name: 'New track',
+  imageUrl: '',
+  layoutPoints: [],
+  maskPolygon: [],
+  checkpoints: [],
+  startGate: { a: { x: 10, y: 50 }, b: { x: 20, y: 50 }, label: 'start' },
+  finishGate: { a: { x: 80, y: 50 }, b: { x: 90, y: 50 }, label: 'finish' },
+  calibration: { direction: 'clockwise' },
+});
+
+const asTrackDraft = (track?: Track | null): TrackDraft => {
+  if (!track) return defaultDraft();
+  return {
+    id: track.id,
+    name: track.name,
+    imageUrl: track.imageUrl ?? '',
+    layoutPoints: [...(track.layoutPoints ?? [])],
+    maskPolygon: [...(track.maskPolygon ?? [])],
+    checkpoints: [...(track.checkpoints ?? [])],
+    startGate: track.startGate ?? { a: { x: 10, y: 50 }, b: { x: 20, y: 50 }, label: 'start' },
+    finishGate: track.finishGate ?? { a: { x: 80, y: 50 }, b: { x: 90, y: 50 }, label: 'finish' },
+    calibration: {
+      startPosition: (track.calibration?.startPosition as Point | undefined),
+      direction: typeof track.calibration?.direction === 'string' ? track.calibration.direction : 'clockwise',
+    },
+  };
+};
+
+function useTrackBounds(track?: Track | null, draft?: TrackDraft | null) {
   return useMemo(() => {
     const points: Point[] = [];
-    if (track?.layoutPoints?.length) points.push(...track.layoutPoints);
-    if (track?.maskPolygon?.length) points.push(...track.maskPolygon);
-    if (track?.checkpoints?.length) points.push(...track.checkpoints.map((item) => item.position));
-    if (track?.startGate) points.push(track.startGate.a, track.startGate.b);
-    if (track?.finishGate) points.push(track.finishGate.a, track.finishGate.b);
+    const sourceTrack = track ?? undefined;
+    if (sourceTrack?.layoutPoints?.length) points.push(...sourceTrack.layoutPoints);
+    if (sourceTrack?.maskPolygon?.length) points.push(...sourceTrack.maskPolygon);
+    if (sourceTrack?.checkpoints?.length) points.push(...sourceTrack.checkpoints.map((item) => item.position));
+    if (sourceTrack?.startGate) points.push(sourceTrack.startGate.a, sourceTrack.startGate.b);
+    if (sourceTrack?.finishGate) points.push(sourceTrack.finishGate.a, sourceTrack.finishGate.b);
+
+    if (draft?.layoutPoints?.length) points.push(...draft.layoutPoints);
+    if (draft?.maskPolygon?.length) points.push(...draft.maskPolygon);
+    if (draft?.checkpoints?.length) points.push(...draft.checkpoints.map((item) => item.position));
 
     if (!points.length) {
       return { minX: 0, minY: 0, width: 100, height: 100 };
@@ -95,15 +152,49 @@ function useTrackBounds(track?: Track | null) {
       width: Math.max(maxX - minX, 1),
       height: Math.max(maxY - minY, 1),
     };
-  }, [track]);
+  }, [track, draft]);
 }
 
-function TrackPreview({ track, entries }: { track?: Track | null; entries: DashboardEntry[] }) {
-  const bounds = useTrackBounds(track);
-  const scalePoint = (point: Point) => ({
-    x: ((point.x - bounds.minX) / bounds.width) * 100,
-    y: ((point.y - bounds.minY) / bounds.height) * 100,
+function toPercentPoint(raw: Point, bounds: { minX: number; minY: number; width: number; height: number }) {
+  return {
+    x: ((raw.x - bounds.minX) / bounds.width) * 100,
+    y: ((raw.y - bounds.minY) / bounds.height) * 100,
+  };
+}
+
+function pickCarPositions(track: Track | null | undefined, entries: DashboardEntry[], events: RaceEvent[]) {
+  const checkpointById = new Map((track?.checkpoints ?? []).map((checkpoint) => [checkpoint.id, checkpoint.position]));
+  const latestByCar = new Map<string, Point>();
+
+  events.forEach((event) => {
+    if (!event.carId || latestByCar.has(event.carId)) return;
+    const payloadPoint = event.payload && typeof event.payload.x === 'number' && typeof event.payload.y === 'number'
+      ? { x: Number(event.payload.x), y: Number(event.payload.y) }
+      : null;
+    if (payloadPoint) {
+      latestByCar.set(event.carId, payloadPoint);
+      return;
+    }
+    if (event.checkpointId && checkpointById.has(event.checkpointId)) {
+      latestByCar.set(event.carId, checkpointById.get(event.checkpointId)!);
+    }
   });
+
+  return entries.map((entry, index) => {
+    const fallbackCheckpoint = track?.checkpoints?.[index % Math.max(track?.checkpoints?.length || 1, 1)]?.position;
+    const fallbackLayout = track?.layoutPoints?.[index % Math.max(track?.layoutPoints?.length || 1, 1)];
+    const point = latestByCar.get(entry.carId)
+      ?? fallbackCheckpoint
+      ?? fallbackLayout
+      ?? { x: 10 + index * 10, y: 80 - index * 8 };
+    return { entry, point };
+  });
+}
+
+function TrackPreview({ track, entries, events }: { track?: Track | null; entries: DashboardEntry[]; events: RaceEvent[] }) {
+  const bounds = useTrackBounds(track);
+  const carMarkers = pickCarPositions(track, entries, events);
+  const scalePoint = (point: Point) => toPercentPoint(point, bounds);
 
   const polyline = track?.layoutPoints?.length
     ? track.layoutPoints.map((point) => {
@@ -123,13 +214,14 @@ function TrackPreview({ track, entries }: { track?: Track | null; entries: Dashb
     <div className={styles.trackCard}>
       <div className={styles.panelHeader}>
         <div>
-          <h2>Track & checkpoints</h2>
-          <p>Start/finish geometry, checkpoints, and live race entries for the selected race.</p>
+          <h2>Track & live camera overlay</h2>
+          <p>Track image, path geometry, checkpoints, and moving car annotations from live events.</p>
         </div>
         {track?.imageUrl ? <a href={track.imageUrl} target="_blank" rel="noreferrer">Track photo</a> : null}
       </div>
       <div className={styles.trackViewport}>
         <svg viewBox="0 0 100 100" className={styles.trackSvg} preserveAspectRatio="none">
+          {track?.imageUrl ? <image href={track.imageUrl} x="0" y="0" width="100" height="100" preserveAspectRatio="none" className={styles.trackImage} /> : null}
           {polygon ? <polygon points={polygon} className={styles.maskPolygon} /> : null}
           {polyline ? <polyline points={polyline} className={styles.layoutPolyline} /> : null}
           {track?.startGate ? (() => {
@@ -153,13 +245,12 @@ function TrackPreview({ track, entries }: { track?: Track | null; entries: Dashb
               </g>
             );
           })}
-          {entries.map((entry, index) => {
-            const checkpoint = track?.checkpoints?.[index % Math.max(track?.checkpoints?.length || 1, 1)];
-            const point = checkpoint ? scalePoint(checkpoint.position) : { x: 10 + index * 10, y: 80 - index * 8 };
+          {carMarkers.map(({ entry, point }) => {
+            const scaled = scalePoint(point);
             return (
               <g key={`${entry.carId}-${entry.racerId || 'na'}`}>
-                <circle cx={point.x} cy={point.y} r="3.2" fill={entry.paintColor || '#4ade80'} className={styles.entryDot} />
-                <text x={point.x} y={point.y + 8} textAnchor="middle" className={styles.entryLabel}>
+                <circle cx={scaled.x} cy={scaled.y} r="3.2" fill={entry.paintColor || '#4ade80'} className={styles.entryDot} />
+                <text x={scaled.x} y={scaled.y + 8} textAnchor="middle" className={styles.entryLabel}>
                   #{entry.carNumber || entry.carId}
                 </text>
               </g>
@@ -172,29 +263,213 @@ function TrackPreview({ track, entries }: { track?: Track | null; entries: Dashb
   );
 }
 
+function TrackSettings({ tracks, selectedTrackId, setSelectedTrackId, onSaved }: {
+  tracks: Track[];
+  selectedTrackId: string;
+  setSelectedTrackId: (id: string) => void;
+  onSaved: (track: Track) => void;
+}) {
+  const [tool, setTool] = useState<PlacementTool>('layout');
+  const [draft, setDraft] = useState<TrackDraft>(defaultDraft());
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+
+  useEffect(() => {
+    const selected = tracks.find((track) => track.id === selectedTrackId);
+    setDraft(asTrackDraft(selected));
+  }, [selectedTrackId, tracks]);
+
+  const bounds = useTrackBounds(undefined, draft);
+  const scalePoint = (point: Point) => toPercentPoint(point, bounds);
+  const unscalePoint = (point: Point): Point => ({
+    x: bounds.minX + (point.x / 100) * bounds.width,
+    y: bounds.minY + (point.y / 100) * bounds.height,
+  });
+
+  const onCanvasClick = (event: MouseEvent<SVGSVGElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const clickPercent = {
+      x: ((event.clientX - rect.left) / rect.width) * 100,
+      y: ((event.clientY - rect.top) / rect.height) * 100,
+    };
+    const clickRaw = unscalePoint(clickPercent);
+
+    setDraft((current) => {
+      if (tool === 'layout') return { ...current, layoutPoints: [...current.layoutPoints, clickRaw] };
+      if (tool === 'mask') return { ...current, maskPolygon: [...current.maskPolygon, clickRaw] };
+      if (tool === 'checkpoint') {
+        const next = current.checkpoints.length + 1;
+        return {
+          ...current,
+          checkpoints: [
+            ...current.checkpoints,
+            {
+              id: `cp-${next}`,
+              name: `CP ${next}`,
+              type: 'checkpoint',
+              order: next,
+              position: clickRaw,
+            },
+          ],
+        };
+      }
+      if (tool === 'start_a') return { ...current, startGate: { ...(current.startGate ?? { a: clickRaw, b: clickRaw }), a: clickRaw } };
+      if (tool === 'start_b') return { ...current, startGate: { ...(current.startGate ?? { a: clickRaw, b: clickRaw }), b: clickRaw } };
+      if (tool === 'finish_a') return { ...current, finishGate: { ...(current.finishGate ?? { a: clickRaw, b: clickRaw }), a: clickRaw } };
+      if (tool === 'finish_b') return { ...current, finishGate: { ...(current.finishGate ?? { a: clickRaw, b: clickRaw }), b: clickRaw } };
+      return {
+        ...current,
+        calibration: {
+          ...current.calibration,
+          startPosition: clickRaw,
+        },
+      };
+    });
+  };
+
+  const saveTrack = async () => {
+    setSaveState('saving');
+    const payload = {
+      name: draft.name,
+      imageUrl: draft.imageUrl || null,
+      layoutPoints: draft.layoutPoints,
+      maskPolygon: draft.maskPolygon,
+      startGate: draft.startGate ?? null,
+      finishGate: draft.finishGate ?? null,
+      checkpoints: draft.checkpoints,
+      calibration: draft.calibration,
+    };
+
+    const targetId = draft.id || selectedTrackId;
+    const url = targetId ? `${apiBase}/api/tracks/${targetId}` : `${apiBase}/api/tracks`;
+    const method = targetId ? 'PUT' : 'POST';
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) throw new Error('save failed');
+      const saved = await response.json() as Track;
+      setSaveState('saved');
+      setSelectedTrackId(saved.id);
+      setDraft(asTrackDraft(saved));
+      onSaved(saved);
+    } catch {
+      setSaveState('error');
+    }
+  };
+
+  const layout = draft.layoutPoints.map((point) => {
+    const scaled = scalePoint(point);
+    return `${scaled.x},${scaled.y}`;
+  }).join(' ');
+
+  return (
+    <section className={styles.panel}>
+      <div className={styles.panelHeader}>
+        <div>
+          <h2>Settings · Track setup wizard</h2>
+          <p>Load the camera image, click to trace the spline path, set start/finish gates, and set start direction.</p>
+        </div>
+      </div>
+
+      <div className={styles.settingsGrid}>
+        <div className={styles.formColumn}>
+          <label className={styles.selectorLabel}>Track
+            <select value={selectedTrackId} onChange={(event) => setSelectedTrackId(event.target.value)}>
+              <option value="">New track</option>
+              {tracks.map((track) => (
+                <option key={track.id} value={track.id}>{track.name}</option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.selectorLabel}>Name
+            <input value={draft.name} onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))} />
+          </label>
+          <label className={styles.selectorLabel}>Camera image URL
+            <input value={draft.imageUrl} onChange={(event) => setDraft((current) => ({ ...current, imageUrl: event.target.value }))} placeholder="https://.../track-camera.jpg" />
+          </label>
+          <label className={styles.selectorLabel}>Direction
+            <select value={draft.calibration.direction || 'clockwise'} onChange={(event) => setDraft((current) => ({ ...current, calibration: { ...current.calibration, direction: event.target.value } }))}>
+              <option value="clockwise">Clockwise</option>
+              <option value="counter-clockwise">Counter-clockwise</option>
+            </select>
+          </label>
+
+          <div className={styles.toolRow}>
+            {(['layout', 'mask', 'checkpoint', 'start_a', 'start_b', 'finish_a', 'finish_b', 'start_position'] as PlacementTool[]).map((item) => (
+              <button key={item} type="button" className={tool === item ? styles.activeTool : styles.toolButton} onClick={() => setTool(item)}>{item.replace('_', ' ')}</button>
+            ))}
+          </div>
+
+          <div className={styles.toolRow}>
+            <button type="button" className={styles.toolButton} onClick={() => setDraft((current) => ({ ...current, layoutPoints: [] }))}>Clear path</button>
+            <button type="button" className={styles.toolButton} onClick={() => setDraft((current) => ({ ...current, checkpoints: [] }))}>Clear checkpoints</button>
+            <button type="button" className={styles.toolButton} onClick={() => setDraft((current) => ({ ...current, maskPolygon: [] }))}>Clear mask</button>
+          </div>
+
+          <button type="button" className={styles.saveButton} onClick={() => void saveTrack()}>
+            {saveState === 'saving' ? 'Saving…' : 'Save track setup'}
+          </button>
+        </div>
+
+        <div className={styles.setupViewport}>
+          <svg viewBox="0 0 100 100" preserveAspectRatio="none" onClick={onCanvasClick} className={styles.trackSvg}>
+            {draft.imageUrl ? <image href={draft.imageUrl} x="0" y="0" width="100" height="100" preserveAspectRatio="none" className={styles.trackImage} /> : null}
+            {layout ? <polyline points={layout} className={styles.layoutPolyline} /> : null}
+            {draft.maskPolygon.length >= 3 ? (
+              <polygon points={draft.maskPolygon.map((point) => {
+                const scaled = scalePoint(point);
+                return `${scaled.x},${scaled.y}`;
+              }).join(' ')} className={styles.maskPolygon} />
+            ) : null}
+            {draft.startGate ? <line x1={scalePoint(draft.startGate.a).x} y1={scalePoint(draft.startGate.a).y} x2={scalePoint(draft.startGate.b).x} y2={scalePoint(draft.startGate.b).y} className={styles.startGate} /> : null}
+            {draft.finishGate ? <line x1={scalePoint(draft.finishGate.a).x} y1={scalePoint(draft.finishGate.a).y} x2={scalePoint(draft.finishGate.b).x} y2={scalePoint(draft.finishGate.b).y} className={styles.finishGate} /> : null}
+            {draft.checkpoints.map((checkpoint) => {
+              const point = scalePoint(checkpoint.position);
+              return <circle key={checkpoint.id} cx={point.x} cy={point.y} r="2.2" className={styles.checkpointDot} />;
+            })}
+            {draft.calibration.startPosition ? (
+              <circle cx={scalePoint(draft.calibration.startPosition).x} cy={scalePoint(draft.calibration.startPosition).y} r="3" className={styles.startPositionDot} />
+            ) : null}
+          </svg>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export default function Home() {
+  const [tab, setTab] = useState<'dashboard' | 'settings'>('dashboard');
   const [races, setRaces] = useState<Race[]>([]);
+  const [tracks, setTracks] = useState<Track[]>([]);
   const [selectedRaceId, setSelectedRaceId] = useState<string>('');
+  const [selectedTrackId, setSelectedTrackId] = useState<string>('');
   const [dashboard, setDashboard] = useState<Dashboard | null>(null);
   const [connectionState, setConnectionState] = useState<'connecting' | 'connected' | 'disconnected'>('connecting');
 
   useEffect(() => {
     let cancelled = false;
     async function loadRaces() {
-      const response = await fetch(`${apiBase}/api/races`);
-      if (!response.ok || cancelled) return;
-      const payload = await response.json() as Race[];
-      setRaces(payload);
-      if (!selectedRaceId && payload[0]?.id) {
-        setSelectedRaceId(payload[0].id);
-      }
+      const [raceResponse, trackResponse] = await Promise.all([
+        fetch(`${apiBase}/api/races`),
+        fetch(`${apiBase}/api/tracks`),
+      ]);
+      if (!raceResponse.ok || !trackResponse.ok || cancelled) return;
+      const racePayload = await raceResponse.json() as Race[];
+      const trackPayload = await trackResponse.json() as Track[];
+      setRaces(racePayload);
+      setTracks(trackPayload);
+      if (!selectedRaceId && racePayload[0]?.id) setSelectedRaceId(racePayload[0].id);
+      if (!selectedTrackId && trackPayload[0]?.id) setSelectedTrackId(trackPayload[0].id);
     }
 
     void loadRaces();
     return () => {
       cancelled = true;
     };
-  }, [selectedRaceId]);
+  }, [selectedRaceId, selectedTrackId]);
 
   useEffect(() => {
     if (!selectedRaceId) return;
@@ -204,6 +479,7 @@ export default function Home() {
       if (!response.ok || cancelled) return;
       const payload = await response.json() as Dashboard;
       setDashboard(payload);
+      if (payload.track?.id) setSelectedTrackId(payload.track.id);
     }
 
     void loadDashboard();
@@ -238,9 +514,7 @@ export default function Home() {
     };
 
     const keepAlive = window.setInterval(() => {
-      if (socket.readyState === WebSocket.OPEN) {
-        socket.send('ping');
-      }
+      if (socket.readyState === WebSocket.OPEN) socket.send('ping');
     }, 15000);
 
     return () => {
@@ -248,6 +522,20 @@ export default function Home() {
       socket.close();
     };
   }, [selectedRaceId]);
+
+  const refreshTracks = async (savedTrack?: Track) => {
+    if (savedTrack) {
+      setTracks((current) => {
+        const without = current.filter((item) => item.id !== savedTrack.id);
+        return [savedTrack, ...without];
+      });
+      return;
+    }
+    const response = await fetch(`${apiBase}/api/tracks`);
+    if (!response.ok) return;
+    const payload = await response.json() as Track[];
+    setTracks(payload);
+  };
 
   return (
     <div className={styles.container}>
@@ -284,25 +572,28 @@ export default function Home() {
               ))}
             </select>
           </label>
-          <div className={styles.toolbarText}>
-            Use the API to CRUD tracks/cars/racers/races, then watch lap + checkpoint events refresh this dashboard in real time.
+          <div className={styles.tabRow}>
+            <button type="button" className={tab === 'dashboard' ? styles.activeTool : styles.toolButton} onClick={() => setTab('dashboard')}>Dashboard</button>
+            <button type="button" className={tab === 'settings' ? styles.activeTool : styles.toolButton} onClick={() => setTab('settings')}>Settings</button>
           </div>
         </section>
 
-        {!dashboard ? (
+        {tab === 'settings' ? (
+          <TrackSettings tracks={tracks} selectedTrackId={selectedTrackId} setSelectedTrackId={setSelectedTrackId} onSaved={(track) => void refreshTracks(track)} />
+        ) : !dashboard ? (
           <section className={styles.emptyState}>
             <h2>No dashboard loaded</h2>
             <p>Create race records through the new CRUD API (`/api/tracks`, `/api/cars`, `/api/racers`, `/api/races`) and select a race to visualize it here.</p>
           </section>
         ) : (
           <div className={styles.grid}>
-            <TrackPreview track={dashboard.track} entries={dashboard.entries} />
+            <TrackPreview track={dashboard.track} entries={dashboard.entries} events={dashboard.recentEvents} />
 
             <section className={styles.panel}>
               <div className={styles.panelHeader}>
                 <div>
                   <h2>{dashboard.race.name}</h2>
-                  <p>{dashboard.race.status} · {dashboard.race.totalLaps} total laps</p>
+                  <p>{dashboard.race.status} · {dashboard.race.totalLaps} total laps (lap count pauses while race is paused)</p>
                 </div>
               </div>
               <div className={styles.entryList}>

--- a/apps/racemanager/ui/styles/Home.module.css
+++ b/apps/racemanager/ui/styles/Home.module.css
@@ -321,3 +321,87 @@
     width: 100%;
   }
 }
+
+.trackImage {
+  opacity: 0.78;
+}
+
+.selectorLabel input {
+  min-width: 320px;
+  background: #020617;
+  color: #eef2ff;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+}
+
+.tabRow,
+.toolRow {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.toolButton,
+.activeTool,
+.saveButton {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #e2e8f0;
+  padding: 0.5rem 0.7rem;
+  cursor: pointer;
+}
+
+.activeTool {
+  border-color: rgba(56, 189, 248, 0.8);
+  background: rgba(14, 116, 144, 0.35);
+}
+
+.saveButton {
+  width: fit-content;
+  background: rgba(34, 197, 94, 0.25);
+  border-color: rgba(34, 197, 94, 0.8);
+}
+
+.settingsGrid {
+  display: grid;
+  grid-template-columns: minmax(280px, 420px) 1fr;
+  gap: 1rem;
+}
+
+.formColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.setupViewport {
+  min-height: 520px;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(2, 6, 23, 0.55);
+}
+
+.startPositionDot {
+  fill: #f43f5e;
+  stroke: #fff;
+  stroke-width: 0.5;
+}
+
+@media (max-width: 1080px) {
+  .settingsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .setupViewport {
+    min-height: 420px;
+  }
+}
+
+@media (max-width: 720px) {
+  .selectorLabel input {
+    min-width: 0;
+  }
+}

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/dashboard/Dashboard.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRaceContext } from '@/stores/raceStore'
 import Leaderboard from './Leaderboard'
 import TrackCanvas from '@/components/track/TrackCanvas'
-import type { Track } from '@/types'
+import type { Checkpoint, Track } from '@/types'
 import {
     TRACK_OVERLAY_EVENT,
     apiFetch,
     getSelectedTrackId,
+    getTrackCheckpoints,
     getTrackPhotoUrl,
     parseTrackRecord,
 } from '@/lib/utils'
@@ -15,6 +16,7 @@ export default function Dashboard() {
     const { liveRace, showTrack } = useRaceContext()
     const [track, setTrack] = useState<Track | null>(null)
     const [trackPhotoUrl, setTrackPhotoUrl] = useState('')
+    const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([])
 
     useEffect(() => {
         let cancelled = false
@@ -30,6 +32,7 @@ export default function Dashboard() {
             const nextTrack = tracks.find((item) => item.id === selectedTrackId) || tracks[0] || null
             setTrack(nextTrack)
             setTrackPhotoUrl(nextTrack ? getTrackPhotoUrl(nextTrack.id) : '')
+            setCheckpoints(nextTrack ? getTrackCheckpoints(nextTrack.id) : [])
         }
 
         void loadTrack()
@@ -44,7 +47,6 @@ export default function Dashboard() {
         }
     }, [])
 
-    const checkpoints = useMemo(() => [], [])
 
     if (!liveRace) {
         return (

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,8 +1,8 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { TRACK_OVERLAY_EVENT, apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl, getLatestSnapshotUrl, getSelectedTrackId, getTrackPhotoUrl, parseTrackRecord, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
+import { TRACK_OVERLAY_EVENT, apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl, getLatestSnapshotUrl, getSelectedTrackId, getTrackCheckpoints, getTrackPhotoUrl, parseTrackRecord, setSelectedTrackId, setTrackCheckpoints, setTrackPhotoUrl } from '@/lib/utils'
 import { useRaceContext } from '@/stores/raceStore'
 import TrackCanvas from '@/components/track/TrackCanvas'
-import type { Track, TrackPoint } from '@/types'
+import type { Checkpoint, Track, TrackPoint } from '@/types'
 
 interface SetupCheckResult {
     command: string
@@ -64,6 +64,8 @@ export default function SettingsPanel() {
     const [trackName, setTrackName] = useState('Main Track')
     const [trackPhotoUrl, setTrackPhotoUrlState] = useState('')
     const [editorPoints, setEditorPoints] = useState<TrackPoint[]>([])
+    const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([])
+    const [editTool, setEditTool] = useState<'spline' | 'start' | 'finish' | 'checkpoint'>('spline')
 
     const selectedTrack = useMemo(
         () => tracks.find(track => track.id === selectedTrackId) || null,
@@ -76,6 +78,7 @@ export default function SettingsPanel() {
             setTrackName('Main Track')
             setTrackPhotoUrlState(getLatestSnapshotUrl())
             setEditorPoints([])
+            setCheckpoints([])
             return
         }
         setSelectedTrackIdState(track.id)
@@ -83,6 +86,7 @@ export default function SettingsPanel() {
         setTrackName(track.name)
         setEditorPoints(track.layout_points)
         setTrackPhotoUrlState(getTrackPhotoUrl(track.id) || getLatestSnapshotUrl())
+        setCheckpoints(getTrackCheckpoints(track.id))
     }
 
     const loadTracks = async () => {
@@ -142,6 +146,7 @@ export default function SettingsPanel() {
                 return
             }
             setTrackPhotoUrlState(getTrackPhotoUrl(selectedId) || getLatestSnapshotUrl())
+            setCheckpoints(getTrackCheckpoints(selectedId))
         }
         window.addEventListener(TRACK_OVERLAY_EVENT, handleOverlayUpdate)
         return () => window.removeEventListener(TRACK_OVERLAY_EVENT, handleOverlayUpdate)
@@ -249,6 +254,11 @@ export default function SettingsPanel() {
             if (trackPhotoUrl) {
                 setTrackPhotoUrl(created.id, trackPhotoUrl)
             }
+            setTrackCheckpoints(created.id, checkpoints.map((checkpoint, index) => ({
+                ...checkpoint,
+                track_id: created.id,
+                sort_order: index,
+            })))
             setSelectedTrackId(created.id)
             await loadTracks()
         } catch (err) {
@@ -277,6 +287,11 @@ export default function SettingsPanel() {
             if (trackPhotoUrl) {
                 setTrackPhotoUrl(selectedTrackId, trackPhotoUrl)
             }
+            setTrackCheckpoints(selectedTrackId, checkpoints.map((checkpoint, index) => ({
+                ...checkpoint,
+                track_id: selectedTrackId,
+                sort_order: index,
+            })))
             await loadTracks()
             setError('')
         } catch (err) {
@@ -446,17 +461,25 @@ export default function SettingsPanel() {
                         </div>
 
                         <div className="flex flex-wrap gap-2">
+                            <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'spline' ? 'bg-blue-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('spline')}>Spline Tool</button>
+                            <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'start' ? 'bg-emerald-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('start')}>Mark Start</button>
+                            <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'finish' ? 'bg-amber-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('finish')}>Mark Finish</button>
+                            <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'checkpoint' ? 'bg-violet-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('checkpoint')}>Add Checkpoint</button>
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
                             <button className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600" type="button" onClick={undoSplinePoint} disabled={editorPoints.length === 0}>Undo Point</button>
                             <button className="rounded bg-rose-700 px-3 py-2 text-xs font-semibold text-white hover:bg-rose-600" type="button" onClick={() => setEditorPoints([])} disabled={editorPoints.length === 0}>Clear Spline</button>
+                            <button className="rounded bg-rose-700 px-3 py-2 text-xs font-semibold text-white hover:bg-rose-600" type="button" onClick={() => setCheckpoints([])} disabled={checkpoints.length === 0}>Clear Markers</button>
                         </div>
 
                         <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-300 space-y-1">
                             <p><strong>How to use:</strong></p>
                             <p>1. Capture the track photo in the Computer Vision tab.</p>
                             <p>2. Click <strong>Use Latest Capture</strong>.</p>
-                            <p>3. Click around the lane centerline to place spline handles.</p>
-                            <p>4. Drag handles until the white path matches the real track.</p>
-                            <p>5. Save, then verify the Dashboard dots follow the spline with minimal lag.</p>
+                            <p>3. Choose <strong>Spline Tool</strong> and click around the lane centerline to place handles.</p>
+                            <p>4. Switch tools to mark <strong>Start</strong>, <strong>Finish</strong>, and additional checkpoints.</p>
+                            <p>5. Save, then verify Dashboard dots and markers line up with the track image.</p>
                         </div>
                     </div>
 
@@ -464,9 +487,11 @@ export default function SettingsPanel() {
                         <TrackCanvas
                             racers={[]}
                             layoutPoints={editorPoints}
-                            checkpoints={[]}
+                            checkpoints={checkpoints}
                             isEditMode
+                            editTool={editTool}
                             onTrackUpdate={setEditorPoints}
+                            onCheckpointUpdate={setCheckpoints}
                             backgroundImageUrl={trackPhotoUrl || undefined}
                         />
                     </div>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
@@ -2,12 +2,16 @@ import { useRef, useEffect, useCallback, useMemo, useState, type PointerEvent as
 import type { LiveRacer, TrackPoint, Checkpoint } from '@/types'
 import { stringToColor } from '@/lib/utils'
 
+type EditTool = 'spline' | 'start' | 'finish' | 'checkpoint'
+
 interface TrackCanvasProps {
     racers: LiveRacer[]
     layoutPoints: TrackPoint[]
     checkpoints: Checkpoint[]
     isEditMode?: boolean
+    editTool?: EditTool
     onTrackUpdate?: (points: TrackPoint[]) => void
+    onCheckpointUpdate?: (checkpoints: Checkpoint[]) => void
     backgroundImageUrl?: string
 }
 
@@ -59,7 +63,9 @@ export default function TrackCanvas({
     layoutPoints,
     checkpoints,
     isEditMode = false,
+    editTool = 'spline',
     onTrackUpdate,
+    onCheckpointUpdate,
     backgroundImageUrl,
 }: TrackCanvasProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -233,9 +239,14 @@ export default function TrackCanvas({
             ctx.fillStyle = '#cbd5f5'
             ctx.font = '12px Inter'
             ctx.textAlign = 'center'
-            ctx.fillText('Click to add spline points. Drag blue handles to reshape the path.', canvas.width / 2, canvas.height - 10)
+            const hint = editTool === 'spline'
+                ? 'Click to add spline points. Drag blue handles to reshape the path.'
+                : editTool === 'checkpoint'
+                    ? 'Click to place checkpoints on the track.'
+                    : `Click to set the ${editTool.toUpperCase()} marker.`
+            ctx.fillText(hint, canvas.width / 2, canvas.height - 10)
         }
-    }, [checkpoints, dragIndex, isEditMode, layoutPoints, pointToCanvas, racers, splinePoints])
+    }, [checkpoints, dragIndex, editTool, isEditMode, layoutPoints, pointToCanvas, racers, splinePoints])
 
     useEffect(() => {
         let animId: number
@@ -248,7 +259,27 @@ export default function TrackCanvas({
     }, [draw])
 
     const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLCanvasElement>) => {
-        if (!isEditMode || !onTrackUpdate) return
+        if (!isEditMode) return
+
+        if (editTool !== 'spline') {
+            if (!onCheckpointUpdate) return
+            const point = canvasToPoint(event.clientX, event.clientY)
+            if (!point) return
+            const nextType = editTool === 'start' ? 'start' : editTool === 'finish' ? 'finish' : 'checkpoint'
+            const checkpoint: Checkpoint = {
+                id: crypto.randomUUID(),
+                track_id: '',
+                name: nextType === 'checkpoint' ? `CP ${checkpoints.filter(item => item.type === 'checkpoint').length + 1}` : nextType.toUpperCase(),
+                type: nextType,
+                sort_order: checkpoints.length,
+                position: point,
+            }
+            const withoutSingle = nextType === 'checkpoint' ? checkpoints : checkpoints.filter(item => item.type !== nextType)
+            onCheckpointUpdate([...withoutSingle, checkpoint])
+            return
+        }
+
+        if (!onTrackUpdate) return
         const nearestIndex = findNearestIndex(event.clientX, event.clientY)
         if (nearestIndex >= 0) {
             setDragIndex(nearestIndex)
@@ -258,7 +289,7 @@ export default function TrackCanvas({
         if (!point) return
         onTrackUpdate([...layoutPoints, point])
         setDragIndex(layoutPoints.length)
-    }, [canvasToPoint, findNearestIndex, isEditMode, layoutPoints, onTrackUpdate])
+    }, [canvasToPoint, checkpoints, editTool, findNearestIndex, isEditMode, layoutPoints, onCheckpointUpdate, onTrackUpdate])
 
     const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLCanvasElement>) => {
         if (!isEditMode || dragIndex == null || !onTrackUpdate) return

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
@@ -1,11 +1,28 @@
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
-import type { Track, TrackPoint } from '@/types'
+import type { Checkpoint, Track, TrackPoint } from '@/types'
 
 const TRACK_SELECTION_KEY = 'race-master-pro.selectedTrackId'
 const TRACK_PHOTO_KEY_PREFIX = 'race-master-pro.trackPhoto.'
 const LATEST_SNAPSHOT_KEY = 'race-master-pro.latestSnapshotUrl'
 export const TRACK_OVERLAY_EVENT = 'j5-track-overlay-updated'
+
+const TRACK_CHECKPOINTS_KEY_PREFIX = 'race-master-pro.trackCheckpoints.'
+
+function sanitizeStoredUrl(url: string): string {
+    const value = (url || '').trim()
+    if (!value || value.startsWith('blob:')) return ''
+    if (value.endsWith('/stream.mjpg')) return `${value.replace(/\/stream\.mjpg$/, '')}/snapshot.jpg`
+    try {
+        const parsed = new URL(value)
+        if (parsed.pathname === '/' || parsed.pathname === '') {
+            return `${parsed.origin}/snapshot.jpg`
+        }
+    } catch {
+        // keep raw value when URL parsing fails
+    }
+    return value
+}
 
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs))
@@ -181,25 +198,62 @@ export function getSelectedTrackId(): string {
 export function setTrackPhotoUrl(trackId: string, url: string): void {
     const storage = getStorage()
     if (!storage || !trackId) return
-    storage.setItem(`${TRACK_PHOTO_KEY_PREFIX}${trackId}`, url)
-    storage.setItem(LATEST_SNAPSHOT_KEY, url)
+    const cleanUrl = sanitizeStoredUrl(url)
+    if (!cleanUrl) return
+    storage.setItem(`${TRACK_PHOTO_KEY_PREFIX}${trackId}`, cleanUrl)
+    storage.setItem(LATEST_SNAPSHOT_KEY, cleanUrl)
     window.dispatchEvent(new CustomEvent(TRACK_OVERLAY_EVENT))
 }
 
 export function getTrackPhotoUrl(trackId: string): string {
     const storage = getStorage()
     if (!storage || !trackId) return ''
-    return storage.getItem(`${TRACK_PHOTO_KEY_PREFIX}${trackId}`) || ''
+    return sanitizeStoredUrl(storage.getItem(`${TRACK_PHOTO_KEY_PREFIX}${trackId}`) || '')
 }
 
 export function setLatestSnapshotUrl(url: string): void {
     const storage = getStorage()
     if (!storage) return
-    storage.setItem(LATEST_SNAPSHOT_KEY, url)
+    const cleanUrl = sanitizeStoredUrl(url)
+    if (!cleanUrl) return
+    storage.setItem(LATEST_SNAPSHOT_KEY, cleanUrl)
     window.dispatchEvent(new CustomEvent(TRACK_OVERLAY_EVENT))
 }
 
 export function getLatestSnapshotUrl(): string {
     const storage = getStorage()
-    return storage?.getItem(LATEST_SNAPSHOT_KEY) || ''
+    return sanitizeStoredUrl(storage?.getItem(LATEST_SNAPSHOT_KEY) || '')
+}
+
+export function setTrackCheckpoints(trackId: string, checkpoints: Checkpoint[]): void {
+    const storage = getStorage()
+    if (!storage || !trackId) return
+    storage.setItem(`${TRACK_CHECKPOINTS_KEY_PREFIX}${trackId}`, JSON.stringify(checkpoints))
+    window.dispatchEvent(new CustomEvent(TRACK_OVERLAY_EVENT))
+}
+
+export function getTrackCheckpoints(trackId: string): Checkpoint[] {
+    const storage = getStorage()
+    if (!storage || !trackId) return []
+    const raw = storage.getItem(`${TRACK_CHECKPOINTS_KEY_PREFIX}${trackId}`)
+    if (!raw) return []
+    try {
+        const parsed = JSON.parse(raw)
+        if (!Array.isArray(parsed)) return []
+        return parsed
+            .filter(item => item && typeof item === 'object')
+            .map(item => ({
+                id: String((item as Checkpoint).id || crypto.randomUUID()),
+                track_id: String((item as Checkpoint).track_id || trackId),
+                name: String((item as Checkpoint).name || 'Checkpoint'),
+                type: ((item as Checkpoint).type || 'checkpoint') as Checkpoint['type'],
+                position: {
+                    x: Number((item as Checkpoint).position?.x || 0),
+                    y: Number((item as Checkpoint).position?.y || 0),
+                },
+                sort_order: Number((item as Checkpoint).sort_order || 0),
+            }))
+    } catch {
+        return []
+    }
 }


### PR DESCRIPTION
### Motivation
- Allow operators to create and edit track geometry and checkpoints from the UI and to persist per-track camera images and checkpoint markers for live overlays.
- Improve live dashboard by positioning car markers from recent events and the track image, and make lap counting honor race status (paused/inactive).
- Centralize browser persistence and sanitization for camera snapshot URLs and checkpoint lists to support the editor and overlay features.

### Description
- Backend: updated `ingest_lap` to detect whether the race is active and mark `payload.validity.minLapTimeOk = False` when inactive, and added `lapCounted` to websocket lap payloads to indicate whether a lap should be counted.
- UI (racemanager app): added a full track setup wizard and editor (`TrackSettings`, draft model, placement tools, save to `/api/tracks`), a tabbed Dashboard/Settings UI, and enhanced `TrackPreview` to render track image and compute car positions from `recentEvents`.
- Shared frontend/ROS UI: added checkpoint editing/marker tools and start/finish placement, passed edit tool state into `TrackCanvas`, and added handlers to create/update checkpoints and markers interactively.
- Utilities and storage: added `sanitizeStoredUrl`, `setTrackPhotoUrl`/`getTrackPhotoUrl` sanitization, and new `setTrackCheckpoints`/`getTrackCheckpoints` to persist checkpoint lists in localStorage and emit overlay update events.
- Styling: extended `Home.module.css` with styles for the track editor, toolbar tools, and image overlay.

### Testing
- Ran frontend TypeScript build and checks (`yarn build`/`next build`) to validate the new components and types, and the build succeeded without type errors.
- Ran the frontend unit/type checks and linting (ESLint/TS) and they passed with no new warnings treated as errors.
- Started the backend service locally and exercised `POST /ingest/lap` and dashboard websocket flows manually to verify `lapCounted` behavior and dashboard broadcasts, with no runtime errors observed.
- Executed existing Python unit tests (`pytest`) for the racemanager backend and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9bf056bf48323bf4bb010557d684d)