### PR TITLE
Add perception Integration tab to verify camera / ROS2 / YOLO wiring

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/App.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import ChampionshipView from '@/components/championship/ChampionshipView'
 import RacerManager from '@/components/racers/RacerManager'
 import VisionPanel from '@/components/vision/VisionPanel'
 import SettingsPanel from '@/components/settings/SettingsPanel'
+import IntegrationCheckPanel from '@/components/vision/IntegrationCheckPanel'
 import { RaceProvider, useRaceContext } from '@/stores/raceStore'
 
 class AppErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean; message: string }> {
@@ -52,6 +53,8 @@ function AppContent() {
                 return <RacerManager />
             case 'vision':
                 return <VisionPanel />
+            case 'integration':
+                return <IntegrationCheckPanel />
             case 'settings':
                 return <SettingsPanel />
             default:

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/layout/VerticalTabs.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/layout/VerticalTabs.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, BarChart3, Trophy, Users, Camera, Settings } from 'lucide-react'
+import { LayoutDashboard, BarChart3, Trophy, Users, Camera, Settings, FlaskConical } from 'lucide-react'
 import type { ViewTab } from '@/types'
 
 interface VerticalTabsProps {
@@ -12,6 +12,7 @@ const tabs: { id: ViewTab; icon: typeof LayoutDashboard; label: string }[] = [
     { id: 'championship', icon: Trophy, label: 'Championship' },
     { id: 'racers', icon: Users, label: 'Racers' },
     { id: 'vision', icon: Camera, label: 'Vision' },
+    { id: 'integration', icon: FlaskConical, label: 'Integration' },
     { id: 'settings', icon: Settings, label: 'Settings' },
 ]
 

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useRaceContext } from '@/stores/raceStore'
 
 function defaultPreviewBaseUrl(): string {
@@ -23,9 +23,19 @@ export default function IntegrationCheckPanel() {
     const { connectionStatus, recentVisionObjects, recentObjectDetections, liveRace } = useRaceContext()
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
+    const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
     const lastVisionSeenAt = recentVisionObjects[0]?.seenAt || 0
-    const secondsSinceVision = lastVisionSeenAt ? Math.max(0, Math.floor((Date.now() - lastVisionSeenAt) / 1000)) : null
+    const secondsSinceVision = lastVisionSeenAt ? Math.max(0, Math.floor((statusNowMs - lastVisionSeenAt) / 1000)) : null
     const raceStatus = liveRace?.status || 'setup'
+
+    useEffect(() => {
+        const timer = window.setInterval(() => {
+            setStatusNowMs(Date.now())
+        }, 1000)
+        return () => {
+            window.clearInterval(timer)
+        }
+    }, [])
 
     return (
         <div className="fade-in space-y-4">

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from 'react'
+import { useRaceContext } from '@/stores/raceStore'
+
+function defaultPreviewBaseUrl(): string {
+    if (typeof window === 'undefined') {
+        return 'http://localhost:8091'
+    }
+    return `http://${window.location.hostname}:8091`
+}
+
+function normalizePreviewBaseUrl(value: string): string {
+    const raw = value.trim()
+    if (!raw) return ''
+    try {
+        const parsed = new URL(raw)
+        return `${parsed.protocol}//${parsed.host}`
+    } catch {
+        return raw.replace(/\/$/, '')
+    }
+}
+
+export default function IntegrationCheckPanel() {
+    const { connectionStatus, recentVisionObjects, recentObjectDetections, liveRace } = useRaceContext()
+    const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
+    const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
+    const lastVisionSeenAt = recentVisionObjects[0]?.seenAt || 0
+    const secondsSinceVision = lastVisionSeenAt ? Math.max(0, Math.floor((Date.now() - lastVisionSeenAt) / 1000)) : null
+    const raceStatus = liveRace?.status || 'setup'
+
+    return (
+        <div className="fade-in space-y-4">
+            <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Perception Integration Check</h2>
+
+            <div className="race-card p-4 space-y-3 text-sm">
+                <p className="text-[var(--color-text-secondary)]">
+                    Use this page to verify camera preview, ROS2 perception, and websocket updates without running the full race flow.
+                </p>
+
+                <div className="rounded border border-slate-700 bg-slate-950/70 p-3 space-y-2 text-xs text-slate-200">
+                    <p><strong>1) Camera preview process</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091 --preview-fps 15
+                    </code>
+                    <p><strong>2) Perception process (choose one)</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        python -m perception.standalone.standalone_runner --camera-source /dev/video0 --camera-id cam1
+                    </code>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        ros2 run racetracker_perception perception_node
+                    </code>
+                </div>
+            </div>
+
+            <div className="race-card p-4 space-y-3">
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Live module status</h3>
+                <ul className="space-y-2 text-sm">
+                    <li>
+                        UI websocket:{' '}
+                        <span className={connectionStatus === 'connected' ? 'text-emerald-300' : 'text-amber-300'}>
+                            {connectionStatus}
+                        </span>
+                    </li>
+                    <li>
+                        Vision object stream:{' '}
+                        <span className={secondsSinceVision !== null && secondsSinceVision <= 3 ? 'text-emerald-300' : 'text-amber-300'}>
+                            {secondsSinceVision === null ? 'waiting for objects' : `${secondsSinceVision}s since last object`}
+                        </span>
+                    </li>
+                    <li>
+                        Detection events in memory:{' '}
+                        <span className={recentObjectDetections.length > 0 ? 'text-emerald-300' : 'text-amber-300'}>
+                            {recentObjectDetections.length}
+                        </span>
+                    </li>
+                    <li>
+                        Race runtime status:{' '}
+                        <span className={raceStatus === 'active' ? 'text-emerald-300' : 'text-slate-300'}>{raceStatus}</span>
+                    </li>
+                </ul>
+            </div>
+
+            <div className="race-card p-4 space-y-2">
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Quick links</h3>
+                <label className="block text-sm text-[var(--color-text-secondary)]">
+                    Preview server URL
+                    <input
+                        className="mt-1 w-full rounded border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-white"
+                        value={previewBaseUrl}
+                        onChange={(event) => setPreviewBaseUrl(event.target.value)}
+                        placeholder="http://192.168.1.134:8091"
+                    />
+                </label>
+                <div className="flex flex-wrap gap-2 text-xs">
+                    <a
+                        className="rounded bg-slate-700 px-3 py-2 font-semibold text-white hover:bg-slate-600"
+                        href={`${normalizedBaseUrl}/stream.mjpg`}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        Open camera stream
+                    </a>
+                    <a
+                        className="rounded bg-slate-700 px-3 py-2 font-semibold text-white hover:bg-slate-600"
+                        href={`${normalizedBaseUrl}/snapshot.jpg`}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        Open latest snapshot
+                    </a>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -2,10 +2,6 @@ import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { apiFetch, getSelectedTrackId, getTrackRacerAssignments, parseTrackRecord, setLatestSnapshotUrl, setSelectedTrackId, setTrackPhotoUrl } from '@/lib/utils'
 import { useRaceContext } from '@/stores/raceStore'
 
-// Module-scope fallback to prevent runtime ReferenceError if a stale bundle references
-// `connectionStatus` without declaring it in component scope.
-let connectionStatus = 'disconnected'
-
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
         return 'http://localhost:8091'
@@ -25,7 +21,7 @@ function normalizePreviewBaseUrl(value: string): string {
 }
 
 export default function VisionPanel() {
-    const { liveRace, recentObjectDetections, recentVisionObjects } = useRaceContext()
+    const { liveRace, recentObjectDetections, recentVisionObjects, connectionStatus } = useRaceContext()
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const [previewEnabled, setPreviewEnabled] = useState(false)
     const [statusMessage, setStatusMessage] = useState('')
@@ -154,6 +150,8 @@ export default function VisionPanel() {
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
     const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
     const hasRecentVisionObjects = recentVisionObjects.length > 0
+    const latestVisionObject = recentVisionObjects[0]
+    const visionFresh = Boolean(latestVisionObject && statusNowMs - latestVisionObject.seenAt <= 3000)
 
     const toggleTracking = async (start: boolean) => {
         const raceId = String(raceContext.race_id || '')

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/types/index.ts
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/types/index.ts
@@ -205,6 +205,7 @@ export type ViewTab =
     | 'championship'
     | 'racers'
     | 'vision'
+    | 'integration'
     | 'settings'
 
 // ── Config ─────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Provide a lightweight, dedicated place in the frontend to verify camera preview, YOLO/ROS2 perception, and websocket updates without running the full race workflow.

### Description
- Add a new `IntegrationCheckPanel` component with bring-up command snippets, live status indicators for UI websocket state, vision-object freshness, detection counts, and quick links to open `stream.mjpg` and `snapshot.jpg` from a configurable preview host.
- Wire the new panel into the app by importing it in `App.tsx` and adding an `integration` tab route in the switch used to render content.
- Add the `integration` tab to the sidebar by updating `VerticalTabs.tsx` and importing the `FlaskConical` icon for the new tab.
- Update `ViewTab` union in `types/index.ts` and adjust `VisionPanel.tsx` to consume `connectionStatus` from context and derive `visionFresh` from recent vision object timestamps so module health is shown consistently.

### Testing
- Ran `pre-commit run --files <changed files>` and hooks passed (`trailing-whitespace`, `end-of-file-fixer`, `check-added-large-files`).
- Ran `make test` but full ROS/colcon tests could not execute in this environment because `/opt/ros/iron/setup.bash` and `colcon` were not available; the Makefile printed a fallback message indicating `colcon` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14452d07083239c7ecbc6b679368a)