### PR TITLE
Standalone camera tracking, CLI, and tracking-start warnings

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -94,12 +94,23 @@ FastAPI service lives on a different host or port.
 ### 3. Run the Perception System
 
 ```bash
-# Standalone mode (no ROS2 needed, uses mock cameras)
-python -m perception.standalone.standalone_runner
+# Standalone mode with a real USB camera (no ROS2 required)
+python -m perception.standalone.standalone_runner \
+  --camera-source /dev/video0 \
+  --camera-id cam1 \
+  --ws-url ws://<api-host>:8080/ws?client_type=cv_system
 
-# ROS2 node mode (requires sourced underlay + overlay in THIS shell)
+# Optional: mock mode for quick UI testing only
+python -m perception.standalone.standalone_runner --use-mock
+
+# ROS2 node mode (requires sourced underlay + overlay in this shell)
 ros2 run racetracker_perception perception_node
 ```
+
+When standalone camera mode is running, it publishes `visionDetection` websocket
+events with object IDs like `cv-track-1`, `cv-track-2`, etc. The **Computer Vision**
+panel will show those IDs in **Recent object detections**, and you can assign
+them to racers in **Settings → Racer tracking assignments**.
 
 If you see `ros2: command not found` here, re-source before running the node:
 
@@ -127,6 +138,20 @@ source ~/j5/ros_ws/install/setup.bash
 ros2 pkg list | rg '^sensor_msgs$'
 python3 -c "from sensor_msgs.msg import Image; print('sensor_msgs OK')"
 ```
+
+### 4. Operator flow for camera-based object tracking
+
+1. Start backend + frontend.
+2. Start camera preview (`scripts/pi_preflight.py --serve-preview ...`) so you can position camera framing.
+3. Start standalone perception camera runner (`python -m perception.standalone.standalone_runner --camera-source /dev/video0 ...`).
+4. In UI **Settings**, initialize race state and assign each racer a live object ID from detections.
+5. In **Computer Vision**, click **Start Tracking**.
+6. In **Dashboard**, verify racer markers move with incoming detections.
+
+If detections do not appear:
+- Confirm the runner is connected to `ws://<api-host>:8080/ws?client_type=cv_system`.
+- Confirm only one process has exclusive access to `/dev/video0`.
+- Move cars clearly across frame (motion-based detector filters static background).
 
 If `sensor_msgs` is still missing, make sure you are building the underlay (not `~/j5/ros_ws`), then re-source both layers:
 

--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -108,7 +108,7 @@ ros2 run racetracker_perception perception_node
 ```
 
 When standalone camera mode is running, it publishes `visionDetection` websocket
-events with object IDs like `cv-track-1`, `cv-track-2`, etc. The **Computer Vision**
+events with object IDs like `cv-cam1-track-1`, `cv-cam1-track-2`, etc. The **Computer Vision**
 panel will show those IDs in **Recent object detections**, and you can assign
 them to racers in **Settings → Racer tracking assignments**.
 

--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -1156,11 +1156,26 @@ async def resume_race_from_snapshot(race_id: str):
 async def start_tracking(race_id: str):
     context = await _get_state_json("race_context", {})
     context["tracking_enabled"] = True
+    cv_system_connections = len(manager.active_connections.get("cv_system", []))
+    warning = None
+    if cv_system_connections == 0:
+        warning = (
+            "Tracking enabled, but no cv_system websocket clients are connected. "
+            "Start the perception runner/ROS2 perception node so detections can be produced."
+        )
     context.setdefault("log_stream", []).append(
         f"{datetime.now().isoformat()} Tracking started for race {race_id}"
     )
+    if warning:
+        context.setdefault("log_stream", []).append(
+            f"{datetime.now().isoformat()} WARNING: {warning}"
+        )
     await _set_state_json("race_context", context)
-    return context
+    return {
+        "context": context,
+        "cv_system_connections": cv_system_connections,
+        "warning": warning,
+    }
 
 
 @app.post("/api/races/{race_id}/tracking/stop")

--- a/ros_ws/src/j5_perception/race-master-pro/docs/PI_DEPLOYMENT_GAP_ANALYSIS.md
+++ b/ros_ws/src/j5_perception/race-master-pro/docs/PI_DEPLOYMENT_GAP_ANALYSIS.md
@@ -37,7 +37,7 @@ This document maps your target architecture to what is already implemented in `r
    - React UI includes dashboard, leaderboard, championship view, racer manager, analytics, track canvas, and settings panels.
 4. **Perception integration path exists**
    - ROS2 node and standalone runner are present.
