### PR TITLE
Perception node: optional YOLO model loading with graceful fallback to motion detection

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
@@ -167,6 +167,24 @@ if ROS2_AVAILABLE:
             self.ws_url = (
                 self.get_parameter("ws_url").get_parameter_value().string_value
             )
+            self.motion_min_area = 180.0
+            self.motion_min_box_size = 10
+            self.yolo_target_classes: set[int] = set()
+            self._yolo_model = None
+            if YOLO is not None:
+                try:
+                    self._yolo_model = YOLO(self.model_path)
+                    self.get_logger().info(
+                        f"Loaded YOLO model from {Path(self.model_path).resolve()}"
+                    )
+                except Exception as exc:
+                    self.get_logger().warning(
+                        f"Failed to load YOLO model '{self.model_path}': {exc}. Falling back to motion detection only."
+                    )
+            else:
+                self.get_logger().warning(
+                    "ultralytics not available; running motion detection only."
+                )
             self._ws_stop = threading.Event()
             self._ws_thread = None
             self._detection_queue: queue.Queue[dict] = queue.Queue(maxsize=128)


### PR DESCRIPTION
### Motivation

- Enable object detection when an Ultralytics YOLO model is available while preserving existing motion-only operation if not.
- Provide clear runtime diagnostics when model loading fails or the `ultralytics` package is not installed.

### Description

- Added default parameters `motion_min_area` and `motion_min_box_size` and fields `yolo_target_classes` and `_yolo_model` to the perception node.
- Attempt to load a YOLO model using `YOLO(self.model_path)` and log a success message with the resolved model path when loading succeeds.
- Log a warning and fall back to motion-only detection if model loading raises an exception or if `ultralytics` (the `YOLO` symbol) is not available.
- Left existing subscription, tracking, and queue setup intact so motion detection continues to function as before when no model is present.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91249cea083238dbf6c5d9f420210)