### PR TITLE
Fix tracking-to-racer mapping UX and checkpoint/lap persistence issues

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -544,6 +544,12 @@ async def delete_track(track_id: str):
 
 @app.post("/api/racers")
 async def create_racer(data: RacerProfileCreate):
+    existing = await query(
+        "SELECT * FROM racer_profiles WHERE lower(name)=lower(?) OR number=? ORDER BY created_at ASC LIMIT 1",
+        [data.name, data.number],
+    )
+    if existing:
+        return existing[0]
     row = {"id": str(uuid.uuid4()), **data.model_dump()}
     return await insert_row("racer_profiles", row)
 
@@ -1040,15 +1046,23 @@ async def initialize_race_from_wizard():
     )
     racers = []
     for idx, name in enumerate(config.get("racer_names", []), start=1):
-        racer = await insert_row(
-            "racer_profiles",
-            {
-                "id": str(uuid.uuid4()),
-                "name": name,
-                "number": str(idx),
-                "profile_pic": None,
-                "vehicle_description": None,
-            },
+        racer_rows = await query(
+            "SELECT * FROM racer_profiles WHERE lower(name)=lower(?) OR number=? ORDER BY created_at ASC LIMIT 1",
+            [name, str(idx)],
+        )
+        racer = (
+            racer_rows[0]
+            if racer_rows
+            else await insert_row(
+                "racer_profiles",
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": name,
+                    "number": str(idx),
+                    "profile_pic": None,
+                    "vehicle_description": None,
+                },
+            )
         )
         racers.append(racer)
     context = {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/dashboard/Leaderboard.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/dashboard/Leaderboard.tsx
@@ -92,7 +92,7 @@ export default function Leaderboard({ racers, totalLaps }: LeaderboardProps) {
 
                             {/* Expanded Detail */}
                             {isExpanded && (
-                                <div className="slide-in-right ml-10 mr-4 mb-2 p-3 rounded-lg bg-[var(--color-bg-surface)] border border-[rgba(255,255,255,0.06)] grid grid-cols-4 gap-3 text-xs">
+                                <div className="slide-in-right ml-10 mr-4 mb-2 p-3 rounded-lg bg-[var(--color-bg-surface)] border border-[rgba(255,255,255,0.06)] grid grid-cols-5 gap-3 text-xs">
                                     <div>
                                         <div className="text-[var(--color-text-muted)]">Total Time</div>
                                         <div className="font-timing text-sm">{formatLapTime(racer.total_time)}</div>
@@ -110,6 +110,10 @@ export default function Leaderboard({ racers, totalLaps }: LeaderboardProps) {
                                     <div>
                                         <div className="text-[var(--color-text-muted)]">Status</div>
                                         <div className="text-sm font-medium capitalize">{racer.status}</div>
+                                    </div>
+                                    <div>
+                                        <div className="text-[var(--color-text-muted)]">Object ID</div>
+                                        <div className="text-sm font-medium">{racer.tracked_object_id || '—'}</div>
                                     </div>
                                 </div>
                             )}

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/racers/RacerManager.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/racers/RacerManager.tsx
@@ -63,6 +63,18 @@ export default function RacerManager() {
 
     const submitRacer = async (event: FormEvent) => {
         event.preventDefault()
+        const normalizedName = form.name.trim().toLowerCase()
+        const normalizedNumber = form.number.trim()
+        const duplicate = racers.find(existing => {
+            if (form.id && existing.id === form.id) return false
+            const sameName = existing.name.trim().toLowerCase() === normalizedName
+            const sameNumber = normalizedNumber && existing.number.trim() === normalizedNumber
+            return sameName || sameNumber
+        })
+        if (duplicate) {
+            setStatus(`Racer already exists (${duplicate.name} #${duplicate.number || '—'}). Edit the existing profile instead of creating a duplicate.`)
+            return
+        }
         const payload = {
             name: form.name,
             number: form.number,

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -178,6 +178,20 @@ export default function SettingsPanel() {
         return () => window.removeEventListener(TRACK_OVERLAY_EVENT, handleOverlayUpdate)
     }, [selectedTrackId])
 
+    useEffect(() => {
+        if (!selectedTrackId) return
+        setTrackCheckpoints(selectedTrackId, checkpoints.map((checkpoint, index) => ({
+            ...checkpoint,
+            track_id: selectedTrackId,
+            sort_order: index,
+        })))
+    }, [checkpoints, selectedTrackId])
+
+    useEffect(() => {
+        if (!selectedTrackId) return
+        setTrackRacerAssignments(selectedTrackId, assignmentDraft)
+    }, [assignmentDraft, selectedTrackId])
+
     const frontendApiUrl = configuredApiBaseUrl() ?? `same-origin /api → fallback ${backendBaseUrl()}`
     const frontendWsUrl = backendWsUrl('organizer')
 

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch, getSelectedTrackId, parseTrackRecord, setLatestSnapshotUrl, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
+import { apiFetch, getSelectedTrackId, getTrackRacerAssignments, parseTrackRecord, setLatestSnapshotUrl, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
+import { useRaceContext } from '@/stores/raceStore'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -20,6 +21,7 @@ function normalizePreviewBaseUrl(value: string): string {
 }
 
 export default function VisionPanel() {
+    const { liveRace, recentObjectDetections } = useRaceContext()
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
@@ -136,6 +138,7 @@ export default function VisionPanel() {
 
     const trackingEnabled = Boolean(raceContext.tracking_enabled)
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
+    const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
 
     const toggleTracking = async (start: boolean) => {
         const raceId = String(raceContext.race_id || '')
@@ -172,7 +175,7 @@ export default function VisionPanel() {
                     captured, return here to start object tracking and monitor lap-count logs.
                 </p>
                 <p className="text-xs text-[var(--color-text-secondary)]">
-                    The preview stream is raw camera video. Tracked car annotations render on the Dashboard track overlay, not directly on this MJPEG feed.
+                    The preview stream is raw camera video. Use the detection table below to map object IDs to racers; dashboard overlay updates when mapped IDs are seen.
                 </p>
                 <p className="text-xs text-amber-300">
                     Keep the camera stream open in only one viewer at a time. Viewing <code>/stream.mjpg</code> in multiple places can drop the camera connection.
@@ -251,6 +254,27 @@ export default function VisionPanel() {
 
                 {statusMessage ? (
                     <p className={`text-sm ${statusError ? 'text-red-400' : 'text-emerald-400'}`}>{statusMessage}</p>
+                ) : null}
+            </div>
+
+            <div className="race-card p-4 space-y-2">
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Recent object detections</h3>
+                {recentObjectDetections.length === 0 ? <p className="text-xs text-[var(--color-text-secondary)]">No detections yet. Start tracking and assign object IDs in Settings.</p> : null}
+                {recentObjectDetections.length > 0 ? (
+                    <div className="max-h-52 overflow-auto rounded border border-slate-700 bg-slate-950 p-2 text-xs text-slate-200 space-y-1">
+                        {recentObjectDetections.map(item => {
+                            const racer = (liveRace?.racers || []).find(entry => entry.racer_profile_id === item.racerProfileId)
+                            const assignedId = racer ? racerAssignments[racer.racer_profile_id] : ''
+                            const mapped = Boolean(racer && assignedId && assignedId === item.objectId)
+                            return (
+                                <p key={`${item.objectId}-${item.seenAt}`}>
+                                    <span className={mapped ? 'text-emerald-300' : 'text-amber-300'}>{item.objectId}</span>
+                                    {' → '}
+                                    <span>{racer?.name || 'unmapped racer'}</span>
+                                </p>
+                            )
+                        })}
+                    </div>
                 ) : null}
             </div>
 

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -15,6 +15,7 @@ interface RaceContextValue {
     wsRef: React.MutableRefObject<WebSocket | null>
     sendWsMessage: (msg: Record<string, unknown>) => void
     refreshRaceState: (raceId?: string | null) => Promise<void>
+    recentObjectDetections: Array<{ objectId: string, racerProfileId: string, seenAt: number }>
 }
 
 const RaceContext = createContext<RaceContextValue | null>(null)
@@ -39,6 +40,7 @@ interface LapRecordResponse {
 
 interface RacerCheckpointState {
     touchedCheckpointIds: Set<string>
+    nextCheckpointIndex: number
     insideMarkers: Set<string>
     lastFinishAtMs: number
 }
@@ -97,6 +99,7 @@ function buildLiveRace(statePayload: RuntimeStateResponse, activeRaceId: string,
                 gap_to_leader: 0,
                 status: race.status === 'finished' ? 'finished' : 'racing',
                 track_position: null,
+                tracked_object_id: null,
             }
         })
         .sort((a, b) => {
@@ -126,6 +129,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
     const wsRef = useRef<WebSocket | null>(null)
     const liveRaceRef = useRef<LiveRaceState | null>(null)
     const checkpointStateRef = useRef<Map<string, RacerCheckpointState>>(new Map())
+    const [recentObjectDetections, setRecentObjectDetections] = useState<Array<{ objectId: string, racerProfileId: string, seenAt: number }>>([])
     const checkpointsRef = useRef<Checkpoint[]>([])
     const requiredCheckpointIdsRef = useRef<Set<string>>(new Set())
 
@@ -199,9 +203,13 @@ export function RaceProvider({ children }: { children: ReactNode }) {
 
         const state = checkpointStateRef.current.get(racerProfileId) || {
             touchedCheckpointIds: new Set<string>(),
+            nextCheckpointIndex: 0,
             insideMarkers: new Set<string>(),
             lastFinishAtMs: 0,
         }
+        const orderedCheckpoints = markers
+            .filter(marker => marker.type === 'checkpoint')
+            .sort((a, b) => a.sort_order - b.sort_order)
 
         for (const marker of markers) {
             const isInside = pointDistance(position, marker.position) <= CHECKPOINT_CAPTURE_RADIUS
@@ -210,12 +218,22 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             if (isInside && !wasInside) {
                 state.insideMarkers.add(marker.id)
                 if (marker.type === 'checkpoint') {
-                    state.touchedCheckpointIds.add(marker.id)
+                    const expected = orderedCheckpoints[state.nextCheckpointIndex]
+                    if (expected?.id === marker.id) {
+                        state.touchedCheckpointIds.add(marker.id)
+                        state.nextCheckpointIndex += 1
+                    } else if (orderedCheckpoints[0]?.id === marker.id) {
+                        state.touchedCheckpointIds.clear()
+                        state.touchedCheckpointIds.add(marker.id)
+                        state.nextCheckpointIndex = 1
+                    }
                 } else if (marker.type === 'finish') {
                     const nowMs = Date.now()
                     if (nowMs - state.lastFinishAtMs > FINISH_COOLDOWN_MS) {
                         const required = requiredCheckpointIdsRef.current
-                        const touchedAll = [...required].every(id => state.touchedCheckpointIds.has(id))
+                        const touchedAll = orderedCheckpoints.length === 0
+                            || (state.nextCheckpointIndex >= orderedCheckpoints.length
+                                && [...required].every(id => state.touchedCheckpointIds.has(id)))
                         if (touchedAll) {
                             const lapNumber = racer.current_lap + 1
                             await apiFetch('/api/laps', {
@@ -241,6 +259,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                             })
                         }
                         state.touchedCheckpointIds.clear()
+                        state.nextCheckpointIndex = 0
                         state.lastFinishAtMs = nowMs
                         void refreshRaceState(race.race_id)
                     }
@@ -353,11 +372,20 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                         if (Object.keys(assignments).length > 0 && !assignments[racerId]) {
                             break
                         }
+                        if (incomingObjectId) {
+                            setRecentObjectDetections(prev => {
+                                const next = [
+                                    { objectId: incomingObjectId, racerProfileId: racerId, seenAt: Date.now() },
+                                    ...prev.filter(item => !(item.objectId === incomingObjectId && item.racerProfileId === racerId)),
+                                ]
+                                return next.slice(0, 12)
+                            })
+                        }
                         const x = Number(msg.data.position_x)
                         const y = Number(msg.data.position_y)
                         if (Number.isFinite(x) && Number.isFinite(y)) {
                             const position = { x, y }
-                            updateRacerPosition(racerId, { track_position: position })
+                            updateRacerPosition(racerId, { track_position: position, tracked_object_id: incomingObjectId || null })
                             void evaluateCheckpointProgress(racerId, position)
                         }
                     }
@@ -404,6 +432,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             wsRef,
             sendWsMessage,
             refreshRaceState,
+            recentObjectDetections,
         }}>
             {children}
         </RaceContext.Provider>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/types/index.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/types/index.ts
@@ -162,6 +162,7 @@ export interface LiveRacer {
     gap_to_leader: number
     status: RacerStatus
     track_position: TrackPoint | null
+    tracked_object_id?: string | null
 }
 
 export interface LiveRaceState {


### PR DESCRIPTION
### Motivation
- Users could not see annotated objects or match camera object IDs to racers, race setup created duplicate racer profiles, checkpoint markers and start/finish were not persisting across tabs, and lap counting did not require ordered checkpoint traversal.

### Description
- Backend: `POST /api/racers` now checks for an existing racer by name/number and returns it instead of creating duplicates, and the setup initializer (`initialize_race_from_wizard`) reuses existing racers when present.
- Frontend: added `recentObjectDetections` and per-racer `tracked_object_id` to the race store, and updated `handleWsMessage` to record detections and set the tracked object id on detections.
- Checkpoint/lap logic: `evaluateCheckpointProgress` now enforces ordered checkpoint traversal via a `nextCheckpointIndex` and only counts a lap at finish when all ordered checkpoints were seen, then resets progress after finish.
- Persistence & UI: `SettingsPanel` now auto-persists checkpoints (`setTrackCheckpoints`) and racer assignments (`setTrackRacerAssignments`) when edited so they survive tab switches; `VisionPanel` shows a “Recent object detections” list to aid mapping; `Leaderboard` expanded view displays the racer’s `tracked_object_id`; types updated to include `tracked_object_id`; `RacerManager` adds a client-side duplicate check to avoid creating duplicates from the UI.

### Testing
- Ran `pre-commit run --files <changed files>` which passed after auto-formatting (`black` reformatted one file then hooks passed).
- Ran `make test` in this environment which outputs the expected fallback message (`colcon not installed`), so the frontend lint/hooks ran but the ROS test runner could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb15af1c188323945dfda0195c29c1)