### PR TITLE
VisionPanel: add tracking quick-start, connection/detection status, and live detection overlay

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -21,7 +21,7 @@ function normalizePreviewBaseUrl(value: string): string {
 }
 
 export default function VisionPanel() {
-    const { liveRace, recentObjectDetections } = useRaceContext()
+    const { connectionStatus, liveRace, recentObjectDetections, recentVisionObjects } = useRaceContext()
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
@@ -139,6 +139,9 @@ export default function VisionPanel() {
     const trackingEnabled = Boolean(raceContext.tracking_enabled)
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
     const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
+    const hasRecentVisionObjects = recentVisionObjects.length > 0
+    const latestVisionSeenAt = recentVisionObjects[0]?.seenAt ?? 0
+    const visionFresh = latestVisionSeenAt > 0 && (Date.now() - latestVisionSeenAt) < 4000
 
     const toggleTracking = async (start: boolean) => {
         const raceId = String(raceContext.race_id || '')
@@ -170,6 +173,22 @@ export default function VisionPanel() {
             <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Computer Vision</h2>
 
             <div className="race-card p-4 space-y-3">
+                <div className="rounded border border-cyan-900/70 bg-cyan-950/30 p-3 text-xs text-cyan-100 space-y-2">
+                    <p className="font-semibold text-cyan-200">Tracking bring-up quick start</p>
+                    <p>Run these commands on the Pi / perception host before pressing <strong>Start Tracking</strong>:</p>
+                    <p><strong>1) Camera preview server</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091 --preview-fps 15
+                    </code>
+                    <p><strong>2) Perception node (choose one)</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        python -m perception.standalone.standalone_runner --camera-source /dev/video0 --camera-id cam1
+                    </code>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        ros2 run racetracker_perception perception_node
+                    </code>
+                    <p>Then in this tab: <strong>Show Live Preview</strong> → <strong>Capture Track Photo</strong> → <strong>Start Tracking</strong>.</p>
+                </div>
                 <label className="block text-sm text-[var(--color-text-secondary)]">
                     Preview server URL
                     <input
@@ -221,12 +240,37 @@ export default function VisionPanel() {
                     </button>
                     <p className="text-xs text-[var(--color-text-secondary)]">Use this only while capturing the track image, then hide it before opening other camera consumers.</p>
                 </div>
+                <div className="rounded border border-slate-700 bg-slate-950/50 px-3 py-2 text-xs text-slate-200">
+                    <p>
+                        Websocket: <span className={connectionStatus === 'connected' ? 'text-emerald-300' : 'text-amber-300'}>{connectionStatus}</span>
+                        {' · '}
+                        Detection stream: <span className={visionFresh ? 'text-emerald-300' : 'text-amber-300'}>{visionFresh ? 'receiving objects' : 'waiting for objects'}</span>
+                    </p>
+                    <p className="mt-1 text-[11px] text-slate-300">
+                        If your ROS2 node is running, this can still show waiting when camera frames are not on the expected topic, no objects are visible yet, or confidence filtering drops detections.
+                    </p>
+                </div>
                 {previewEnabled ? (
-                    <img
-                        src={streamUrl}
-                        alt="Live camera preview"
-                        className="w-full rounded border border-slate-700 bg-black"
-                    />
+                    <div className="relative">
+                        <img
+                            src={streamUrl}
+                            alt="Live camera preview"
+                            className="w-full rounded border border-slate-700 bg-black"
+                        />
+                        <div className="pointer-events-none absolute left-2 top-2 max-w-[65%] space-y-1">
+                            {recentVisionObjects.slice(0, 6).map((item) => (
+                                <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
+                                    {item.objectId}
+                                    {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
+                                </p>
+                            ))}
+                            {!hasRecentVisionObjects ? (
+                                <p className="rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
+                                    No objects received yet. If ROS2 perception is already running, verify active camera topic + visible cars in frame.
+                                </p>
+                            ) : null}
+                        </div>
+                    </div>
                 ) : (
                     <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
                         Live preview is paused to avoid multiple stream consumers.


### PR DESCRIPTION
### Motivation
- Provide operators a quick-start checklist to bring up the camera preview and perception node before starting tracking. 
- Surface websocket and detection stream health so users can tell whether the perception node and topics are producing objects. 
- Make it easy to inspect recent detected object IDs/positions directly on the live preview for faster mapping/debugging. 

### Description
- Extend `useRaceContext` usage to include `connectionStatus` and `recentVisionObjects` and compute `visionFresh` and `hasRecentVisionObjects` for status indicators. 
- Add a “Tracking bring-up quick start” UI block showing example Pi commands (`python3 scripts/pi_preflight.py` and perception node variants) and recommended workflow. 
- Show a compact connection/detection status panel indicating websocket state and whether objects are being received. 
- Render a detection overlay on the live preview that lists up to six recent objects with their `objectId` and `position` coordinates, and a fallback message when no objects are received. 

### Testing
- Ran TypeScript type-check with `tsc --noEmit` and the check passed. 
- Ran linter with `npm run lint` and it passed with no new issues. 
- Executed frontend automated tests with `npm test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d980a149448323b81901ba6d61026a)