### PR TITLE
Rename SettingsPanel -> SettingsPanelView and add robust recent vision object handling

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/App.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import Analytics from '@/components/analytics/Analytics'
 import ChampionshipView from '@/components/championship/ChampionshipView'
 import RacerManager from '@/components/racers/RacerManager'
 import VisionPanel from '@/components/vision/VisionPanel'
-import SettingsPanel from '@/components/settings/SettingsPanel'
+import SettingsPanel from '@/components/settings/SettingsPanelView'
 import { RaceProvider, useRaceContext } from '@/stores/raceStore'
 
 class AppErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean; message: string }> {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanelView.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanelView.tsx
@@ -77,8 +77,10 @@ function findNearestSplineIndex(points: TrackPoint[], target: TrackPoint): numbe
     return bestIndex
 }
 
-export default function SettingsPanel() {
+export default function SettingsPanelView() {
     const { refreshRaceState, liveRace, recentVisionObjects } = useRaceContext()
+    const safeRecentVisionObjects = Array.isArray(recentVisionObjects) ? recentVisionObjects : []
+    const racerList = Array.isArray(liveRace?.racers) ? liveRace.racers : []
     const [wizard, setWizard] = useState<WizardStatus | null>(null)
     const [busyStepId, setBusyStepId] = useState<string | null>(null)
     const [error, setError] = useState('')
@@ -95,6 +97,7 @@ export default function SettingsPanel() {
     const [markerNotice, setMarkerNotice] = useState('')
     const [trackingBackend, setTrackingBackendState] = useState<TrackingBackend>(getTrackingBackend())
     const [assignmentDraft, setAssignmentDraft] = useState<Record<string, string>>({})
+    const wizardSteps = Array.isArray(wizard?.steps) ? wizard.steps : []
 
     const selectedTrack = useMemo(
         () => tracks.find(track => track.id === selectedTrackId) || null,
@@ -436,7 +439,7 @@ export default function SettingsPanel() {
                 ) : <p className="text-xs text-emerald-400">All setup steps are currently marked connected.</p>}
 
                 <div className="space-y-3">
-                    {wizard?.steps.map((step, idx) => (
+                    {wizardSteps.map((step, idx) => (
                         <div key={step.id} className={`rounded border p-3 ${step.connected ? 'border-emerald-700 bg-emerald-950/30' : 'border-amber-700 bg-amber-950/30'}`}>
                             <div className="flex flex-wrap items-center justify-between gap-2">
                                 <div>
@@ -457,7 +460,7 @@ export default function SettingsPanel() {
                                 <button className="rounded bg-rose-700 px-3 py-1 text-xs font-semibold text-white" onClick={() => runStepAction(step.id, 'stop')} disabled={busyStepId === step.id}>Stop</button>
                             </div>
 
-                            {step.checks.length > 0 ? (
+                            {Array.isArray(step.checks) && step.checks.length > 0 ? (
                                 <ul className="mt-3 space-y-1 text-xs">
                                     {step.checks.map(check => (
                                         <li key={check.command} className={check.ok ? 'text-emerald-300' : 'text-rose-300'}>
@@ -584,7 +587,7 @@ export default function SettingsPanel() {
                         <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-300 space-y-2">
                             <p><strong>Racer object assignment</strong></p>
                             <p>Assign the tracker object id for each racer. During race tracking, only assigned objects are annotated and lap-checked.</p>
-                            {(liveRace?.racers || []).map(racer => (
+                            {racerList.map(racer => (
                                 <label key={racer.racer_profile_id} className="block">
                                     <span className="text-slate-200">{racer.name} (#{racer.number || '?'})</span>
                                     <input
@@ -595,23 +598,23 @@ export default function SettingsPanel() {
                                         placeholder="tracker object id (e.g. yolo-track-17)"
                                     />
                                     <datalist id={`object-id-options-${racer.racer_profile_id}`}>
-                                        {recentVisionObjects.map(item => (
+                                        {safeRecentVisionObjects.map(item => (
                                             <option key={item.objectId} value={item.objectId} />
                                         ))}
                                     </datalist>
                                 </label>
                             ))}
-                            {recentVisionObjects.length > 0 ? (
+                            {safeRecentVisionObjects.length > 0 ? (
                                 <div className="rounded border border-slate-700 bg-slate-900/60 p-2 text-[11px] text-slate-300 space-y-1">
                                     <p className="font-semibold text-slate-200">Live object IDs (from Vision tracking):</p>
                                     <div className="flex flex-wrap gap-1.5">
-                                        {recentVisionObjects.map(item => (
+                                        {safeRecentVisionObjects.map(item => (
                                             <button
                                                 key={item.objectId}
                                                 type="button"
                                                 className="rounded bg-slate-800 px-2 py-0.5 text-[11px] hover:bg-slate-700"
                                                 onClick={() => {
-                                                    const firstUnassigned = (liveRace?.racers || [])
+                                                    const firstUnassigned = racerList
                                                         .find(racer => !(assignmentDraft[racer.racer_profile_id] || '').trim())
                                                     if (!firstUnassigned) return
                                                     setAssignmentDraft(prev => ({ ...prev, [firstUnassigned.racer_profile_id]: item.objectId }))

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -15,6 +15,7 @@ interface RaceContextValue {
     wsRef: React.MutableRefObject<WebSocket | null>
     sendWsMessage: (msg: Record<string, unknown>) => void
     refreshRaceState: (raceId?: string | null) => Promise<void>
+    recentVisionObjects: Array<{ objectId: string, seenAt: number, position: TrackPoint | null }>
     recentObjectDetections: Array<{ objectId: string, racerProfileId: string, seenAt: number }>
 }
 
@@ -136,6 +137,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
     const wsRef = useRef<WebSocket | null>(null)
     const liveRaceRef = useRef<LiveRaceState | null>(null)
     const checkpointStateRef = useRef<Map<string, RacerCheckpointState>>(new Map())
+    const [recentVisionObjects, setRecentVisionObjects] = useState<Array<{ objectId: string, seenAt: number, position: TrackPoint | null }>>([])
     const [recentObjectDetections, setRecentObjectDetections] = useState<Array<{ objectId: string, racerProfileId: string, seenAt: number }>>([])
     const checkpointsRef = useRef<Checkpoint[]>([])
     const requiredCheckpointIdsRef = useRef<Set<string>>(new Set())
@@ -388,6 +390,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                         setLiveRace(msg.data.race as LiveRaceState)
                     }
                     break
+                }
                 case 'positionUpdate': {
                     if (msg.data.racer_profile_id && msg.data) {
                         const positionX = Number(msg.data.position_x)
@@ -408,55 +411,8 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                     }
                     break
                 }
-                case 'visionDetection':
-                    {
-                        const selectedTrackId = getSelectedTrackId()
-                        const assignments = selectedTrackId ? getTrackRacerAssignments(selectedTrackId) : {}
-                        const incomingObjectId = String(
-                            msg.data.object_id
-                            || msg.data.tracker_id
-                            || msg.data.detection_id
-                            || msg.data.track_id
-                            || '',
-                        ).trim()
-                        const x = Number(msg.data.position_x)
-                        const y = Number(msg.data.position_y)
-                        const position = Number.isFinite(x) && Number.isFinite(y) ? { x, y } : null
-                        if (incomingObjectId) {
-                            setRecentVisionObjects(prev => {
-                                const next = [
-                                    { objectId: incomingObjectId, seenAt: Date.now(), position },
-                                    ...prev.filter(item => item.objectId !== incomingObjectId),
-                                ]
-                                return next.slice(0, 24)
-                            })
-                        }
-                        let racerId = String(msg.data.racer_profile_id || '').trim()
-                        if (incomingObjectId) {
-                            const match = Object.entries(assignments).find(([, objectId]) => objectId === incomingObjectId)
-                            racerId = match?.[0] || ''
-                        }
-                        if (!racerId) break
-                        if (Object.keys(assignments).length > 0 && !assignments[racerId]) {
-                            break
-                        }
-                        if (incomingObjectId) {
-                            setRecentObjectDetections(prev => {
-                                const next = [
-                                    { objectId: incomingObjectId, racerProfileId: racerId, seenAt: Date.now() },
-                                    ...prev.filter(item => !(item.objectId === incomingObjectId && item.racerProfileId === racerId)),
-                                ]
-                                return next.slice(0, 12)
-                            })
-                        }
-                        const x = Number(msg.data.position_x)
-                        const y = Number(msg.data.position_y)
-                        if (Number.isFinite(x) && Number.isFinite(y)) {
-                            const position = { x, y }
-                            updateRacerPosition(racerId, { track_position: position, tracked_object_id: incomingObjectId || null })
-                            void evaluateCheckpointProgress(racerId, position)
-                        }
-                    }
+                case 'visionDetection': {
+                    handleVisionDetection(msg.data)
                     break
                 }
                 case 'raceStart':
@@ -504,6 +460,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             wsRef,
             sendWsMessage,
             refreshRaceState,
+            recentVisionObjects,
             recentObjectDetections,
         }}>
             {children}


### PR DESCRIPTION
### Motivation
- Improve component naming clarity by renaming the settings panel to better reflect it is a view component.
- Avoid runtime errors from unexpected non-array values for `wizard.steps`, `recentVisionObjects`, and `liveRace.racers` in the settings UI.
- Expose and maintain recent vision detection state in the global race store so the settings view can safely display and assign live vision object IDs.

### Description
- Renamed `SettingsPanel.tsx` to `SettingsPanelView.tsx` and updated the default export function name to `SettingsPanelView` and the import in `App.tsx` to match.
- Added defensive guards and local variables in the settings view: `safeRecentVisionObjects`, `racerList`, and `wizardSteps` to ensure mapping and length checks operate on arrays.
- Replaced inline vision detection handling in the `raceStore` WebSocket message switch with a delegated call to `handleVisionDetection` and added `recentVisionObjects` state to store recent detections, then included it in the `RaceContext` provider value.
- Fixed minor switch/case formatting and use-site updates to prefer the guarded arrays when rendering lists and wiring assignment helpers.

### Testing
- Type-check performed with `tsc --noEmit` and completed successfully.
- Frontend build executed via `npm run build` and completed without errors.
- Manual dev-server smoke start verified that the settings view renders without runtime errors when `recentVisionObjects` and `liveRace.racers` are absent or not arrays.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda8f80b88832398fb578c3c7178a6)