### PR TITLE
Add racer assignment controls and checkpoint-gated lap tracking

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { TRACK_OVERLAY_EVENT, apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl, getLatestSnapshotUrl, getSelectedTrackId, getTrackCheckpoints, getTrackPhotoUrl, parseTrackRecord, setSelectedTrackId, setTrackCheckpoints, setTrackPhotoUrl } from '@/lib/utils'
+import { TRACK_OVERLAY_EVENT, apiFetch, backendBaseUrl, backendWsUrl, configuredApiBaseUrl, getLatestSnapshotUrl, getSelectedTrackId, getTrackCheckpoints, getTrackPhotoUrl, getTrackRacerAssignments, getTrackingBackend, parseTrackRecord, setSelectedTrackId, setTrackCheckpoints, setTrackPhotoUrl, setTrackRacerAssignments, setTrackingBackend, type TrackingBackend } from '@/lib/utils'
 import { useRaceContext } from '@/stores/raceStore'
 import TrackCanvas from '@/components/track/TrackCanvas'
 import type { Checkpoint, Track, TrackPoint } from '@/types'
@@ -72,7 +72,7 @@ function findNearestSplineIndex(points: TrackPoint[], target: TrackPoint): numbe
 }
 
 export default function SettingsPanel() {
-    const { refreshRaceState } = useRaceContext()
+    const { refreshRaceState, liveRace } = useRaceContext()
     const [wizard, setWizard] = useState<WizardStatus | null>(null)
     const [busyStepId, setBusyStepId] = useState<string | null>(null)
     const [error, setError] = useState('')
@@ -85,6 +85,10 @@ export default function SettingsPanel() {
     const [editorPoints, setEditorPoints] = useState<TrackPoint[]>([])
     const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([])
     const [editTool, setEditTool] = useState<'spline' | 'start' | 'finish' | 'checkpoint'>('spline')
+    const [lapDirection, setLapDirection] = useState<'clockwise' | 'counterclockwise'>('clockwise')
+    const [markerNotice, setMarkerNotice] = useState('')
+    const [trackingBackend, setTrackingBackendState] = useState<TrackingBackend>(getTrackingBackend())
+    const [assignmentDraft, setAssignmentDraft] = useState<Record<string, string>>({})
 
     const selectedTrack = useMemo(
         () => tracks.find(track => track.id === selectedTrackId) || null,
@@ -99,6 +103,7 @@ export default function SettingsPanel() {
             setTrackPhotoLoadState('idle')
             setEditorPoints([])
             setCheckpoints([])
+            setAssignmentDraft({})
             return
         }
         setSelectedTrackIdState(track.id)
@@ -107,6 +112,7 @@ export default function SettingsPanel() {
         setEditorPoints(track.layout_points)
         setTrackPhotoUrlState(getTrackPhotoUrl(track.id) || getLatestSnapshotUrl())
         setCheckpoints(getTrackCheckpoints(track.id))
+        setAssignmentDraft(getTrackRacerAssignments(track.id))
     }
 
     const loadTracks = async () => {
@@ -312,6 +318,8 @@ export default function SettingsPanel() {
                 track_id: selectedTrackId,
                 sort_order: index,
             })))
+            setTrackRacerAssignments(selectedTrackId, assignmentDraft)
+            setTrackingBackend(trackingBackend)
             await loadTracks()
             setError('')
         } catch (err) {
@@ -335,6 +343,17 @@ export default function SettingsPanel() {
         const nearestIndex = findNearestSplineIndex(editorPoints, checkpoint.position)
         const splineText = nearestIndex >= 0 ? ` snapped to spline point #${nearestIndex + 1}` : ''
         setMarkerNotice(`${checkpoint.type.toUpperCase()} marker placed${splineText}.`)
+    }
+
+    const saveAssignments = () => {
+        if (!selectedTrackId) {
+            setError('Select or create a track before saving racer/object assignments.')
+            return
+        }
+        setTrackRacerAssignments(selectedTrackId, assignmentDraft)
+        setTrackingBackend(trackingBackend)
+        setMarkerNotice('Racer tracking assignments saved.')
+        setError('')
     }
 
     return (
@@ -501,6 +520,18 @@ export default function SettingsPanel() {
                                 <option value="counterclockwise">Counter-clockwise</option>
                             </select>
                         </label>
+                        <label className="block text-sm text-[var(--color-text-secondary)]">
+                            Tracking backend
+                            <select
+                                className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+                                value={trackingBackend}
+                                onChange={event => setTrackingBackendState(event.target.value as TrackingBackend)}
+                            >
+                                <option value="yolo">YOLO (recommended)</option>
+                                <option value="isaac">NVIDIA Isaac (placeholder)</option>
+                                <option value="manual">Manual object IDs</option>
+                            </select>
+                        </label>
 
                         <div className="flex flex-wrap gap-2">
                             <button className={`rounded px-3 py-2 text-xs font-semibold text-white ${editTool === 'spline' ? 'bg-blue-500' : 'bg-slate-700 hover:bg-slate-600'}`} type="button" onClick={() => setEditTool('spline')}>Spline Tool</button>
@@ -523,18 +554,25 @@ export default function SettingsPanel() {
                             <p>4. Switch tools to mark <strong>Start</strong>, <strong>Finish</strong>, and additional checkpoints.</p>
                             <p>5. Save, then verify Dashboard dots and markers line up with the track image.</p>
                         </div>
+                        <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-300 space-y-2">
+                            <p><strong>Racer object assignment</strong></p>
+                            <p>Assign the tracker object id for each racer. During race tracking, only assigned objects are annotated and lap-checked.</p>
+                            {(liveRace?.racers || []).map(racer => (
+                                <label key={racer.racer_profile_id} className="block">
+                                    <span className="text-slate-200">{racer.name} (#{racer.number || '?'})</span>
+                                    <input
+                                        className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-white"
+                                        value={assignmentDraft[racer.racer_profile_id] || ''}
+                                        onChange={event => setAssignmentDraft(prev => ({ ...prev, [racer.racer_profile_id]: event.target.value }))}
+                                        placeholder="tracker object id (e.g. yolo-track-17)"
+                                    />
+                                </label>
+                            ))}
+                            <button className="rounded bg-teal-600 px-3 py-2 text-xs font-semibold text-white hover:bg-teal-500" type="button" onClick={saveAssignments}>Save Assignments</button>
+                        </div>
                     </div>
 
                     <div className="rounded border border-slate-700 bg-slate-950/40 p-3">
-                        {trackPhotoUrl ? (
-                            <img
-                                src={trackPhotoUrl}
-                                alt="Track snapshot preview"
-                                className="mb-3 max-h-52 w-full rounded border border-slate-700 object-contain bg-black/30"
-                                onLoad={() => setTrackPhotoLoadState('loaded')}
-                                onError={() => setTrackPhotoLoadState('error')}
-                            />
-                        ) : null}
                         <TrackCanvas
                             racers={[]}
                             layoutPoints={editorPoints}
@@ -543,10 +581,12 @@ export default function SettingsPanel() {
                             editTool={editTool}
                             onTrackUpdate={setEditorPoints}
                             onCheckpointUpdate={setCheckpoints}
+                            onMarkerPlaced={onMarkerPlaced}
                             backgroundImageUrl={trackPhotoUrl || undefined}
                         />
                     </div>
                 </div>
+                {markerNotice ? <p className="text-xs text-emerald-300">{markerNotice}</p> : null}
             </div>
         </div>
     )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
@@ -12,6 +12,8 @@ interface TrackCanvasProps {
     editTool?: EditTool
     onTrackUpdate?: (points: TrackPoint[]) => void
     onCheckpointUpdate?: (checkpoints: Checkpoint[]) => void
+    onMarkerPlaced?: (checkpoint: Checkpoint) => void
+    onBackgroundImageError?: () => void
     backgroundImageUrl?: string
 }
 
@@ -66,6 +68,8 @@ export default function TrackCanvas({
     editTool = 'spline',
     onTrackUpdate,
     onCheckpointUpdate,
+    onMarkerPlaced,
+    onBackgroundImageError,
     backgroundImageUrl,
 }: TrackCanvasProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -93,10 +97,11 @@ export default function TrackCanvas({
                     return
                 }
                 backgroundImageRef.current = null
+                onBackgroundImageError?.()
             }
         }
         loadImage(true)
-    }, [backgroundImageUrl])
+    }, [backgroundImageUrl, onBackgroundImageError])
 
     const splinePoints = useMemo(() => sampleSpline(layoutPoints), [layoutPoints])
 
@@ -290,7 +295,7 @@ export default function TrackCanvas({
             if (!point) return
             const nextType = editTool === 'start' ? 'start' : editTool === 'finish' ? 'finish' : 'checkpoint'
             const checkpoint: Checkpoint = {
-                id: generateId('checkpoint'),
+                id: generateId(),
                 track_id: '',
                 name: nextType === 'checkpoint' ? `CP ${checkpoints.filter(item => item.type === 'checkpoint').length + 1}` : nextType.toUpperCase(),
                 type: nextType,
@@ -299,6 +304,7 @@ export default function TrackCanvas({
             }
             const withoutSingle = nextType === 'checkpoint' ? checkpoints : checkpoints.filter(item => item.type !== nextType)
             onCheckpointUpdate([...withoutSingle, checkpoint])
+            onMarkerPlaced?.(checkpoint)
             return
         }
 
@@ -312,7 +318,7 @@ export default function TrackCanvas({
         if (!point) return
         onTrackUpdate([...layoutPoints, point])
         setDragIndex(layoutPoints.length)
-    }, [canvasToPoint, checkpoints, editTool, findNearestIndex, isEditMode, layoutPoints, onCheckpointUpdate, onTrackUpdate, snapToSplinePoint])
+    }, [canvasToPoint, checkpoints, editTool, findNearestIndex, isEditMode, layoutPoints, onCheckpointUpdate, onMarkerPlaced, onTrackUpdate, snapToSplinePoint])
 
     const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLCanvasElement>) => {
         if (!isEditMode || dragIndex == null || !onTrackUpdate) return

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
@@ -5,6 +5,8 @@ import type { Checkpoint, Track, TrackPoint } from '@/types'
 const TRACK_SELECTION_KEY = 'race-master-pro.selectedTrackId'
 const TRACK_PHOTO_KEY_PREFIX = 'race-master-pro.trackPhoto.'
 const LATEST_SNAPSHOT_KEY = 'race-master-pro.latestSnapshotUrl'
+const TRACK_RACER_ASSIGNMENTS_KEY_PREFIX = 'race-master-pro.trackRacerAssignments.'
+const TRACKING_BACKEND_KEY = 'race-master-pro.trackingBackend'
 export const TRACK_OVERLAY_EVENT = 'j5-track-overlay-updated'
 
 const TRACK_CHECKPOINTS_KEY_PREFIX = 'race-master-pro.trackCheckpoints.'
@@ -258,5 +260,45 @@ export function getTrackCheckpoints(trackId: string): Checkpoint[] {
             }))
     } catch {
         return []
+    }
+}
+
+export type TrackingBackend = 'yolo' | 'isaac' | 'manual'
+
+export function setTrackingBackend(backend: TrackingBackend): void {
+    const storage = getStorage()
+    if (!storage) return
+    storage.setItem(TRACKING_BACKEND_KEY, backend)
+}
+
+export function getTrackingBackend(): TrackingBackend {
+    const storage = getStorage()
+    const value = storage?.getItem(TRACKING_BACKEND_KEY)
+    if (value === 'isaac' || value === 'manual' || value === 'yolo') return value
+    return 'yolo'
+}
+
+export function setTrackRacerAssignments(trackId: string, assignments: Record<string, string>): void {
+    const storage = getStorage()
+    if (!storage || !trackId) return
+    storage.setItem(`${TRACK_RACER_ASSIGNMENTS_KEY_PREFIX}${trackId}`, JSON.stringify(assignments))
+}
+
+export function getTrackRacerAssignments(trackId: string): Record<string, string> {
+    const storage = getStorage()
+    if (!storage || !trackId) return {}
+    const raw = storage.getItem(`${TRACK_RACER_ASSIGNMENTS_KEY_PREFIX}${trackId}`)
+    if (!raw) return {}
+    try {
+        const parsed = JSON.parse(raw)
+        if (!parsed || typeof parsed !== 'object') return {}
+        return Object.entries(parsed).reduce<Record<string, string>>((acc, [racerId, objectId]) => {
+            if (typeof objectId !== 'string') return acc
+            const clean = objectId.trim()
+            if (clean) acc[racerId] = clean
+            return acc
+        }, {})
+    } catch {
+        return {}
     }
 }

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useCallback, useRef, useEffect, type ReactNode } from 'react'
-import type { LiveRaceState, LiveRacer } from '@/types'
-import { apiFetch, backendWsUrl, stringToColor } from '@/lib/utils'
+import type { Checkpoint, LiveRaceState, LiveRacer, TrackPoint } from '@/types'
+import { apiFetch, backendWsUrl, getSelectedTrackId, getTrackCheckpoints, getTrackRacerAssignments, stringToColor } from '@/lib/utils'
 
 export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected'
 