-   - Standalone runner can stream mock detections over WebSocket for end-to-end flow testing.
+   - Standalone runner can stream mock detections and camera-based motion tracking detections over WebSocket for end-to-end flow testing.
 
 ---
 
@@ -91,6 +91,7 @@ This document maps your target architecture to what is already implemented in `r
    - Guided confirmation and revision screens for racers/cars/race format before green flag.
 3. **Video stream endpoint integration**
    - Publish annotated feed (e.g., RTSP/WebRTC) and embed in browser panel.
+   - Note: object ID tracking events are now available via websocket, but annotated browser video streaming is still pending.
 
 ---
 
@@ -114,4 +115,3 @@ Use this as go/no-go criteria:
 - camera discovered
 - snapshot captured
 - setup summary reviewed and accepted
-

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -150,10 +150,19 @@ export default function VisionPanel() {
         const endpoint = start ? `/api/races/${raceId}/tracking/start` : `/api/races/${raceId}/tracking/stop`
         const response = await apiFetch(endpoint, { method: 'POST' })
         if (response.ok) {
+            const payload = await response.json() as { warning?: string }
             await refreshWizardContext()
+            if (start && payload.warning) {
+                setStatusMessage(payload.warning)
+                setStatusError(true)
+                return
+            }
             setStatusMessage(start ? 'Object tracking started.' : 'Object tracking stopped.')
             setStatusError(false)
+            return
         }
+        setStatusMessage(start ? 'Unable to start object tracking.' : 'Unable to stop object tracking.')
+        setStatusError(true)
     }
 
     return (

--- a/ros_ws/src/j5_perception/race-master-pro/perception/standalone/standalone_runner.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/standalone/standalone_runner.py
@@ -5,8 +5,11 @@ Pushes detections to the backend via WebSocket.
 """
 
 import asyncio
+import argparse
 import json
 import time
+from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Optional
 
 try:
@@ -20,6 +23,82 @@ try:
 except ImportError:
     cv2 = None  # type: ignore
     np = None  # type: ignore
+
+
+@dataclass
+class TrackerState:
+    centroid: tuple[float, float]
+    disappeared: int = 0
+
+
+class SimpleCentroidTracker:
+    """Lightweight centroid tracker for moving objects."""
+
+    def __init__(self, max_disappeared: int = 10, max_distance: float = 80.0):
+        self.max_disappeared = max_disappeared
+        self.max_distance = max_distance
+        self.next_object_id = 1
+        self.objects: OrderedDict[int, TrackerState] = OrderedDict()
+
+    def _register(self, centroid: tuple[float, float]):
+        self.objects[self.next_object_id] = TrackerState(centroid=centroid)
+        self.next_object_id += 1
+
+    def _deregister(self, object_id: int):
+        self.objects.pop(object_id, None)
+
+    def update(
+        self, centroids: list[tuple[float, float]]
+    ) -> OrderedDict[int, TrackerState]:
+        if not centroids:
+            stale_ids: list[int] = []
+            for object_id, state in self.objects.items():
+                state.disappeared += 1
+                if state.disappeared > self.max_disappeared:
+                    stale_ids.append(object_id)
+            for object_id in stale_ids:
+                self._deregister(object_id)
+            return self.objects
+
+        if not self.objects:
+            for centroid in centroids:
+                self._register(centroid)
+            return self.objects
+
+        object_items = list(self.objects.items())
+        object_ids = [item[0] for item in object_items]
+        existing = np.array([item[1].centroid for item in object_items], dtype=float)
+        incoming = np.array(centroids, dtype=float)
+        distances = np.linalg.norm(existing[:, None] - incoming[None, :], axis=2)
+
+        rows = distances.min(axis=1).argsort()
+        used_rows: set[int] = set()
+        used_cols: set[int] = set()
+
+        for row in rows:
+            col = int(distances[row].argmin())
+            if row in used_rows or col in used_cols:
+                continue
+            if float(distances[row, col]) > self.max_distance:
+                continue
+            object_id = object_ids[row]
+            self.objects[object_id].centroid = centroids[col]
+            self.objects[object_id].disappeared = 0
+            used_rows.add(row)
+            used_cols.add(col)
+
+        for row, object_id in enumerate(object_ids):
+            if row in used_rows:
+                continue
+            self.objects[object_id].disappeared += 1
+            if self.objects[object_id].disappeared > self.max_disappeared:
+                self._deregister(object_id)
+
+        for col, centroid in enumerate(centroids):
+            if col not in used_cols:
+                self._register(centroid)
+
+        return self.objects
 
 
 class StandaloneRunner:
@@ -41,6 +120,8 @@ class StandaloneRunner:
         self._ws = None
         self._running = False
         self._captures: dict = {}
+        self._trackers: dict[str, SimpleCentroidTracker] = {}
+        self._background_models: dict[str, object] = {}
 
     async def connect(self):
         """Connect to the backend WebSocket."""
@@ -91,6 +172,13 @@ class StandaloneRunner:
                 cap = cv2.VideoCapture(source)
                 if cap.isOpened():
                     self._captures[cam["id"]] = cap
+                    self._trackers[cam["id"]] = SimpleCentroidTracker()
+                    if cv2 is not None:
+                        self._background_models[cam["id"]] = (
+                            cv2.createBackgroundSubtractorMOG2(
+                                history=500, varThreshold=24, detectShadows=False
+                            )
+                        )
                     print(f"Opened camera: {cam['name']} ({cam['source']})")
                 else:
                     print(f"Failed to open camera: {cam['name']} ({cam['source']})")
@@ -102,6 +190,8 @@ class StandaloneRunner:
         for cap in self._captures.values():
             cap.release()
         self._captures.clear()
+        self._trackers.clear()
+        self._background_models.clear()
 
     async def generate_mock_detections(self) -> list[dict]:
         """Generate mock detections for development/testing."""
@@ -125,11 +215,60 @@ class StandaloneRunner:
 
             detections.append(
                 {
-                    "racer_id": f"racer_{i+1}",
+                    "object_id": f"mock-track-{i+1}",
                     "camera_id": "cam1",
                     "position_x": round(x, 1),
                     "position_y": round(y, 1),
                     "confidence": round(confidence, 3),
+                }
+            )
+        return detections
+
+    async def process_frame(self, cam_id: str, frame) -> list[dict]:
+        """Run lightweight motion-based detection + centroid tracking."""
+        if cv2 is None or np is None:
+            return []
+
+        subtractor = self._background_models.get(cam_id)
+        tracker = self._trackers.get(cam_id)
+        if subtractor is None or tracker is None:
+            return []
+
+        mask = subtractor.apply(frame)
+        mask = cv2.GaussianBlur(mask, (5, 5), 0)
+        _, thresh = cv2.threshold(mask, 200, 255, cv2.THRESH_BINARY)
+        kernel = np.ones((3, 3), dtype=np.uint8)
+        cleaned = cv2.morphologyEx(thresh, cv2.MORPH_OPEN, kernel, iterations=2)
+        cleaned = cv2.dilate(cleaned, kernel, iterations=2)
+
+        contours, _ = cv2.findContours(
+            cleaned, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
+        centroids: list[tuple[float, float]] = []
+        bounds: list[tuple[int, int, int, int]] = []
+        for contour in contours:
+            area = cv2.contourArea(contour)
+            if area < 250:
+                continue
+            x, y, w, h = cv2.boundingRect(contour)
+            if w < 10 or h < 10:
+                continue
+            centroids.append((x + (w / 2.0), y + (h / 2.0)))
+            bounds.append((x, y, w, h))
+
+        tracked = tracker.update(centroids)
+        detections: list[dict] = []
+        for object_id, state in tracked.items():
+            if state.disappeared != 0:
+                continue
+            detections.append(
+                {
+                    "object_id": f"cv-track-{object_id}",
+                    "camera_id": cam_id,
+                    "position_x": round(state.centroid[0], 1),
+                    "position_y": round(state.centroid[1], 1),
+                    "confidence": 0.95,
+                    "bbox_count": len(bounds),
                 }
             )
         return detections
@@ -154,12 +293,11 @@ class StandaloneRunner:
                     detections = await self.generate_mock_detections()
                 else:
                     detections = []
-                    # TODO: Process real frames through AI pipeline
-                    # for cam_id, cap in self._captures.items():
-                    #     ret, frame = cap.read()
-                    #     if ret:
-                    #         dets = await self.process_frame(cam_id, frame)
-                    #         detections.extend(dets)
+                    for cam_id, cap in self._captures.items():
+                        ret, frame = cap.read()
+                        if ret:
+                            dets = await self.process_frame(cam_id, frame)
+                            detections.extend(dets)
 
                 for det in detections:
                     if det["confidence"] >= self.confidence_threshold:
@@ -179,7 +317,30 @@ class StandaloneRunner:
 
 def main():
     """CLI entry point."""
-    runner = StandaloneRunner(use_mock=True, mock_racer_count=4)
+    parser = argparse.ArgumentParser(
+        description="Race Master Pro standalone perception runner"
+    )
+    parser.add_argument(
+        "--ws-url", default="ws://localhost:8080/ws?client_type=cv_system"
+    )
+    parser.add_argument("--camera-source", default="0", help="Camera source index/path")
+    parser.add_argument("--camera-id", default="cam1")
+    parser.add_argument(
+        "--use-mock", action="store_true", help="Use generated mock detections"
+    )
+    parser.add_argument("--mock-racer-count", type=int, default=4)
+    parser.add_argument("--confidence-threshold", type=float, default=0.7)
+    args = parser.parse_args()
+
+    runner = StandaloneRunner(
+        ws_url=args.ws_url,
+        cameras=[
+            {"id": args.camera_id, "name": "Main Camera", "source": args.camera_source}
+        ],
+        use_mock=args.use_mock,
+        mock_racer_count=args.mock_racer_count,
+        confidence_threshold=args.confidence_threshold,
+    )
     asyncio.run(runner.run())
 
 

--- a/ros_ws/src/j5_perception/race-master-pro/perception/standalone/standalone_runner.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/standalone/standalone_runner.py
@@ -76,16 +76,20 @@ class SimpleCentroidTracker:
         used_cols: set[int] = set()
 
         for row in rows:
-            col = int(distances[row].argmin())
-            if row in used_rows or col in used_cols:
+            if row in used_rows:
                 continue
-            if float(distances[row, col]) > self.max_distance:
-                continue
-            object_id = object_ids[row]
-            self.objects[object_id].centroid = centroids[col]
-            self.objects[object_id].disappeared = 0
-            used_rows.add(row)
-            used_cols.add(col)
+            for col in np.argsort(distances[row]):
+                col = int(col)
+                if col in used_cols:
+                    continue
+                if float(distances[row, col]) > self.max_distance:
+                    continue
+                object_id = object_ids[row]
+                self.objects[object_id].centroid = centroids[col]
+                self.objects[object_id].disappeared = 0
+                used_rows.add(row)
+                used_cols.add(col)
+                break
 
         for row, object_id in enumerate(object_ids):
             if row in used_rows:
@@ -215,7 +219,7 @@ class StandaloneRunner:
 
             detections.append(
                 {
-                    "object_id": f"mock-track-{i+1}",
+                    "object_id": f"mock-cam1-track-{i+1}",
                     "camera_id": "cam1",
                     "position_x": round(x, 1),
                     "position_y": round(y, 1),
@@ -263,7 +267,7 @@ class StandaloneRunner:
                 continue
             detections.append(
                 {
-                    "object_id": f"cv-track-{object_id}",
+                    "object_id": f"cv-{cam_id}-track-{object_id}",
                     "camera_id": cam_id,
                     "position_x": round(state.centroid[0], 1),
                     "position_y": round(state.centroid[1], 1),


### PR DESCRIPTION
### Motivation
- Enable real USB camera usage in the standalone perception runner and provide a lightweight motion-based centroid tracker so the system can produce real detections without ROS2.
- Improve operator UX by documenting camera-runner usage and an end-to-end operator flow for camera-based tracking in the README and deployment notes.
- Surface backend-side warnings when tracking is enabled but no `cv_system` websocket clients are connected so operators know why no detections are arriving.

### Description
- Implemented a lightweight centroid tracker and motion-based detector in `perception/standalone/standalone_runner.py`, including `SimpleCentroidTracker`, background subtraction, contour filtering, per-camera trackers, and conversion of tracked objects into `visionDetection` events with `object_id` like `cv-track-<n>`.
- Added CLI arguments to the runner (`--ws-url`, `--camera-source`, `--camera-id`, `--use-mock`, `--mock-racer-count`, `--confidence-threshold`) and switched mock detections to emit `object_id` values (`mock-track-<n>`).
- Backend `start_tracking` endpoint now counts `cv_system` websocket connections, appends a warning into the `race_context` log if none are connected, and returns `cv_system_connections` and `warning` in the response JSON.
- Frontend `VisionPanel` updated to handle the backend warning payload: it reads the returned JSON and surfaces the warning message in the UI when starting tracking fails because no CV clients are connected.
- Documentation updates: expanded `README.md` usage examples for running the standalone runner with a real USB camera, added an operator flow section, and noted that object ID tracking events are available in `PI_DEPLOYMENT_GAP_ANALYSIS.md`.

### Testing
- No automated tests were added or modified for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced30ec080832385ba336b6540c2ff)