### PR TITLE
Vision panel: add quick-start help, live detection status, overlay, and resilient rendering

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -21,7 +21,9 @@ function normalizePreviewBaseUrl(value: string): string {
 }
 
 export default function VisionPanel() {
-    const { liveRace, recentObjectDetections } = useRaceContext()
+    const raceStore = useRaceContext()
+    const { liveRace, recentObjectDetections, recentVisionObjects } = raceStore
+    const connectionStatus = raceStore?.connectionStatus ?? 'disconnected'
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
@@ -29,6 +31,7 @@ export default function VisionPanel() {
     const [capturing, setCapturing] = useState(false)
     const [raceContext, setRaceContext] = useState<Record<string, unknown>>({})
     const [activeTrackName, setActiveTrackName] = useState('')
+    const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
 
     const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
     const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
@@ -90,6 +93,15 @@ export default function VisionPanel() {
         void refreshTrackLabel()
     }, [])
 
+    useEffect(() => {
+        const timer = window.setInterval(() => {
+            setStatusNowMs(Date.now())
+        }, 1000)
+        return () => {
+            window.clearInterval(timer)
+        }
+    }, [])
+
     const onCapture = async (event: FormEvent) => {
         event.preventDefault()
         setCapturing(true)
@@ -139,6 +151,10 @@ export default function VisionPanel() {
     const trackingEnabled = Boolean(raceContext.tracking_enabled)
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
     const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
+    const freshVisionObjects = recentVisionObjects.filter((item) => (statusNowMs - item.seenAt) < 4000)
+    const hasRecentVisionObjects = freshVisionObjects.length > 0
+    const latestVisionSeenAt = recentVisionObjects[0]?.seenAt ?? 0
+    const visionFresh = latestVisionSeenAt > 0 && (statusNowMs - latestVisionSeenAt) < 4000
 
     const toggleTracking = async (start: boolean) => {
         const raceId = String(raceContext.race_id || '')
@@ -165,11 +181,40 @@ export default function VisionPanel() {
         setStatusError(true)
     }
 
-    return (
-        <div className="fade-in space-y-4">
+    try {
+        return (
+            <div className="fade-in space-y-4">
             <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Computer Vision</h2>
 
             <div className="race-card p-4 space-y-3">
+                <div className="rounded border border-cyan-900/70 bg-cyan-950/30 p-3 text-xs text-cyan-100 space-y-2">
+                    <p className="font-semibold text-cyan-200">Tracking bring-up quick start</p>
+                    <p>Run these commands on the Pi / perception host before pressing <strong>Start Tracking</strong>:</p>
+                    <p><strong>1) Camera preview server</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091 --preview-fps 15
+                    </code>
+                    <p><strong>2) Perception node (choose one)</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        python -m perception.standalone.standalone_runner --camera-source /dev/video0 --camera-id cam1
+                    </code>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
+                        ros2 run racetracker_perception perception_node
+                    </code>
+                    <p>Then in this tab: <strong>Show Live Preview</strong> → <strong>Capture Track Photo</strong> → <strong>Start Tracking</strong>.</p>
+                </div>
+                <div className="rounded border border-indigo-900/70 bg-indigo-950/30 p-3 text-xs text-indigo-100 space-y-2">
+                    <p className="font-semibold text-indigo-200">Computer Vision step-by-step (camera → tracking → lap checks)</p>
+                    <ol className="list-decimal space-y-1 pl-4">
+                        <li>Start camera preview on the Pi (command above), then click <strong>Show Live Preview</strong> in this tab.</li>
+                        <li>Click <strong>Capture Track Photo</strong> so Settings can load the same image for spline + checkpoints.</li>
+                        <li>Start perception (<code>standalone_runner</code> or <code>ros2 run racetracker_perception perception_node</code>), then click <strong>Start Tracking</strong>.</li>
+                        <li>Confirm live object IDs appear in the preview overlay and in <strong>Recent object detections</strong>.</li>
+                        <li>Open <strong>Settings → Racer tracking assignments</strong>, map each racer to an object ID, and save assignments.</li>
+                        <li>Drive a test lap crossing the configured finish gate and confirm entries in <strong>Lap / Tracking Logs</strong> before race start.</li>
+                    </ol>
+                    <p className="text-[11px] text-indigo-200/90">After this passes, return to Settings to initialize/start the race lifecycle controls.</p>
+                </div>
                 <label className="block text-sm text-[var(--color-text-secondary)]">
                     Preview server URL
                     <input
@@ -221,12 +266,37 @@ export default function VisionPanel() {
                     </button>
                     <p className="text-xs text-[var(--color-text-secondary)]">Use this only while capturing the track image, then hide it before opening other camera consumers.</p>
                 </div>
+                <div className="rounded border border-slate-700 bg-slate-950/50 px-3 py-2 text-xs text-slate-200">
+                    <p>
+                        Websocket: <span className={connectionStatus === 'connected' ? 'text-emerald-300' : 'text-amber-300'}>{connectionStatus}</span>
+                        {' · '}
+                        Detection stream: <span className={visionFresh ? 'text-emerald-300' : 'text-amber-300'}>{visionFresh ? 'receiving objects' : 'waiting for objects'}</span>
+                    </p>
+                    <p className="mt-1 text-[11px] text-slate-300">
+                        If your ROS2 node is running, this can still show waiting when camera frames are not on the expected topic, no objects are visible yet, or confidence filtering drops detections.
+                    </p>
+                </div>
                 {previewEnabled ? (
-                    <img
-                        src={streamUrl}
-                        alt="Live camera preview"
-                        className="w-full rounded border border-slate-700 bg-black"
-                    />
+                    <div className="relative">
+                        <img
+                            src={streamUrl}
+                            alt="Live camera preview"
+                            className="w-full rounded border border-slate-700 bg-black"
+                        />
+                        <div className="pointer-events-none absolute left-2 top-2 max-w-[65%] space-y-1">
+                            {freshVisionObjects.slice(0, 6).map((item) => (
+                                <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
+                                    {item.objectId}
+                                    {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
+                                </p>
+                            ))}
+                            {!hasRecentVisionObjects ? (
+                                <p className="rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
+                                    No objects received yet. If ROS2 perception is already running, verify active camera topic + visible cars in frame.
+                                </p>
+                            ) : null}
+                        </div>
+                    </div>
                 ) : (
                     <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
                         Live preview is paused to avoid multiple stream consumers.
@@ -296,6 +366,19 @@ export default function VisionPanel() {
                     ))}
                 </div>
             </div>
-        </div>
-    )
+            </div>
+        )
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return (
+            <div className="fade-in space-y-4">
+                <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Computer Vision</h2>
+                <div className="race-card p-4 space-y-2">
+                    <p className="text-sm text-red-300">Vision panel rendering failed, but the app recovered.</p>
+                    <p className="text-xs text-[var(--color-text-secondary)]">Please refresh this tab and restart the frontend dev server if the error persists.</p>
+                    <p className="text-xs text-amber-300 break-all">Error: {message}</p>
+                </div>
+            </div>
+        )
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide operators with step-by-step bring-up guidance for getting camera preview and perception running before starting tracking. 
- Surface live system health (websocket + detection stream) and recent object visibility to help diagnose connectivity and topic issues. 
- Improve UI resilience so rendering errors in the vision panel do not break the entire app. 

### Description
- Replace direct destructuring of `useRaceContext()` with `raceStore` and read `connectionStatus` and `recentVisionObjects` from the store. 
- Add a per-second clock (`statusNowMs`) and compute `freshVisionObjects`, `hasRecentVisionObjects`, and `visionFresh` to indicate recent object detections. 
- Add two informational cards with quick-start commands (camera preview + perception launch) and a step-by-step checklist, plus a compact status row showing websocket and detection-stream states. 
- Show live preview overlayed with up to six recent object IDs and positions, add messaging when no objects are received, and wrap the component render in a `try/catch` that returns a graceful error panel on failure. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d980a149448323b81901ba6d61026a)