### PR TITLE
Update IntegrationCheckPanel ROS2 commands and troubleshooting flow

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -48,7 +48,8 @@ export default function IntegrationCheckPanel() {
     const topicEchoCommand = 'ros2 topic echo /camera/cam1/image_raw --once'
     const topicInfoCommand = 'ros2 topic info /camera/cam1/image_raw -v'
     const nodeListCommand = 'ros2 node list'
-    const ros2SourceCommand = 'source ~/ros2_kilted/install/setup.bash && source ~/j5/ros_ws/install/setup.bash'
+    const ros2SourceCommand =
+        'if [ -f ~/ros2_kilted/install/setup.bash ]; then source ~/ros2_kilted/install/setup.bash; elif [ -f /opt/ros/iron/setup.bash ]; then source /opt/ros/iron/setup.bash; else echo "Missing ROS underlay setup.bash"; fi; if [ -f ~/j5/ros_ws/install/setup.bash ]; then source ~/j5/ros_ws/install/setup.bash; elif [ -f ~/alive/j5/ros_ws/install/setup.bash ]; then source ~/alive/j5/ros_ws/install/setup.bash; else echo "Missing j5 workspace setup.bash"; fi'
     const perceptionRunCommand =
         'ros2 run racetracker_perception perception_node --ros-args --log-level info -p camera_topics:=[/camera/cam1/image_raw] -p auto_discover_camera_topics:=true'
     const lapEventPublishCommand =

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -43,16 +43,14 @@ export default function IntegrationCheckPanel() {
         }
     }, [])
 
-    const topicListCommand = 'ros2 topic list | grep -E "camera|image"'
-    const topicTypeCommand = 'ros2 topic type /camera/cam1/image_raw'
+    const topicListCommand = 'ros2 topic list -t | rg -n "Image|CompressedImage|camera|video"'
+    const topicHzCommand = 'ros2 topic hz /camera/cam1/image_raw'
+    const topicEchoCommand = 'ros2 topic echo /camera/cam1/image_raw --once'
     const topicInfoCommand = 'ros2 topic info /camera/cam1/image_raw -v'
     const nodeListCommand = 'ros2 node list'
-    const perceptionLogsCommand = 'ros2 run racetracker_perception perception_node --ros-args --log-level info'
-    const ros2CliCheckCommand = 'ros2 node -h && ros2 topic -h && ros2 param -h'
-    const ros2SourceCommand =
-        'if [ -f ~/ros2_kilted/install/setup.bash ]; then source ~/ros2_kilted/install/setup.bash; elif [ -f /opt/ros/iron/setup.bash ]; then source /opt/ros/iron/setup.bash; fi && if [ -f ~/alive/j5/ros_ws/install/setup.bash ]; then source ~/alive/j5/ros_ws/install/setup.bash; elif [ -f ~/j5/ros_ws/install/setup.bash ]; then source ~/j5/ros_ws/install/setup.bash; fi'
-    const autodiscoverCommand = 'ros2 param set /racetracker_perception auto_discover_camera_topics true'
-    const cameraTopicCommand = "ros2 param set /racetracker_perception camera_topics \"['/camera/cam1/image_raw']\""
+    const ros2SourceCommand = 'source ~/ros2_kilted/install/setup.bash && source ~/j5/ros_ws/install/setup.bash'
+    const perceptionRunCommand =
+        'ros2 run racetracker_perception perception_node --ros-args --log-level info -p camera_topics:=[/camera/cam1/image_raw] -p auto_discover_camera_topics:=true'
     const lapEventPublishCommand =
         "ros2 topic pub /race/lap_event std_msgs/msg/String '{data: \"{\\\"raceId\\\":\\\"demo-race\\\",\\\"carId\\\":\\\"car-7\\\",\\\"sessionLap\\\":1,\\\"lapTimeMs\\\":70000,\\\"trackDistanceM\\\":350.0,\\\"validity\\\":{\\\"onTrack\\\":true,\\\"directionOk\\\":true,\\\"minLapTimeOk\\\":true}}\"}' --once -w 0"
 
@@ -66,31 +64,33 @@ export default function IntegrationCheckPanel() {
                 </p>
 
                 <div className="rounded border border-slate-700 bg-slate-950/70 p-3 space-y-2 text-xs text-slate-200">
-                    <p><strong>1) Source your ROS2 workspaces (source-build flow)</strong></p>
+                    <p><strong>Run these commands in order (kilted source-build flow)</strong></p>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
                         {ros2SourceCommand}
                     </code>
-                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
-                        {ros2CliCheckCommand}
-                    </code>
-                    <p><strong>2) Start camera preview process</strong></p>
-                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
-                        python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091 --preview-fps 15
-                    </code>
-                    <p><strong>3) Start perception process (choose one)</strong></p>
-                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
-                        python -m perception.standalone.standalone_runner --camera-source /dev/video0 --camera-id cam1
-                    </code>
-                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
-                        ros2 run racetracker_perception perception_node
-                    </code>
-                    <p><strong>4) Validate perception topics (safe checks)</strong></p>
+                    <p><strong>1) Confirm the camera topic exists and is publishing frames</strong></p>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
                         {topicListCommand}
                     </code>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
