### PR TITLE
Lower perception confidence threshold default to 0.5

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/config/default.yaml
+++ b/ros_ws/src/j5_perception/race-master-pro/config/default.yaml
@@ -22,7 +22,7 @@ perception:
   # AI model configuration
   ai_model: "yolov8n"  # Options: yolov8n, yolov8s, yolov8m, yolov8l, custom
   model_path: "perception/models/"
-  confidence_threshold: 0.7
+  confidence_threshold: 0.5
   tracker: "deepsort"  # Options: deepsort, bytetrack
 
   # Camera sources (for standalone mode)

--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
@@ -133,7 +133,7 @@ if ROS2_AVAILABLE:
             # Declare parameters
             self.declare_parameter("camera_topics", ["/camera/cam1/image_raw"])
             self.declare_parameter("model_path", "perception/models/yolov8n.pt")
-            self.declare_parameter("confidence_threshold", 0.7)
+            self.declare_parameter("confidence_threshold", 0.5)
             self.declare_parameter(
                 "ws_url", "ws://localhost:8080/ws?client_type=cv_system"
             )


### PR DESCRIPTION
### Motivation
- Small and medium moving objects were often assigned confidences around the motion-tracker base (≈0.5) and were being filtered out by the previous `0.7` cutoff, leaving the Settings tab with no live object IDs.

### Description
- Set `perception.confidence_threshold` to `0.5` in `ros_ws/src/j5_perception/race-master-pro/config/default.yaml`.
- Change the ROS2 node declared default to `self.declare_parameter("confidence_threshold", 0.5)` in `ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py` so runtime defaults align with the config.

### Testing
- Ran `pre-commit run --files ros_ws/src/j5_perception/race-master-pro/config/default.yaml ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py` and hooks passed.
- Ran `make test` which completed but reported `colcon` is not installed in this environment, so ROS package tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf028993bc83238d8ae717354b5eed)