### PR TITLE
Fix Settings tab crash by defining liveRacers

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -80,6 +80,7 @@ function findNearestSplineIndex(points: TrackPoint[], target: TrackPoint): numbe
 export default function SettingsPanelView() {
     const { refreshRaceState, liveRace, recentVisionObjects } = useRaceContext()
     const safeRecentVisionObjects = Array.isArray(recentVisionObjects) ? recentVisionObjects : []
+    const liveRacers = useMemo(() => (Array.isArray(liveRace?.racers) ? liveRace.racers : []), [liveRace])
     const [wizard, setWizard] = useState<WizardStatus | null>(null)
     const [busyStepId, setBusyStepId] = useState<string | null>(null)
     const [error, setError] = useState('')


### PR DESCRIPTION
### Motivation
- The Settings tab threw `ReferenceError: liveRacers is not defined` when opened, breaking the racer↔object assignment UI needed for camera-based tracking, so the component must derive a safe racer list from runtime race state.

### Description
- Define `liveRacers` inside `SettingsPanelView` using `useMemo` to return `(Array.isArray(liveRace?.racers) ? liveRace.racers : [])`, ensuring a stable empty-array fallback; change applied in `ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx`.

### Testing
- Ran `pre-commit run --files ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx` which passed the configured hooks, and ran `make test` which completed but reported the environment limitation `colcon not installed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec0679324832389ca2d17918c9710)