### PR TITLE
Harden lap logging and add checkpoint log events during active tracking

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -717,6 +717,22 @@ async def update_result(result_id: str, data: RaceResultCreate):
 
 @app.post("/api/laps")
 async def record_lap(data: LapRecordCreate):
+    race = await get_row("races", data.race_id)
+    if not race:
+        raise HTTPException(404, "Race not found")
+    if race.get("status") != "active":
+        raise HTTPException(
+            409,
+            f"Cannot record lap while race status is '{race.get('status')}'. Start or resume the race first.",
+        )
+
+    context = await _get_state_json("race_context", {})
+    if not context.get("tracking_enabled", False):
+        raise HTTPException(
+            409,
+            "Cannot record lap while object tracking is disabled. Start tracking first.",
+        )
+
     row = {"id": str(uuid.uuid4()), **data.model_dump()}
     result = await insert_row("lap_records", row)
     # Broadcast lap complete

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -201,13 +201,10 @@ export function RaceProvider({ children }: { children: ReactNode }) {
         }
     }, [])
 
-    const evaluateCheckpointProgress = useCallback(async (racerProfileId: string, position: TrackPoint) => {
+    const evaluateCheckpointProgress = useCallback((racerProfileId: string, position: TrackPoint) => {
         const race = liveRaceRef.current
         if (!race) return
-        if (race.status !== 'active') {
-            checkpointStateRef.current.delete(racerProfileId)
-            return
-        }
+        if (race.status !== 'active') return
         const markers = checkpointsRef.current
         if (markers.length === 0) return
 
@@ -223,6 +220,13 @@ export function RaceProvider({ children }: { children: ReactNode }) {
         const orderedCheckpoints = markers
             .filter(marker => marker.type === 'checkpoint')
             .sort((a, b) => a.sort_order - b.sort_order)
+        const queueLogEntry = (entry: string) => {
+            void apiFetch(`/api/races/${race.race_id}/logs`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ entry }),
+            })
+        }
 
         for (const marker of markers) {
             const isInside = pointDistance(position, marker.position) <= CHECKPOINT_CAPTURE_RADIUS
@@ -235,28 +239,19 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                     if (expected?.id === marker.id) {
                         state.touchedCheckpointIds.add(marker.id)
                         state.nextCheckpointIndex += 1
-                        await apiFetch(`/api/races/${race.race_id}/logs`, {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} crossed checkpoint ${state.nextCheckpointIndex}/${orderedCheckpoints.length}` }),
-                        })
+                        checkpointStateRef.current.set(racerProfileId, state)
+                        queueLogEntry(`${new Date().toISOString()} ${racer.name} crossed checkpoint ${state.nextCheckpointIndex}/${orderedCheckpoints.length}`)
                     } else if (orderedCheckpoints[0]?.id === marker.id) {
                         state.touchedCheckpointIds.clear()
                         state.touchedCheckpointIds.add(marker.id)
                         state.nextCheckpointIndex = 1
-                        await apiFetch(`/api/races/${race.race_id}/logs`, {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} restarted checkpoint sequence (crossed checkpoint 1/${orderedCheckpoints.length})` }),
-                        })
+                        checkpointStateRef.current.set(racerProfileId, state)
+                        queueLogEntry(`${new Date().toISOString()} ${racer.name} restarted checkpoint sequence (crossed checkpoint 1/${orderedCheckpoints.length})`)
                     } else {
-                        await apiFetch(`/api/races/${race.race_id}/logs`, {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} crossed checkpoint out of order; lap sequence reset` }),
-                        })
                         state.touchedCheckpointIds.clear()
                         state.nextCheckpointIndex = 0
+                        checkpointStateRef.current.set(racerProfileId, state)
+                        queueLogEntry(`${new Date().toISOString()} ${racer.name} crossed checkpoint out of order; lap sequence reset`)
                     }
                 } else if (marker.type === 'finish') {
                     const nowMs = Date.now()
@@ -267,32 +262,31 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                                 && [...required].every(id => state.touchedCheckpointIds.has(id)))
                         if (touchedAll) {
                             const lapNumber = racer.current_lap + 1
-                            await apiFetch('/api/laps', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({
-                                    race_id: race.race_id,
-                                    racer_profile_id: racerProfileId,
-                                    lap_number: lapNumber,
-                                    lap_time: Math.max(racer.current_lap_time, 1),
-                                }),
-                            })
-                            await apiFetch(`/api/races/${race.race_id}/logs`, {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} completed lap ${lapNumber}` }),
-                            })
+                            state.touchedCheckpointIds.clear()
+                            state.nextCheckpointIndex = 0
+                            state.lastFinishAtMs = nowMs
+                            checkpointStateRef.current.set(racerProfileId, state)
+                            void (async () => {
+                                await apiFetch('/api/laps', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({
+                                        race_id: race.race_id,
+                                        racer_profile_id: racerProfileId,
+                                        lap_number: lapNumber,
+                                        lap_time: Math.max(racer.current_lap_time, 1),
+                                    }),
+                                })
+                                queueLogEntry(`${new Date().toISOString()} ${racer.name} completed lap ${lapNumber}`)
+                                void refreshRaceState(race.race_id)
+                            })()
                         } else {
-                            await apiFetch(`/api/races/${race.race_id}/logs`, {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} hit finish without all checkpoints (shortcut detected)` }),
-                            })
+                            queueLogEntry(`${new Date().toISOString()} ${racer.name} hit finish without all checkpoints (shortcut detected)`)
+                            state.touchedCheckpointIds.clear()
+                            state.nextCheckpointIndex = 0
+                            state.lastFinishAtMs = nowMs
+                            checkpointStateRef.current.set(racerProfileId, state)
                         }
-                        state.touchedCheckpointIds.clear()
-                        state.nextCheckpointIndex = 0
-                        state.lastFinishAtMs = nowMs
-                        void refreshRaceState(race.race_id)
                     }
                 }
             } else if (!isInside && wasInside) {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -204,6 +204,10 @@ export function RaceProvider({ children }: { children: ReactNode }) {
     const evaluateCheckpointProgress = useCallback(async (racerProfileId: string, position: TrackPoint) => {
         const race = liveRaceRef.current
         if (!race) return
+        if (race.status !== 'active') {
+            checkpointStateRef.current.delete(racerProfileId)
+            return
+        }
         const markers = checkpointsRef.current
         if (markers.length === 0) return
 
@@ -231,10 +235,28 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                     if (expected?.id === marker.id) {
                         state.touchedCheckpointIds.add(marker.id)
                         state.nextCheckpointIndex += 1
+                        await apiFetch(`/api/races/${race.race_id}/logs`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} crossed checkpoint ${state.nextCheckpointIndex}/${orderedCheckpoints.length}` }),
+                        })
                     } else if (orderedCheckpoints[0]?.id === marker.id) {
                         state.touchedCheckpointIds.clear()
                         state.touchedCheckpointIds.add(marker.id)
                         state.nextCheckpointIndex = 1
+                        await apiFetch(`/api/races/${race.race_id}/logs`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} restarted checkpoint sequence (crossed checkpoint 1/${orderedCheckpoints.length})` }),
+                        })
+                    } else {
+                        await apiFetch(`/api/races/${race.race_id}/logs`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ entry: `${new Date().toISOString()} ${racer.name} crossed checkpoint out of order; lap sequence reset` }),
+                        })
+                        state.touchedCheckpointIds.clear()
+                        state.nextCheckpointIndex = 0
                     }
                 } else if (marker.type === 'finish') {
                     const nowMs = Date.now()


### PR DESCRIPTION
### Motivation
- Prevent laps or checkpoint progress from being recorded while the race is not running or when object tracking is disabled so the system behaves consistently with Start/Pause/Resume semantics.
- Make the lap/tracking log stream more informative so operators can see checkpoint crossings, sequence restarts, and out-of-order resets during a live session.

### Description
- Add backend guardrails in `POST /api/laps` to validate the referenced race exists, that the race `status` is `active`, and that `race_context.tracking_enabled` is true, returning `409` when those conditions are not met. 
- Update frontend `evaluateCheckpointProgress` to ignore checkpoint processing when `race.status !== 'active'` and to clear per-racer checkpoint state when not active. 
- Emit explicit checkpoint log entries from the frontend via `POST /api/races/{race_id}/logs` for in-order checkpoint hits, sequence restarts, and out-of-order crossings so the server log stream and UI show why laps are accepted or rejected. 

### Testing
- Ran `pre-commit run --files ros_ws/src/j5_perception/race-master-pro/backend/app/main.py ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx` and hooks passed (including `black`).
- Executed `make test` and the environment returned `colcon not installed`, so package-level tests were not run in this container. 
- Re-ran `source /opt/ros/iron/setup.bash` and sourcing of the local workspace then `make test` again and the same `colcon not installed` result was observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d930ddde6083239f15338ae1d8b55e)