@@ -35,6 +35,19 @@ interface LapRecordResponse {
     racer_profile_id?: string
     lap_number?: number
     lap_time?: number
+}
+
+interface RacerCheckpointState {
+    touchedCheckpointIds: Set<string>
+    insideMarkers: Set<string>
+    lastFinishAtMs: number
+}
+
+const CHECKPOINT_CAPTURE_RADIUS = 0.035
+const FINISH_COOLDOWN_MS = 2000
+
+function pointDistance(a: TrackPoint, b: TrackPoint): number {
+    return Math.hypot(a.x - b.x, a.y - b.y)
 }
 
 function buildLiveRace(statePayload: RuntimeStateResponse, activeRaceId: string, laps: LapRecordResponse[]): LiveRaceState {
@@ -112,6 +125,9 @@ export function RaceProvider({ children }: { children: ReactNode }) {
     const [showTrack, setShowTrack] = useState(true)
     const wsRef = useRef<WebSocket | null>(null)
     const liveRaceRef = useRef<LiveRaceState | null>(null)
+    const checkpointStateRef = useRef<Map<string, RacerCheckpointState>>(new Map())
+    const checkpointsRef = useRef<Checkpoint[]>([])
+    const requiredCheckpointIdsRef = useRef<Set<string>>(new Set())
 
     const toggleTrack = useCallback(() => {
         setShowTrack(prev => !prev)
@@ -172,9 +188,88 @@ export function RaceProvider({ children }: { children: ReactNode }) {
         }
     }, [])
 
+    const evaluateCheckpointProgress = useCallback(async (racerProfileId: string, position: TrackPoint) => {
+        const race = liveRaceRef.current
+        if (!race) return
+        const markers = checkpointsRef.current
+        if (markers.length === 0) return
+
+        const racer = race.racers.find(item => item.racer_profile_id === racerProfileId)
+        if (!racer) return
+
+        const state = checkpointStateRef.current.get(racerProfileId) || {
+            touchedCheckpointIds: new Set<string>(),
+            insideMarkers: new Set<string>(),
+            lastFinishAtMs: 0,
+        }
+
+        for (const marker of markers) {
+            const isInside = pointDistance(position, marker.position) <= CHECKPOINT_CAPTURE_RADIUS
+            const wasInside = state.insideMarkers.has(marker.id)
+
+            if (isInside && !wasInside) {
+                state.insideMarkers.add(marker.id)
+                if (marker.type === 'checkpoint') {
+                    state.touchedCheckpointIds.add(marker.id)
+                } else if (marker.type === 'finish') {
+                    const nowMs = Date.now()
+                    if (nowMs - state.lastFinishAtMs > FINISH_COOLDOWN_MS) {
+                        const required = requiredCheckpointIdsRef.current
+                        const touchedAll = [...required].every(id => state.touchedCheckpointIds.has(id))
+                        if (touchedAll) {
+                            const lapNumber = racer.current_lap + 1
+                            await apiFetch('/api/laps', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({
+                                    race_id: race.race_id,
+                                    racer_profile_id: racerProfileId,
+                                    lap_number: lapNumber,
+                                    lap_time: Math.max(racer.current_lap_time, 1),
+                                }),
+                            })
+                            await apiFetch(`/api/races/${race.race_id}/logs`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} completed lap ${lapNumber}` }),
+                            })
+                        } else {
+                            await apiFetch(`/api/races/${race.race_id}/logs`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} hit finish without all checkpoints (shortcut detected)` }),
+                            })
+                        }
+                        state.touchedCheckpointIds.clear()
+                        state.lastFinishAtMs = nowMs
+                        void refreshRaceState(race.race_id)
+                    }
+                }
+            } else if (!isInside && wasInside) {
+                state.insideMarkers.delete(marker.id)
+            }
+        }
+
+        checkpointStateRef.current.set(racerProfileId, state)
+    }, [refreshRaceState])
+
     useEffect(() => {
         liveRaceRef.current = liveRace
     }, [liveRace])
