### PR TITLE
Add embedded camera preview, ROS2 helper commands, and tracking health to IntegrationCheckPanel

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -22,11 +22,16 @@ function normalizePreviewBaseUrl(value: string): string {
 export default function IntegrationCheckPanel() {
     const { connectionStatus, recentVisionObjects, recentObjectDetections, liveRace } = useRaceContext()
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
+    const [previewEnabled, setPreviewEnabled] = useState(true)
+    const [copiedCommand, setCopiedCommand] = useState('')
     const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
+    const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
     const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
     const lastVisionSeenAt = recentVisionObjects[0]?.seenAt || 0
     const secondsSinceVision = lastVisionSeenAt ? Math.max(0, Math.floor((statusNowMs - lastVisionSeenAt) / 1000)) : null
     const raceStatus = liveRace?.status || 'setup'
+    const hasRecentVisionObjects = recentVisionObjects.length > 0
+    const visionIsFresh = secondsSinceVision !== null && secondsSinceVision <= 3
 
     useEffect(() => {
         const timer = window.setInterval(() => {
@@ -37,13 +42,30 @@ export default function IntegrationCheckPanel() {
         }
     }, [])
 
+    const topicListCommand = 'ros2 topic list'
+    const topicHzCommand = 'ros2 topic hz /camera/cam1/image_raw'
+    const topicEchoCommand = 'ros2 topic echo /camera/cam1/image_raw --once'
+    const rerunPerceptionAutodiscoverCommand = 'ros2 run racetracker_perception perception_node --ros-args -p auto_discover_camera_topics:=true'
+    const rerunPerceptionTopicCommand = "ros2 run racetracker_perception perception_node --ros-args -p camera_topics:=\"['/camera/cam1/image_raw']\""
+
+    const copyCommand = async (label: string, command: string) => {
+        try {
+            await navigator.clipboard.writeText(command)
+            setCopiedCommand(`${label} copied`)
+            window.setTimeout(() => setCopiedCommand(''), 1800)
+        } catch {
+            setCopiedCommand('Clipboard blocked (copy manually)')
+            window.setTimeout(() => setCopiedCommand(''), 1800)
+        }
+    }
+
     return (
         <div className="fade-in space-y-4">
             <h2 className="text-xl font-semibold text-[var(--color-text-primary)]">Perception Integration Check</h2>
 
             <div className="race-card p-4 space-y-3 text-sm">
                 <p className="text-[var(--color-text-secondary)]">
-                    Use this page to verify camera preview, ROS2 perception, and websocket updates without running the full race flow.
+                    Use this page to verify camera video, ROS2 perception, and websocket updates without running the full race flow.
                 </p>
 
                 <div className="rounded border border-slate-700 bg-slate-950/70 p-3 space-y-2 text-xs text-slate-200">
@@ -58,6 +80,19 @@ export default function IntegrationCheckPanel() {
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
                         ros2 run racetracker_perception perception_node
                     </code>
+                    <p><strong>3) Validate perception topics (quick checks)</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        {topicListCommand}
+                    </code>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        {topicHzCommand}
+                    </code>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        {topicEchoCommand}
+                    </code>
+                    <p className="text-[11px] text-slate-300">
+                        Use the camera topic name shown by the topic list command if your stream is not on <code>/camera/cam1/image_raw</code>.
+                    </p>
                 </div>
             </div>
 
@@ -83,14 +118,29 @@ export default function IntegrationCheckPanel() {
                         </span>
                     </li>
                     <li>
+                        Tracking health:{' '}
+                        <span className={visionIsFresh && recentObjectDetections.length > 0 ? 'text-emerald-300' : 'text-amber-300'}>
+                            {visionIsFresh && recentObjectDetections.length > 0 ? 'active detections' : 'camera up but no confirmed detections yet'}
+                        </span>
+                    </li>
+                    <li>
                         Race runtime status:{' '}
                         <span className={raceStatus === 'active' ? 'text-emerald-300' : 'text-slate-300'}>{raceStatus}</span>
                     </li>
                 </ul>
             </div>
 
-            <div className="race-card p-4 space-y-2">
-                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Quick links</h3>
+            <div className="race-card p-4 space-y-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Live camera + object activity</h3>
+                    <button
+                        type="button"
+                        className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                        onClick={() => setPreviewEnabled(prev => !prev)}
+                    >
+                        {previewEnabled ? 'Hide embedded camera' : 'Show embedded camera'}
+                    </button>
+                </div>
                 <label className="block text-sm text-[var(--color-text-secondary)]">
                     Preview server URL
                     <input
@@ -100,24 +150,105 @@ export default function IntegrationCheckPanel() {
                         placeholder="http://192.168.1.134:8091"
                     />
                 </label>
-                <div className="flex flex-wrap gap-2 text-xs">
-                    <a
-                        className="rounded bg-slate-700 px-3 py-2 font-semibold text-white hover:bg-slate-600"
-                        href={`${normalizedBaseUrl}/stream.mjpg`}
-                        target="_blank"
-                        rel="noreferrer"
-                    >
-                        Open camera stream
-                    </a>
-                    <a
-                        className="rounded bg-slate-700 px-3 py-2 font-semibold text-white hover:bg-slate-600"
-                        href={`${normalizedBaseUrl}/snapshot.jpg`}
-                        target="_blank"
-                        rel="noreferrer"
-                    >
-                        Open latest snapshot
-                    </a>
+                {previewEnabled ? (
+                    <div className="relative">
+                        <img
+                            src={streamUrl}
+                            alt="Embedded camera stream"
+                            className="w-full rounded border border-slate-700 bg-black"
+                        />
+                        <div className="pointer-events-none absolute left-2 top-2 max-w-[70%] space-y-1">
+                            {recentVisionObjects.slice(0, 6).map((item) => (
+                                <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
+                                    {item.objectId}
+                                    {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
+                                </p>
+                            ))}
+                            {!hasRecentVisionObjects ? (
+                                <p className="rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
+                                    No object IDs yet. Move an object through frame and verify ROS2 topics below.
+                                </p>
+                            ) : null}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
+                        Embedded camera preview is paused.
+                    </div>
+                )}
+                <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-1">
+                    <p className="font-semibold text-slate-100">If tracking still does not start, check this in order:</p>
+                    <p>• Camera stream loads in this panel and updates continuously.</p>
+                    <p>• <code>ros2 topic hz /camera/cam1/image_raw</code> reports a steady frame rate.</p>
+                    <p>• <code>ros2 topic echo /camera/cam1/image_raw --once</code> returns a frame message (update topic if needed).</p>
+                    <p>• Detection count in this tab increases from 0 and “seconds since last object” stays low.</p>
                 </div>
+            </div>
+
+            <div className="race-card p-4 space-y-3">
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Quick calibration helpers</h3>
+                <p className="text-xs text-[var(--color-text-secondary)]">
+                    The browser cannot run ROS2 commands directly, but these buttons copy common calibration/topic commands so you can paste them into your robot terminal quickly.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                    <button
+                        type="button"
+                        className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                        onClick={() => void copyCommand('topic list', topicListCommand)}
+                    >
+                        Copy topic list command
+                    </button>
+                    <button
+                        type="button"
+                        className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                        onClick={() => void copyCommand('topic hz', topicHzCommand)}
+                    >
+                        Copy image FPS command
+                    </button>
+                    <button
+                        type="button"
+                        className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                        onClick={() => void copyCommand('topic echo', topicEchoCommand)}
+                    >
+                        Copy object echo command
+                    </button>
+                </div>
+                <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-2">
+                    <p className="font-semibold text-slate-100">Common ROS2 perception restart commands</p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        {rerunPerceptionAutodiscoverCommand}
+                    </code>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        {rerunPerceptionTopicCommand}
+                    </code>
+                    <div className="flex flex-wrap gap-2">
+                        <button
+                            type="button"
+                            className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                            onClick={() => void copyCommand('auto-discover restart', rerunPerceptionAutodiscoverCommand)}
+                        >
+                            Copy auto-discover restart
+                        </button>
+                        <button
+                            type="button"
+                            className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
+                            onClick={() => void copyCommand('camera topic restart', rerunPerceptionTopicCommand)}
+                        >
+                            Copy camera topic restart
+                        </button>
+                    </div>
+                    <p className="text-[11px] text-slate-300">
+                        These commands restart the perception node with explicit parameters and avoid relying on optional <code>ros2 param</code> CLI support.
+                    </p>
+                </div>
+                {copiedCommand ? <p className="text-xs text-emerald-300">{copiedCommand}</p> : null}
+            </div>
+
+            <div className="race-card p-4 space-y-2 text-xs text-slate-200">
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">How IDs flow into race tracking</h3>
+                <p>1) Object IDs that appear here are the same IDs suggested in the Settings tab assignment fields.</p>
+                <p>2) Saved assignments are reused by tracking logic to map object IDs → racer IDs.</p>
+                <p>3) During an active race, mapped detections update racer position, trigger checkpoint/finish events, and write lap records/log entries.</p>
             </div>
         </div>
     )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -5,7 +5,7 @@ function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
         return 'http://localhost:8091'
     }
-    return `http://${window.location.hostname}:8091`
+    return `${window.location.protocol}//${window.location.hostname}:8091`
 }
 
 function normalizePreviewBaseUrl(value: string): string {
@@ -29,9 +29,15 @@ export default function IntegrationCheckPanel() {
     const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
     const lastVisionSeenAt = recentVisionObjects[0]?.seenAt || 0
     const secondsSinceVision = lastVisionSeenAt ? Math.max(0, Math.floor((statusNowMs - lastVisionSeenAt) / 1000)) : null
+    const lastDetectionSeenAt = recentObjectDetections[0]?.seenAt || 0
+    const secondsSinceDetection = lastDetectionSeenAt ? Math.max(0, Math.floor((statusNowMs - lastDetectionSeenAt) / 1000)) : null
     const raceStatus = liveRace?.status || 'setup'
     const hasRecentVisionObjects = recentVisionObjects.length > 0
     const visionIsFresh = secondsSinceVision !== null && secondsSinceVision <= 3
+    const detectionsAreFresh = secondsSinceDetection !== null && secondsSinceDetection <= 3
+    const insecurePreviewFromSecurePage = typeof window !== 'undefined'
+        && window.location.protocol === 'https:'
+        && normalizedBaseUrl.startsWith('http://')
 
     useEffect(() => {
         const timer = window.setInterval(() => {
@@ -119,8 +125,8 @@ export default function IntegrationCheckPanel() {
                     </li>
                     <li>
                         Tracking health:{' '}
-                        <span className={visionIsFresh && recentObjectDetections.length > 0 ? 'text-emerald-300' : 'text-amber-300'}>
-                            {visionIsFresh && recentObjectDetections.length > 0 ? 'active detections' : 'camera up but no confirmed detections yet'}
+                        <span className={visionIsFresh && detectionsAreFresh ? 'text-emerald-300' : 'text-amber-300'}>
+                            {visionIsFresh && detectionsAreFresh ? 'active detections' : 'camera up but no confirmed detections yet'}
                         </span>
                     </li>
                     <li>
@@ -150,6 +156,12 @@ export default function IntegrationCheckPanel() {
                         placeholder="http://192.168.1.134:8091"
                     />
                 </label>
+                {insecurePreviewFromSecurePage ? (
+                    <p className="text-xs text-amber-300">
+                        This page is HTTPS, but preview URL is HTTP. Embedded preview may be blocked by browser mixed-content policy.
+                        Use the open-stream fallback link below or switch preview URL to HTTPS if available.
+                    </p>
+                ) : null}
                 {previewEnabled ? (
                     <div className="relative">
                         <img
@@ -176,6 +188,16 @@ export default function IntegrationCheckPanel() {
                         Embedded camera preview is paused.
                     </div>
                 )}
+                <div className="flex flex-wrap gap-2 text-xs">
+                    <a
+                        className="rounded bg-slate-700 px-3 py-2 font-semibold text-white hover:bg-slate-600"
+                        href={streamUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        Open stream in new tab (fallback)
+                    </a>
+                </div>
                 <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-1">
                     <p className="font-semibold text-slate-100">If tracking still does not start, check this in order:</p>
                     <p>• Camera stream loads in this panel and updates continuously.</p>


### PR DESCRIPTION
### Motivation
- Improve the developer-facing perception integration page to make it easier to verify camera video, ROS2 topics, and object-tracking without running a full race.
- Provide quick copyable ROS2 commands and restart helpers so operators can run checks from the robot terminal faster.
- Surface tracking health and recent object IDs to help diagnose when the camera stream is live but detections are not being confirmed.

### Description
- Added an embedded MJPEG preview with a `previewEnabled` toggle and `streamUrl` computed from the normalized preview base URL.`
- Overlaid recent object IDs/positions on the preview and added a `Tracking health` status line using `visionIsFresh` and detection count.
- Introduced copyable ROS2 helper commands (`ros2 topic list`, `ros2 topic hz ...`, `ros2 topic echo ...`) and perception restart examples with a `copyCommand` function and `copiedCommand` feedback state.
- Reworked panel layout and explanatory text into separate sections for live camera/activity, quick calibration helpers, and a short description of how IDs flow into tracking logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a2a35c0483239ee64507a3764969)