### PR TITLE
Add object ID mapping & sequential checkpoint handling; prevent duplicate racers; UI and storage improvements

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -544,6 +544,12 @@ async def delete_track(track_id: str):
 
 @app.post("/api/racers")
 async def create_racer(data: RacerProfileCreate):
+    existing = await query(
+        "SELECT * FROM racer_profiles WHERE lower(name)=lower(?) OR number=? ORDER BY created_at ASC LIMIT 1",
+        [data.name, data.number],
+    )
+    if existing:
+        return existing[0]
     row = {"id": str(uuid.uuid4()), **data.model_dump()}
     return await insert_row("racer_profiles", row)
 
@@ -1040,15 +1046,23 @@ async def initialize_race_from_wizard():
     )
     racers = []
     for idx, name in enumerate(config.get("racer_names", []), start=1):
-        racer = await insert_row(
-            "racer_profiles",
-            {
-                "id": str(uuid.uuid4()),
-                "name": name,
-                "number": str(idx),
-                "profile_pic": None,
-                "vehicle_description": None,
-            },
+        racer_rows = await query(
+            "SELECT * FROM racer_profiles WHERE lower(name)=lower(?) OR number=? ORDER BY created_at ASC LIMIT 1",
+            [name, str(idx)],
+        )
+        racer = (
+            racer_rows[0]
+            if racer_rows
+            else await insert_row(
+                "racer_profiles",
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": name,
+                    "number": str(idx),
+                    "profile_pic": None,
+                    "vehicle_description": None,
+                },
+            )
         )
         racers.append(racer)
     context = {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/dashboard/Leaderboard.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/dashboard/Leaderboard.tsx
@@ -92,7 +92,7 @@ export default function Leaderboard({ racers, totalLaps }: LeaderboardProps) {
 
                             {/* Expanded Detail */}
                             {isExpanded && (
-                                <div className="slide-in-right ml-10 mr-4 mb-2 p-3 rounded-lg bg-[var(--color-bg-surface)] border border-[rgba(255,255,255,0.06)] grid grid-cols-4 gap-3 text-xs">
+                                <div className="slide-in-right ml-10 mr-4 mb-2 p-3 rounded-lg bg-[var(--color-bg-surface)] border border-[rgba(255,255,255,0.06)] grid grid-cols-5 gap-3 text-xs">
                                     <div>
                                         <div className="text-[var(--color-text-muted)]">Total Time</div>
                                         <div className="font-timing text-sm">{formatLapTime(racer.total_time)}</div>
@@ -110,6 +110,10 @@ export default function Leaderboard({ racers, totalLaps }: LeaderboardProps) {
                                     <div>
                                         <div className="text-[var(--color-text-muted)]">Status</div>
                                         <div className="text-sm font-medium capitalize">{racer.status}</div>
+                                    </div>
+                                    <div>
+                                        <div className="text-[var(--color-text-muted)]">Object ID</div>
+                                        <div className="text-sm font-medium">{racer.tracked_object_id || '—'}</div>
                                     </div>
                                 </div>
                             )}

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/racers/RacerManager.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/racers/RacerManager.tsx
@@ -63,6 +63,18 @@ export default function RacerManager() {
 
     const submitRacer = async (event: FormEvent) => {
         event.preventDefault()
+        const normalizedName = form.name.trim().toLowerCase()
+        const normalizedNumber = form.number.trim()
+        const duplicate = racers.find(existing => {
+            if (form.id && existing.id === form.id) return false
+            const sameName = existing.name.trim().toLowerCase() === normalizedName
+            const sameNumber = normalizedNumber && existing.number.trim() === normalizedNumber
+            return sameName || sameNumber
+        })
+        if (duplicate) {
+            setStatus(`Racer already exists (${duplicate.name} #${duplicate.number || '—'}). Edit the existing profile instead of creating a duplicate.`)
+            return
+        }
         const payload = {
             name: form.name,
             number: form.number,

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -53,6 +53,12 @@ function normalizeBaseUrl(value: string): string {
     }
 }
 
+function withCacheBust(url: string): string {
+    if (!url) return ''
+    const separator = url.includes('?') ? '&' : '?'
+    return `${url}${separator}t=${Date.now()}`
+}
+
 function pointDistance(a: TrackPoint, b: TrackPoint): number {
     return Math.hypot(a.x - b.x, a.y - b.y)
 }
@@ -177,6 +183,20 @@ export default function SettingsPanel() {
         window.addEventListener(TRACK_OVERLAY_EVENT, handleOverlayUpdate)
         return () => window.removeEventListener(TRACK_OVERLAY_EVENT, handleOverlayUpdate)
     }, [selectedTrackId])
+
+    useEffect(() => {
+        if (!selectedTrackId) return
+        setTrackCheckpoints(selectedTrackId, checkpoints.map((checkpoint, index) => ({
+            ...checkpoint,
+            track_id: selectedTrackId,
+            sort_order: index,
+        })))
+    }, [checkpoints, selectedTrackId])
+
+    useEffect(() => {
+        if (!selectedTrackId) return
+        setTrackRacerAssignments(selectedTrackId, assignmentDraft)
+    }, [assignmentDraft, selectedTrackId])
 
     const frontendApiUrl = configuredApiBaseUrl() ?? `same-origin /api → fallback ${backendBaseUrl()}`
     const frontendWsUrl = backendWsUrl('organizer')
@@ -330,9 +350,16 @@ export default function SettingsPanel() {
     const useLatestCapture = () => {
         const latest = getLatestSnapshotUrl()
         const previewBase = normalizeBaseUrl(config.preview_url)
-        const fallback = previewBase ? `${previewBase}/snapshot.jpg?t=${Date.now()}` : ''
-        setTrackPhotoUrlState(latest || fallback)
+        const fallback = previewBase ? `${previewBase}/snapshot.jpg` : ''
+        const nextUrl = latest || fallback
+        if (!nextUrl) {
+            setError('No snapshot is available yet. Capture one in the Computer Vision tab first.')
+            return
+        }
+        setTrackPhotoUrlState(withCacheBust(nextUrl))
         setTrackPhotoLoadState('idle')
+        setMarkerNotice('Loaded latest capture into the track mapper preview.')
+        setError('')
     }
 
     const undoSplinePoint = () => {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/track/TrackCanvas.tsx
@@ -82,25 +82,16 @@ export default function TrackCanvas({
             backgroundImageRef.current = null
             return
         }
-        const loadImage = (useAnonymousCors: boolean) => {
-            const image = new Image()
-            if (useAnonymousCors) {
-                image.crossOrigin = 'anonymous'
-            }
-            image.src = backgroundImageUrl
-            image.onload = () => {
-                backgroundImageRef.current = image
-            }
-            image.onerror = () => {
-                if (useAnonymousCors) {
-                    loadImage(false)
-                    return
-                }
-                backgroundImageRef.current = null
-                onBackgroundImageError?.()
-            }
+        const image = new Image()
+        image.crossOrigin = 'anonymous'
+        image.src = backgroundImageUrl
+        image.onload = () => {
+            backgroundImageRef.current = image
         }
-        loadImage(true)
+        image.onerror = () => {
+            backgroundImageRef.current = null
+            onBackgroundImageError?.()
+        }
     }, [backgroundImageUrl, onBackgroundImageError])
 
     const splinePoints = useMemo(() => sampleSpline(layoutPoints), [layoutPoints])

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
-import { apiFetch, getSelectedTrackId, parseTrackRecord, setLatestSnapshotUrl, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
+import { apiFetch, getSelectedTrackId, getTrackRacerAssignments, parseTrackRecord, setLatestSnapshotUrl, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
+import { useRaceContext } from '@/stores/raceStore'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -20,6 +21,7 @@ function normalizePreviewBaseUrl(value: string): string {
 }
 
 export default function VisionPanel() {
+    const { liveRace, recentObjectDetections } = useRaceContext()
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
@@ -136,6 +138,7 @@ export default function VisionPanel() {
 
     const trackingEnabled = Boolean(raceContext.tracking_enabled)
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
+    const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
 
     const toggleTracking = async (start: boolean) => {
         const raceId = String(raceContext.race_id || '')
@@ -172,7 +175,7 @@ export default function VisionPanel() {
                     captured, return here to start object tracking and monitor lap-count logs.
                 </p>
                 <p className="text-xs text-[var(--color-text-secondary)]">
-                    The preview stream is raw camera video. Tracked car annotations render on the Dashboard track overlay, not directly on this MJPEG feed.
+                    The preview stream is raw camera video. Use the detection table below to map object IDs to racers; dashboard overlay updates when mapped IDs are seen.
                 </p>
                 <p className="text-xs text-amber-300">
                     Keep the camera stream open in only one viewer at a time. Viewing <code>/stream.mjpg</code> in multiple places can drop the camera connection.
@@ -251,6 +254,27 @@ export default function VisionPanel() {
 
                 {statusMessage ? (
                     <p className={`text-sm ${statusError ? 'text-red-400' : 'text-emerald-400'}`}>{statusMessage}</p>
+                ) : null}
+            </div>
+
+            <div className="race-card p-4 space-y-2">
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Recent object detections</h3>
+                {recentObjectDetections.length === 0 ? <p className="text-xs text-[var(--color-text-secondary)]">No detections yet. Start tracking and assign object IDs in Settings.</p> : null}
+                {recentObjectDetections.length > 0 ? (
+                    <div className="max-h-52 overflow-auto rounded border border-slate-700 bg-slate-950 p-2 text-xs text-slate-200 space-y-1">
+                        {recentObjectDetections.map(item => {
+                            const racer = (liveRace?.racers || []).find(entry => entry.racer_profile_id === item.racerProfileId)
+                            const assignedId = racer ? racerAssignments[racer.racer_profile_id] : ''
+                            const mapped = Boolean(racer && assignedId && assignedId === item.objectId)
+                            return (
+                                <p key={`${item.objectId}-${item.seenAt}`}>
+                                    <span className={mapped ? 'text-emerald-300' : 'text-amber-300'}>{item.objectId}</span>
+                                    {' → '}
+                                    <span>{racer?.name || 'unmapped racer'}</span>
+                                </p>
+                            )
+                        })}
+                    </div>
                 ) : null}
             </div>
 

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/lib/utils.ts
@@ -233,7 +233,10 @@ export function getLatestSnapshotUrl(): string {
 export function setTrackCheckpoints(trackId: string, checkpoints: Checkpoint[]): void {
     const storage = getStorage()
     if (!storage || !trackId) return
-    storage.setItem(`${TRACK_CHECKPOINTS_KEY_PREFIX}${trackId}`, JSON.stringify(checkpoints))
+    const key = `${TRACK_CHECKPOINTS_KEY_PREFIX}${trackId}`
+    const payload = JSON.stringify(checkpoints)
+    if (storage.getItem(key) === payload) return
+    storage.setItem(key, payload)
     window.dispatchEvent(new CustomEvent(TRACK_OVERLAY_EVENT))
 }
 
@@ -247,17 +250,24 @@ export function getTrackCheckpoints(trackId: string): Checkpoint[] {
         if (!Array.isArray(parsed)) return []
         return parsed
             .filter(item => item && typeof item === 'object')
-            .map(item => ({
-                id: String((item as Checkpoint).id || crypto.randomUUID()),
-                track_id: String((item as Checkpoint).track_id || trackId),
-                name: String((item as Checkpoint).name || 'Checkpoint'),
-                type: ((item as Checkpoint).type || 'checkpoint') as Checkpoint['type'],
-                position: {
-                    x: Number((item as Checkpoint).position?.x || 0),
-                    y: Number((item as Checkpoint).position?.y || 0),
-                },
-                sort_order: Number((item as Checkpoint).sort_order || 0),
-            }))
+            .map((item, index) => {
+                const checkpoint = item as Checkpoint
+                const type = (checkpoint.type || 'checkpoint') as Checkpoint['type']
+                const positionX = Number(checkpoint.position?.x || 0)
+                const positionY = Number(checkpoint.position?.y || 0)
+                const sortOrder = Number(checkpoint.sort_order || 0)
+                return {
+                    id: String(checkpoint.id || `${trackId}-${type}-${sortOrder || index}-${positionX.toFixed(4)}-${positionY.toFixed(4)}`),
+                    track_id: String(checkpoint.track_id || trackId),
+                    name: String(checkpoint.name || 'Checkpoint'),
+                    type,
+                    position: {
+                        x: positionX,
+                        y: positionY,
+                    },
+                    sort_order: sortOrder,
+                }
+            })
     } catch {
         return []
     }
@@ -281,7 +291,11 @@ export function getTrackingBackend(): TrackingBackend {
 export function setTrackRacerAssignments(trackId: string, assignments: Record<string, string>): void {
     const storage = getStorage()
     if (!storage || !trackId) return
-    storage.setItem(`${TRACK_RACER_ASSIGNMENTS_KEY_PREFIX}${trackId}`, JSON.stringify(assignments))
+    const key = `${TRACK_RACER_ASSIGNMENTS_KEY_PREFIX}${trackId}`
+    const payload = JSON.stringify(assignments)
+    if (storage.getItem(key) === payload) return
+    storage.setItem(key, payload)
+    window.dispatchEvent(new CustomEvent(TRACK_OVERLAY_EVENT))
 }
 
 export function getTrackRacerAssignments(trackId: string): Record<string, string> {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -15,6 +15,7 @@ interface RaceContextValue {
     wsRef: React.MutableRefObject<WebSocket | null>
     sendWsMessage: (msg: Record<string, unknown>) => void
     refreshRaceState: (raceId?: string | null) => Promise<void>
+    recentObjectDetections: Array<{ objectId: string, racerProfileId: string, seenAt: number }>
 }
 
 const RaceContext = createContext<RaceContextValue | null>(null)
@@ -39,6 +40,7 @@ interface LapRecordResponse {
 
 interface RacerCheckpointState {
     touchedCheckpointIds: Set<string>
+    nextCheckpointIndex: number
     insideMarkers: Set<string>
     lastFinishAtMs: number
 }
@@ -97,6 +99,7 @@ function buildLiveRace(statePayload: RuntimeStateResponse, activeRaceId: string,
                 gap_to_leader: 0,
                 status: race.status === 'finished' ? 'finished' : 'racing',
                 track_position: null,
+                tracked_object_id: null,
             }
         })
         .sort((a, b) => {
@@ -126,6 +129,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
     const wsRef = useRef<WebSocket | null>(null)
     const liveRaceRef = useRef<LiveRaceState | null>(null)
     const checkpointStateRef = useRef<Map<string, RacerCheckpointState>>(new Map())
+    const [recentObjectDetections, setRecentObjectDetections] = useState<Array<{ objectId: string, racerProfileId: string, seenAt: number }>>([])
     const checkpointsRef = useRef<Checkpoint[]>([])
     const requiredCheckpointIdsRef = useRef<Set<string>>(new Set())
 
@@ -199,9 +203,13 @@ export function RaceProvider({ children }: { children: ReactNode }) {
 
         const state = checkpointStateRef.current.get(racerProfileId) || {
             touchedCheckpointIds: new Set<string>(),
+            nextCheckpointIndex: 0,
             insideMarkers: new Set<string>(),
             lastFinishAtMs: 0,
         }
+        const orderedCheckpoints = markers
+            .filter(marker => marker.type === 'checkpoint')
+            .sort((a, b) => a.sort_order - b.sort_order)
 
         for (const marker of markers) {
             const isInside = pointDistance(position, marker.position) <= CHECKPOINT_CAPTURE_RADIUS
@@ -210,12 +218,22 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             if (isInside && !wasInside) {
                 state.insideMarkers.add(marker.id)
                 if (marker.type === 'checkpoint') {
-                    state.touchedCheckpointIds.add(marker.id)
+                    const expected = orderedCheckpoints[state.nextCheckpointIndex]
+                    if (expected?.id === marker.id) {
+                        state.touchedCheckpointIds.add(marker.id)
+                        state.nextCheckpointIndex += 1
+                    } else if (orderedCheckpoints[0]?.id === marker.id) {
+                        state.touchedCheckpointIds.clear()
+                        state.touchedCheckpointIds.add(marker.id)
+                        state.nextCheckpointIndex = 1
+                    }
                 } else if (marker.type === 'finish') {
                     const nowMs = Date.now()
                     if (nowMs - state.lastFinishAtMs > FINISH_COOLDOWN_MS) {
                         const required = requiredCheckpointIdsRef.current
-                        const touchedAll = [...required].every(id => state.touchedCheckpointIds.has(id))
+                        const touchedAll = orderedCheckpoints.length === 0
+                            || (state.nextCheckpointIndex >= orderedCheckpoints.length
+                                && [...required].every(id => state.touchedCheckpointIds.has(id)))
                         if (touchedAll) {
                             const lapNumber = racer.current_lap + 1
                             await apiFetch('/api/laps', {
@@ -241,6 +259,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                             })
                         }
                         state.touchedCheckpointIds.clear()
+                        state.nextCheckpointIndex = 0
                         state.lastFinishAtMs = nowMs
                         void refreshRaceState(race.race_id)
                     }
@@ -353,11 +372,20 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                         if (Object.keys(assignments).length > 0 && !assignments[racerId]) {
                             break
                         }
+                        if (incomingObjectId) {
+                            setRecentObjectDetections(prev => {
+                                const next = [
+                                    { objectId: incomingObjectId, racerProfileId: racerId, seenAt: Date.now() },
+                                    ...prev.filter(item => !(item.objectId === incomingObjectId && item.racerProfileId === racerId)),
+                                ]
+                                return next.slice(0, 12)
+                            })
+                        }
                         const x = Number(msg.data.position_x)
                         const y = Number(msg.data.position_y)
                         if (Number.isFinite(x) && Number.isFinite(y)) {
                             const position = { x, y }
-                            updateRacerPosition(racerId, { track_position: position })
+                            updateRacerPosition(racerId, { track_position: position, tracked_object_id: incomingObjectId || null })
                             void evaluateCheckpointProgress(racerId, position)
                         }
                     }
@@ -404,6 +432,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             wsRef,
             sendWsMessage,
             refreshRaceState,
+            recentObjectDetections,
         }}>
             {children}
         </RaceContext.Provider>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/types/index.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/types/index.ts
@@ -162,6 +162,7 @@ export interface LiveRacer {
     gap_to_leader: number
     status: RacerStatus
     track_position: TrackPoint | null
+    tracked_object_id?: string | null
 }
 
 export interface LiveRaceState {


### PR DESCRIPTION
### Motivation
- Prevent duplicate racer profiles and reuse existing profiles when initializing a race from the setup wizard.
- Surface object-tracking information in the UI and provide a recent detections view to help map tracked object IDs to racer profiles.
- Enforce sequential checkpoint traversal for lap validation and improve robustness of checkpoint IDs and local storage writes.
- Reduce unnecessary storage events and make track snapshot loading cache-friendly.

### Description
- Backend: `POST /api/racers` now queries for an existing racer by case-insensitive `name` or `number` and returns the existing row instead of creating a duplicate; the wizard initializer also reuses matching `racer_profiles` when creating racers.
- Frontend state: `raceStore` adds `recentObjectDetections`, stores `tracked_object_id` on racers, handles `visionDetection` websocket messages to map object IDs to racers, updates recent detections list, and enforces sequential checkpoint progress with `nextCheckpointIndex` logic.
- Local storage utilities: `getTrackCheckpoints` now produces deterministic checkpoint `id`s and normalizes parsed checkpoint fields, and `setTrackCheckpoints` / `setTrackRacerAssignments` avoid writing unchanged payloads and only dispatch overlay events on real changes.
- UI/UX: Leaderboard expanded detail shows `Object ID`; RacerManager prevents creating client-side duplicates by name/number and shows an explanatory status; SettingsPanel adds `withCacheBust`, auto-sync effects for checkpoints and assignments, and improved `useLatestCapture` handling and messages; VisionPanel shows recent object detections mapped to racers and updates explanatory text; TrackCanvas simplifies image loading with consistent `crossOrigin` handling and error callback invocation.
- Types: `LiveRacer` now optionally includes `tracked_object_id`.

### Testing
- Type-check: frontend TypeScript type-check (`tsc --noEmit`) completed successfully on the modified code.
- Frontend build: the frontend build step completed successfully with the updated files (no type errors during build).
- No new automated unit tests were added for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb15af1c188323945dfda0195c29c1)