### PR TITLE
Expose recentVisionObjects in RaceContext to fix SettingsPanel crash

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -15,6 +15,7 @@ interface RaceContextValue {
     wsRef: React.MutableRefObject<WebSocket | null>
     sendWsMessage: (msg: Record<string, unknown>) => void
     refreshRaceState: (raceId?: string | null) => Promise<void>
+    recentVisionObjects: Array<{ objectId: string, seenAt: number, position: TrackPoint | null }>
     recentObjectDetections: Array<{ objectId: string, racerProfileId: string, seenAt: number }>
 }
 
@@ -136,6 +137,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
     const wsRef = useRef<WebSocket | null>(null)
     const liveRaceRef = useRef<LiveRaceState | null>(null)
     const checkpointStateRef = useRef<Map<string, RacerCheckpointState>>(new Map())
+    const [recentVisionObjects, setRecentVisionObjects] = useState<Array<{ objectId: string, seenAt: number, position: TrackPoint | null }>>([])
     const [recentObjectDetections, setRecentObjectDetections] = useState<Array<{ objectId: string, racerProfileId: string, seenAt: number }>>([])
     const checkpointsRef = useRef<Checkpoint[]>([])
     const requiredCheckpointIdsRef = useRef<Set<string>>(new Set())
@@ -504,6 +506,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             wsRef,
             sendWsMessage,
             refreshRaceState,
+            recentVisionObjects,
             recentObjectDetections,
         }}>
             {children}


### PR DESCRIPTION
### Motivation
- `SettingsPanel` called `.map` on `recentVisionObjects` but the `RaceContext` did not expose this array, causing `Cannot read properties of undefined (reading 'map')` at render time.

### Description
- Added `recentVisionObjects` to the `RaceContextValue` interface so consumers have a typed field.
- Initialized `recentVisionObjects` state in `RaceProvider` and added `setRecentVisionObjects` state variable.
- Included `recentVisionObjects` in the context provider `value` so components like `SettingsPanel` receive a defined array.

### Testing
- Ran `pre-commit run --files ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx`, which passed the configured hooks. 
- Ran `make test` in this environment which reported `colcon not installed` (no further automated tests executed due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda8f80b88832398fb578c3c7178a6)