### PR TITLE
vision: show connection/status and recent vision objects overlay; add bring-up quick start

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -31,6 +31,7 @@ export default function VisionPanel() {
     const [capturing, setCapturing] = useState(false)
     const [raceContext, setRaceContext] = useState<Record<string, unknown>>({})
     const [activeTrackName, setActiveTrackName] = useState('')
+    const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
 
     const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
     const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
@@ -92,6 +93,15 @@ export default function VisionPanel() {
         void refreshTrackLabel()
     }, [])
 
+    useEffect(() => {
+        const timer = window.setInterval(() => {
+            setStatusNowMs(Date.now())
+        }, 1000)
+        return () => {
+            window.clearInterval(timer)
+        }
+    }, [])
+
     const onCapture = async (event: FormEvent) => {
         event.preventDefault()
         setCapturing(true)
@@ -143,7 +153,7 @@ export default function VisionPanel() {
     const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
     const hasRecentVisionObjects = recentVisionObjects.length > 0
     const latestVisionSeenAt = recentVisionObjects[0]?.seenAt ?? 0
-    const visionFresh = latestVisionSeenAt > 0 && (Date.now() - latestVisionSeenAt) < 4000
+    const visionFresh = latestVisionSeenAt > 0 && (statusNowMs - latestVisionSeenAt) < 4000
 
     const toggleTracking = async (start: boolean) => {
         const raceId = String(raceContext.race_id || '')

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -21,7 +21,9 @@ function normalizePreviewBaseUrl(value: string): string {
 }
 
 export default function VisionPanel() {
-    const { liveRace, recentObjectDetections } = useRaceContext()
+    const raceStore = useRaceContext()
+    const { liveRace, recentObjectDetections, recentVisionObjects } = raceStore
+    const raceConnectionStatus = raceStore?.connectionStatus ?? 'disconnected'
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
@@ -139,6 +141,9 @@ export default function VisionPanel() {
     const trackingEnabled = Boolean(raceContext.tracking_enabled)
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
     const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
+    const hasRecentVisionObjects = recentVisionObjects.length > 0
+    const latestVisionSeenAt = recentVisionObjects[0]?.seenAt ?? 0
+    const visionFresh = latestVisionSeenAt > 0 && (Date.now() - latestVisionSeenAt) < 4000
 
     const toggleTracking = async (start: boolean) => {
         const raceId = String(raceContext.race_id || '')
@@ -170,6 +175,22 @@ export default function VisionPanel() {
             <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Computer Vision</h2>
 
             <div className="race-card p-4 space-y-3">
+                <div className="rounded border border-cyan-900/70 bg-cyan-950/30 p-3 text-xs text-cyan-100 space-y-2">
+                    <p className="font-semibold text-cyan-200">Tracking bring-up quick start</p>
+                    <p>Run these commands on the Pi / perception host before pressing <strong>Start Tracking</strong>:</p>
+                    <p><strong>1) Camera preview server</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091 --preview-fps 15
+                    </code>
+                    <p><strong>2) Perception node (choose one)</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        python -m perception.standalone.standalone_runner --camera-source /dev/video0 --camera-id cam1
+                    </code>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        ros2 run racetracker_perception perception_node
+                    </code>
+                    <p>Then in this tab: <strong>Show Live Preview</strong> → <strong>Capture Track Photo</strong> → <strong>Start Tracking</strong>.</p>
+                </div>
                 <label className="block text-sm text-[var(--color-text-secondary)]">
                     Preview server URL
                     <input
@@ -221,12 +242,37 @@ export default function VisionPanel() {
                     </button>
                     <p className="text-xs text-[var(--color-text-secondary)]">Use this only while capturing the track image, then hide it before opening other camera consumers.</p>
                 </div>
+                <div className="rounded border border-slate-700 bg-slate-950/50 px-3 py-2 text-xs text-slate-200">
+                    <p>
+                        Websocket: <span className={raceConnectionStatus === 'connected' ? 'text-emerald-300' : 'text-amber-300'}>{raceConnectionStatus}</span>
+                        {' · '}
+                        Detection stream: <span className={visionFresh ? 'text-emerald-300' : 'text-amber-300'}>{visionFresh ? 'receiving objects' : 'waiting for objects'}</span>
+                    </p>
+                    <p className="mt-1 text-[11px] text-slate-300">
+                        If your ROS2 node is running, this can still show waiting when camera frames are not on the expected topic, no objects are visible yet, or confidence filtering drops detections.
+                    </p>
+                </div>
                 {previewEnabled ? (
-                    <img
-                        src={streamUrl}
-                        alt="Live camera preview"
-                        className="w-full rounded border border-slate-700 bg-black"
-                    />
+                    <div className="relative">
+                        <img
+                            src={streamUrl}
+                            alt="Live camera preview"
+                            className="w-full rounded border border-slate-700 bg-black"
+                        />
+                        <div className="pointer-events-none absolute left-2 top-2 max-w-[65%] space-y-1">
+                            {recentVisionObjects.slice(0, 6).map((item) => (
+                                <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
+                                    {item.objectId}
+                                    {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
+                                </p>
+                            ))}
+                            {!hasRecentVisionObjects ? (
+                                <p className="rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
+                                    No objects received yet. If ROS2 perception is already running, verify active camera topic + visible cars in frame.
+                                </p>
+                            ) : null}
+                        </div>
+                    </div>
                 ) : (
                     <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
                         Live preview is paused to avoid multiple stream consumers.


### PR DESCRIPTION
### Motivation

- Provide concise bring-up instructions for running the camera preview and perception node so users can start tracking quickly. 
- Surface live connection and detection stream status so operators can confirm websocket and vision data availability. 
- Surface recent vision detections on the preview so object IDs and positions are visible when debugging mapping and tracking.

### Description

- Use `useRaceContext()` into `raceStore` and destructure `recentVisionObjects` and `connectionStatus` to derive `visionFresh` and `hasRecentVisionObjects` for UI state. 
- Add a bring-up quick-start panel with recommended commands to run the preview server and perception node (examples include `python3 scripts/pi_preflight.py` and `ros2 run racetracker_perception perception_node`).
- Add a connection/status panel that shows websocket status and whether detection objects are being received (based on recent vision timestamps). 
- When preview is enabled, render an overlay on the live image that lists up to 6 recent objects (object IDs and positions) or a helpful message when none are received.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d980a149448323b81901ba6d61026a)