### PR TITLE
Fix track spline tools, marker placement, and settings panel runtime errors

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -81,6 +81,7 @@ export default function SettingsPanel() {
     const [selectedTrackId, setSelectedTrackIdState] = useState('')
     const [trackName, setTrackName] = useState('Main Track')
     const [trackPhotoUrl, setTrackPhotoUrlState] = useState('')
+    const [, setTrackPhotoLoadState] = useState<'idle' | 'loaded' | 'error'>('idle')
     const [editorPoints, setEditorPoints] = useState<TrackPoint[]>([])
     const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([])
     const [editTool, setEditTool] = useState<'spline' | 'start' | 'finish' | 'checkpoint'>('spline')
@@ -500,13 +501,6 @@ export default function SettingsPanel() {
                                 <option value="counterclockwise">Counter-clockwise</option>
                             </select>
                         </label>
-
-                        <div className="flex flex-wrap gap-2">
-                            <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'spline' ? 'bg-blue-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('spline')}>Spline Tool</button>
-                            <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'start' ? 'bg-emerald-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('start')}>Mark Start</button>
-                            <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'finish' ? 'bg-amber-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('finish')}>Mark Finish</button>
-                            <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'checkpoint' ? 'bg-violet-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('checkpoint')}>Add Checkpoint</button>
-                        </div>
 
                         <div className="flex flex-wrap gap-2">
                             <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'spline' ? 'bg-blue-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('spline')}>Spline Tool</button>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
@@ -4,8 +4,6 @@ import { generateId, stringToColor } from '@/lib/utils'
 
 type EditTool = 'spline' | 'start' | 'finish' | 'checkpoint'
 
-type EditTool = 'spline' | 'start' | 'finish' | 'checkpoint'
-
 interface TrackCanvasProps {
     racers: LiveRacer[]
     layoutPoints: TrackPoint[]
@@ -292,12 +290,12 @@ export default function TrackCanvas({
             if (!point) return
             const nextType = editTool === 'start' ? 'start' : editTool === 'finish' ? 'finish' : 'checkpoint'
             const checkpoint: Checkpoint = {
-                id: crypto.randomUUID(),
+                id: generateId('checkpoint'),
                 track_id: '',
                 name: nextType === 'checkpoint' ? `CP ${checkpoints.filter(item => item.type === 'checkpoint').length + 1}` : nextType.toUpperCase(),
                 type: nextType,
                 sort_order: checkpoints.length,
-                position: point,
+                position: snapToSplinePoint(point),
             }
             const withoutSingle = nextType === 'checkpoint' ? checkpoints : checkpoints.filter(item => item.type !== nextType)
             onCheckpointUpdate([...withoutSingle, checkpoint])
@@ -314,7 +312,7 @@ export default function TrackCanvas({
         if (!point) return
         onTrackUpdate([...layoutPoints, point])
         setDragIndex(layoutPoints.length)
-    }, [canvasToPoint, checkpoints, editTool, findNearestIndex, isEditMode, layoutPoints, onCheckpointUpdate, onTrackUpdate])
+    }, [canvasToPoint, checkpoints, editTool, findNearestIndex, isEditMode, layoutPoints, onCheckpointUpdate, onTrackUpdate, snapToSplinePoint])
 
     const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLCanvasElement>) => {
         if (!isEditMode || dragIndex == null || !onTrackUpdate) return


### PR DESCRIPTION
### Motivation
- Remove the duplicated spline-tool button row so each mapper action appears only once in the Track spline mapper UI.
- Fix runtime errors in the Settings panel where image handlers referenced a missing state setter causing `ReferenceError`.
- Make checkpoint/start/finish placement work reliably by avoiding `crypto.randomUUID()` (not available in some environments) and snapping markers to the nearest sampled spline point.

### Description
- Restored the missing track photo load-state setter by adding `const [, setTrackPhotoLoadState] = useState<'idle' | 'loaded' | 'error'>('idle')` and wired it to image load/error handlers and selection logic in `SettingsPanel.tsx`.
- Removed the duplicated tool-button row from the Track spline mapper so `Spline Tool`, `Mark Start`, `Mark Finish`, and `Add Checkpoint` are shown only once in `SettingsPanel.tsx`.
- Replaced `crypto.randomUUID()` with the project helper `generateId('checkpoint')` for checkpoint `id` generation in `TrackCanvas.tsx` to improve browser compatibility.
- Snapped newly placed non-spline markers to the nearest sampled spline point by using `position: snapToSplinePoint(point)` and added `snapToSplinePoint` to the hook dependency list in `TrackCanvas.tsx`.

### Testing
- Ran `pre-commit run --files ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx` and the configured hooks passed for the changed files.
- Ran `make test` in this environment which completed but reported that `colcon` is not installed via the message `colcon not installed` so ROS-level tests were not executed.
- Verified that the Settings panel no longer throws the previous `ReferenceError` and that marker-placement logic now produces checkpoint entries (behavior checked via code inspection and local component wiring).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cafb9ad61c8323b7cf048f2fcf1825)