-                        {topicTypeCommand}
+                        {topicHzCommand}
                     </code>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        {topicEchoCommand}
+                    </code>
+                    <p><strong>2) Start camera preview (annotated IDs are overlaid in this Integration tab)</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091 --preview-fps 15
+                    </code>
+                    <p><strong>3) In a second terminal, source workspaces again</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        {ros2SourceCommand}
+                    </code>
+                    <p><strong>4) Start the perception node on the real image topic</strong></p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        {perceptionRunCommand}
+                    </code>
+                    <p><strong>5) Verify perception node is alive and subscribed</strong></p>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
                         {topicInfoCommand}
                     </code>
@@ -98,12 +98,12 @@ export default function IntegrationCheckPanel() {
                         {nodeListCommand}
                     </code>
                     <p className="text-[11px] text-amber-200">
-                        If <code>ros2 topic hz</code> or <code>ros2 topic echo</code> crashes with <code>Segmentation fault</code> / <code>double free</code>, your ROS2 shell environment is likely mixed. Open a fresh shell and source only ROS Iron + this workspace, then retry.
+                        If <code>ros2 topic hz</code>, <code>ros2 topic echo</code>, or <code>ros2 param</code> crashes with <code>Segmentation fault</code> / <code>double free</code>, open a fresh shell and run only the two <code>source</code> commands shown above.
                     </p>
                     <p className="text-[11px] text-slate-300">
-                        Use the camera topic name shown by the topic list command if your stream is not on <code>/camera/cam1/image_raw</code>.
+                        If your camera topic is different, replace <code>/camera/cam1/image_raw</code> in steps 1, 4, and 5 with the topic shown by step 1.
                     </p>
-                    <p><strong>5) Optional bridge smoke test (publish one lap event)</strong></p>
+                    <p><strong>6) Optional bridge smoke test (publish one lap event)</strong></p>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
                         {lapEventPublishCommand}
                     </code>
@@ -201,28 +201,9 @@ export default function IntegrationCheckPanel() {
                     <p>• <code>{topicInfoCommand}</code> shows at least one publisher and one subscriber.</p>
                     <p>• Keep the perception process running in a dedicated terminal and watch logs for frame decode or websocket errors:</p>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
-                        {perceptionLogsCommand}
+                        {perceptionRunCommand}
                     </code>
                     <p>• Detection count in this tab increases from 0 and “seconds since last object” stays low.</p>
-                </div>
-            </div>
-
-            <div className="race-card p-4 space-y-3">
-                <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Quick calibration helpers</h3>
-                <p className="text-xs text-[var(--color-text-secondary)]">
-                    The browser cannot run ROS2 commands directly. Copy/paste the commands below into your robot terminal.
-                </p>
-                <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-2">
-                    <p className="font-semibold text-slate-100">Common ROS2 topic adjustments</p>
-                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
-                        {autodiscoverCommand}
-                    </code>
-                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
-                        {cameraTopicCommand}
-                    </code>
-                    <p className="text-[11px] text-slate-300">
-                        If your node name differs, replace <code>/racetracker_perception</code> with the value from <code>ros2 node list</code>.
-                    </p>
                 </div>
             </div>
 


### PR DESCRIPTION
### Motivation

- Improve and clarify the ROS2 troubleshooting steps shown in the Integration Check UI to better surface camera/topic checks and perception startup on kilted source-build setups.
- Replace brittle and ambiguous CLI suggestions with targeted `ros2 topic` checks (`hz`, `echo`, `info`) and a single `perception` runner that sets camera topics and auto-discovery.
- Simplify the workspace sourcing guidance to avoid mixed ROS environments and reduce common segmentation-fault errors.

### Description

- Reworked the displayed commands inside `IntegrationCheckPanel.tsx`, replacing the topic list with `ros2 topic list -t | rg -n "Image|CompressedImage|camera|video"` and adding `ros2 topic hz` and `ros2 topic echo` checks.
- Added `perceptionRunCommand` that runs the perception node with parameters: `-p camera_topics:=[/camera/cam1/image_raw] -p auto_discover_camera_topics:=true`, and replaced usages of the old run/log commands with this consolidated command.
- Simplified `ros2SourceCommand` to `source ~/ros2_kilted/install/setup.bash && source ~/j5/ros_ws/install/setup.bash` and updated in-panel step ordering and explanatory text accordingly.
- Removed the separate quick-calibration helpers block and updated inline guidance, numbering, and error messages to reflect the new flow.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3abeb0208323bd3057d5891e6d8d)