### PR TITLE
Require active cv_system connection before starting tracking

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -1171,26 +1171,33 @@ async def resume_race_from_snapshot(race_id: str):
 @app.post("/api/races/{race_id}/tracking/start")
 async def start_tracking(race_id: str):
     context = await _get_state_json("race_context", {})
-    context["tracking_enabled"] = True
     cv_system_connections = len(manager.active_connections.get("cv_system", []))
-    warning = None
     if cv_system_connections == 0:
         warning = (
-            "Tracking enabled, but no cv_system websocket clients are connected. "
-            "Start the perception runner/ROS2 perception node so detections can be produced."
+            "Cannot start tracking because no cv_system websocket clients are connected. "
+            "Start the perception runner/ROS2 perception node so detections can be produced, then retry."
         )
-    context.setdefault("log_stream", []).append(
-        f"{datetime.now().isoformat()} Tracking started for race {race_id}"
-    )
-    if warning:
+        context["tracking_enabled"] = False
         context.setdefault("log_stream", []).append(
             f"{datetime.now().isoformat()} WARNING: {warning}"
         )
+        await _set_state_json("race_context", context)
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": warning,
+                "cv_system_connections": cv_system_connections,
+            },
+        )
+    context["tracking_enabled"] = True
+    context.setdefault("log_stream", []).append(
+        f"{datetime.now().isoformat()} Tracking started for race {race_id}"
+    )
     await _set_state_json("race_context", context)
     return {
         "context": context,
         "cv_system_connections": cv_system_connections,
-        "warning": warning,
+        "warning": None,
     }
 
 

--- a/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
+++ b/ros_ws/src/j5_perception/race-master-pro/backend/app/main.py
@@ -1177,7 +1177,6 @@ async def start_tracking(race_id: str):
             "Cannot start tracking because no cv_system websocket clients are connected. "
             "Start the perception runner/ROS2 perception node so detections can be produced, then retry."
         )
-        context["tracking_enabled"] = False
         context.setdefault("log_stream", []).append(
             f"{datetime.now().isoformat()} WARNING: {warning}"
         )

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -53,7 +53,7 @@ export default function IntegrationCheckPanel() {
     const autodiscoverCommand = 'ros2 param set /racetracker_perception auto_discover_camera_topics true'
     const cameraTopicCommand = "ros2 param set /racetracker_perception camera_topics \"['/camera/cam1/image_raw']\""
     const lapEventPublishCommand =
-        "ros2 topic pub /race/lap_event std_msgs/msg/String '{data: \"{\\\"raceId\\\":\\\"demo-race\\\",\\\"carId\\\":\\\"car-7\\\",\\\"sessionLap\\\":1,\\\"lapTimeMs\\\":70000,\\\"trackDistanceM\\\":350.0,\\\"validity\\\":{\\\"onTrack\\\":true,\\\"directionOk\\\":true,\\\"minLapTimeOk\\\":true}}\"}' --once"
+        "ros2 topic pub /race/lap_event std_msgs/msg/String '{data: \"{\\\"raceId\\\":\\\"demo-race\\\",\\\"carId\\\":\\\"car-7\\\",\\\"sessionLap\\\":1,\\\"lapTimeMs\\\":70000,\\\"trackDistanceM\\\":350.0,\\\"validity\\\":{\\\"onTrack\\\":true,\\\"directionOk\\\":true,\\\"minLapTimeOk\\\":true}}\"}' --once -w 0"
 
     return (
         <div className="fade-in space-y-4">
@@ -103,6 +103,10 @@ export default function IntegrationCheckPanel() {
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
                         {lapEventPublishCommand}
                     </code>
+                    <p className="text-[11px] text-slate-300">
+                        This command only validates the ROS lap-event bridge path. It does <strong>not</strong> create Computer Vision detections by itself.
+                        If it waits for subscribers, either start your bridge subscriber first or keep <code>-w 0</code> to publish without waiting.
+                    </p>
                 </div>
             </div>
 

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -174,7 +174,18 @@ export default function VisionPanel() {
             setStatusError(false)
             return
         }
-        setStatusMessage(start ? 'Unable to start object tracking.' : 'Unable to stop object tracking.')
+        let failureMessage = start ? 'Unable to start object tracking.' : 'Unable to stop object tracking.'
+        try {
+            const payload = await response.json() as { detail?: string | { message?: string } }
+            if (typeof payload.detail === 'string' && payload.detail.trim()) {
+                failureMessage = payload.detail
+            } else if (payload.detail && typeof payload.detail.message === 'string' && payload.detail.message.trim()) {
+                failureMessage = payload.detail.message
+            }
+        } catch {
+            // keep default fallback message
+        }
+        setStatusMessage(failureMessage)
         setStatusError(true)
     }
 


### PR DESCRIPTION
### Motivation
- Prevent operators from enabling race tracking when no perception (cv_system) websocket client is connected, which created a misleading “tracking enabled but no detections” state.
- Surface useful backend failure details in the UI so operators see the exact reason a start request failed.
- Clarify the ROS smoke-test guidance to avoid `ros2 topic pub` hanging when no subscribers are present.

### Description
- Change `/api/races/{race_id}/tracking/start` to refuse enabling tracking if `cv_system` websocket connections are zero, log a warning in `race_context`, and return HTTP `409` with a structured `detail` payload instead of silently enabling tracking (`ros_ws/src/j5_perception/race-master-pro/backend/app/main.py`).
- Set `tracking_enabled` only after verifying active `cv_system` connections and include the tracking start log entry only on success (`race_context` updated accordingly).
- Update the Computer Vision UI (`VisionPanel.tsx`) to parse backend error payloads and display server-provided messages (including `detail.message`) instead of always showing a generic failure string.
- Update the Integration Check UI (`IntegrationCheckPanel.tsx`) to add `-w 0` to the example `ros2 topic pub` command and include text explaining that publishing a lap event does not produce CV detections and may wait for subscribers.

### Testing
- Ran `pre-commit run --files` for the modified files and the configured hooks passed (black, trailing-whitespace, end-of-file-fixer, etc.).
- Ran `make test`; the target executed but the environment lacks `colcon`, producing `/bin/sh: 1: colcon not installed` (no runtime integration tests executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b8bd5908323b433b5a1977123eb)