+
+    useEffect(() => {
+        const hydrateTrackOverlayState = () => {
+            const selectedTrackId = getSelectedTrackId()
+            const markers = selectedTrackId ? getTrackCheckpoints(selectedTrackId) : []
+            checkpointsRef.current = markers
+            requiredCheckpointIdsRef.current = new Set(
+                markers.filter(marker => marker.type === 'checkpoint').map(marker => marker.id),
+            )
+        }
+        hydrateTrackOverlayState()
+        window.addEventListener('j5-track-overlay-updated', hydrateTrackOverlayState)
+        return () => window.removeEventListener('j5-track-overlay-updated', hydrateTrackOverlayState)
+    }, [])
 
     useEffect(() => {
         const wsUrl = backendWsUrl('organizer')
@@ -223,26 +318,47 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                     if (msg.data.racer_profile_id && msg.data) {
                         const x = Number(msg.data.position_x)
                         const y = Number(msg.data.position_y)
+                        const nextPosition = Number.isFinite(x) && Number.isFinite(y)
+                            ? { x, y }
+                            : (msg.data as Partial<LiveRacer>).track_position ?? null
                         updateRacerPosition(
                             msg.data.racer_profile_id as string,
                             {
                                 ...(msg.data as Partial<LiveRacer>),
-                                track_position: Number.isFinite(x) && Number.isFinite(y)
-                                    ? { x, y }
-                                    : (msg.data as Partial<LiveRacer>).track_position ?? null,
+                                track_position: nextPosition,
                             },
                         )
+                        if (nextPosition) {
+                            void evaluateCheckpointProgress(String(msg.data.racer_profile_id), nextPosition)
+                        }
                     }
                     break
                 case 'visionDetection':
-                    if (msg.data.racer_profile_id) {
+                    {
+                        const selectedTrackId = getSelectedTrackId()
+                        const assignments = selectedTrackId ? getTrackRacerAssignments(selectedTrackId) : {}
+                        const incomingObjectId = String(
+                            msg.data.object_id
+                            || msg.data.tracker_id
+                            || msg.data.detection_id
+                            || msg.data.track_id
+                            || '',
+                        ).trim()
+                        let racerId = String(msg.data.racer_profile_id || '').trim()
+                        if (incomingObjectId) {
+                            const match = Object.entries(assignments).find(([, objectId]) => objectId === incomingObjectId)
+                            racerId = match?.[0] || ''
+                        }
+                        if (!racerId) break
+                        if (Object.keys(assignments).length > 0 && !assignments[racerId]) {
+                            break
+                        }
                         const x = Number(msg.data.position_x)
                         const y = Number(msg.data.position_y)
                         if (Number.isFinite(x) && Number.isFinite(y)) {
-                            updateRacerPosition(
-                                String(msg.data.racer_profile_id),
-                                { track_position: { x, y } },
-                            )
+                            const position = { x, y }
+                            updateRacerPosition(racerId, { track_position: position })
+                            void evaluateCheckpointProgress(racerId, position)
                         }
                     }
                     break
@@ -274,7 +390,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                 ws.close()
             }
         }
-    }, [refreshRaceState, updateRacerPosition])
+    }, [evaluateCheckpointProgress, refreshRaceState, updateRacerPosition])
 
     return (
         <RaceContext.Provider value={{


### PR DESCRIPTION
### Motivation
- Provide a workflow to map Start/Finish/Checkpoint markers to the drawn spline and persist them with the track so laps can be validated by crossing the finish after touching all checkpoints. 
- Allow users to bind tracked objects to racer profiles so object detections only update the assigned racers instead of tracking everything in the frame. 
- Offer a simple tracking-backend selection (YOLO now, Isaac placeholder, Manual) so detector backend can be swapped later without reworking race logic. 

### Description
- Settings UI: added a `Tracking backend` selector and per-racer `object id` assignment inputs and save flow, and replaced the stacked preview image with the single `TrackCanvas` render surface to avoid image/spline stacking; saves assignments per-track. (file: `SettingsPanel.tsx`) 
- TrackCanvas: added `onMarkerPlaced` and `onBackgroundImageError` callbacks and fixed checkpoint id generation to use `generateId()`; canvas now notifies Settings when markers are placed. (file: `TrackCanvas.tsx`) 
- Utils: added storage helpers for per-track racer→object assignments and persisted tracking backend choice (`setTrackRacerAssignments`, `getTrackRacerAssignments`, `setTrackingBackend`, `getTrackingBackend`). (file: `lib/utils.ts`) 
- Race store: implemented per-racer checkpoint state tracking, finish-line validation that requires touching all required checkpoints to record a lap (otherwise logs a shortcut), per-racer checkpoint resets after crossing finish, and wired vision-detection handling to only update racers when incoming object ids match assignments (or when no assignments exist). (file: `raceStore.tsx`) 

### Testing
- Ran `pre-commit run --files <changed-files>` and hooks passed (with a recorded deprecation warning for `check-added-large-files` stage). (Succeeded) 
- Ran `make test` in the environment; tool reported `colcon not installed` so Python/ROS tests did not execute here. (Not run due to environment) 
- Attempted frontend build via `npm --prefix ros_ws/src/j5_perception/race-master-pro/frontend run build`; runtime container lacks `vite`/packages (and `tsc` lookup failed due to registry access), so full frontend build could not be validated in this environment. (Not run due to environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb0a4a02cc83239ad31c1ef70d90fa)