### PR TITLE
Add YOLO model loading and motion-fallback detection flow

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
@@ -448,8 +448,6 @@ if ROS2_AVAILABLE:
             if not candidates and self.fallback_to_motion_tracking:
                 candidates = self._motion_candidates(frame, subtractor)
                 detection_source = "motion"
-            if not candidates:
-                return
             centroids = [centroid for centroid, _confidence in candidates]
 
             tracked = tracker.update(centroids)

--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
@@ -167,6 +167,26 @@ if ROS2_AVAILABLE:
             self.ws_url = (
                 self.get_parameter("ws_url").get_parameter_value().string_value
             )
+            self.motion_min_area = 180.0
+            self.motion_min_box_size = 10
+            self.yolo_target_classes: set[int] = set()
+            self.fallback_to_motion_tracking = True
+            self._yolo_model = None
+            self._detections_sent = 0
+            if YOLO is not None:
+                try:
+                    self._yolo_model = YOLO(self.model_path)
+                    self.get_logger().info(
+                        f"Loaded YOLO model from {Path(self.model_path).resolve()}"
+                    )
+                except Exception as exc:
+                    self.get_logger().warning(
+                        f"Failed to load YOLO model '{self.model_path}': {exc}. Falling back to motion detection only."
+                    )
+            else:
+                self.get_logger().warning(
+                    "ultralytics not available; running motion detection only."
+                )
             self._ws_stop = threading.Event()
             self._ws_thread = None
             self._detection_queue: queue.Queue[dict] = queue.Queue(maxsize=128)
@@ -424,8 +444,12 @@ if ROS2_AVAILABLE:
                 return
 
             candidates = self._yolo_candidates(frame)
+            detection_source = "yolo"
             if not candidates and self.fallback_to_motion_tracking:
                 candidates = self._motion_candidates(frame, subtractor)
+                detection_source = "motion"
+            if not candidates:
+                return
             centroids = [centroid for centroid, _confidence in candidates]
 
             tracked = tracker.update(centroids)


### PR DESCRIPTION
### Motivation
- Enable optional object detection using a YOLO model while retaining existing motion-based tracking as a fallback.
- Make model loading more robust with informative logging and a graceful fallback when the `ultralytics` package or model file is unavailable.
- Track detection metadata and prepare internal state for distinguishing detection sources.

### Description
- Add configuration defaults and internal fields: `motion_min_area`, `motion_min_box_size`, `yolo_target_classes`, `fallback_to_motion_tracking`, `_yolo_model`, and `_detections_sent`.
- Attempt to load the YOLO model via `YOLO(self.model_path)` inside a `try/except` and log success or a warning on failure, and warn when `ultralytics` is not available.
- Modify the image processing flow to prefer YOLO candidates first, set a `detection_source` to either `yolo` or `motion`, fallback to motion candidates when YOLO yields none, and return early if no candidates remain.
- Preserve existing tracker/background initialization and queue behavior while enriching logs about the model path and runtime configuration.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91249cea083238dbf6c5d9f420210)