### PR TITLE
Improve computer vision troubleshooting and auto-detected camera topic diagnostics

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -425,6 +425,10 @@ export default function SettingsPanelView() {
                         <button className="rounded bg-rose-700 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" type="button" onClick={() => controlRace('finish')}>Race Finish</button>
                     </div>
                 </form>
+                <p className="text-xs text-[var(--color-text-secondary)]">
+                    The <strong>Camera preview stream</strong> step is green only when the configured Preview URL responds to <code>/ready</code> or <code>/snapshot.jpg</code>.
+                    If it stays red, run <code>python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091</code> on the camera host and set Preview URL to that host (for example <code>http://192.168.1.134:8091</code>).
+                </p>
             </div>
 
             {error ? <p className="text-sm text-red-400">{error}</p> : null}

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -33,6 +33,13 @@ export default function IntegrationCheckPanel() {
     const raceStatus = liveRace?.status || 'setup'
     const hasRecentVisionObjects = recentVisionObjects.length > 0
     const visionIsFresh = secondsSinceVision !== null && secondsSinceVision <= 3
+    const autoDetectedTopics = Array.from(
+        new Set(
+            recentVisionObjects
+                .map(item => item.cameraTopic)
+                .filter(topic => Boolean(topic)),
+        ),
+    )
 
     useEffect(() => {
         const timer = window.setInterval(() => {
@@ -62,6 +69,9 @@ export default function IntegrationCheckPanel() {
             <div className="race-card p-4 space-y-3 text-sm">
                 <p className="text-[var(--color-text-secondary)]">
                     Use this page to verify camera video, ROS2 perception, and websocket updates without running the full race flow.
+                </p>
+                <p className="text-xs text-amber-200">
+                    Note: the embedded camera image is a raw MJPEG preview. This UI currently overlays object-ID badges, not pixel bounding boxes.
                 </p>
 
                 <div className="rounded border border-slate-700 bg-slate-950/70 p-3 space-y-2 text-xs text-slate-200">
@@ -134,6 +144,12 @@ export default function IntegrationCheckPanel() {
                         </span>
                     </li>
                     <li>
+                        Auto-detected camera topics:{' '}
+                        <span className={autoDetectedTopics.length > 0 ? 'text-emerald-300' : 'text-amber-300'}>
+                            {autoDetectedTopics.length > 0 ? autoDetectedTopics.join(', ') : 'none detected yet'}
+                        </span>
+                    </li>
+                    <li>
                         Detection events in memory:{' '}
                         <span className={recentObjectDetections.length > 0 ? 'text-emerald-300' : 'text-amber-300'}>
                             {recentObjectDetections.length}
@@ -184,6 +200,7 @@ export default function IntegrationCheckPanel() {
                                 <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
                                     {item.objectId}
                                     {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
+                                    {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
                                 </p>
                             ))}
                             {!hasRecentVisionObjects ? (
@@ -208,6 +225,14 @@ export default function IntegrationCheckPanel() {
                         {perceptionRunCommand}
                     </code>
                     <p>• Detection count in this tab increases from 0 and “seconds since last object” stays low.</p>
+                </div>
+                <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-1">
+                    <p className="font-semibold text-slate-100">Camera publisher helper script</p>
+                    <p>If <code>usb_camera</code> is unavailable, publish camera frames with this script:</p>
+                    <code className="block overflow-x-auto rounded bg-black/40 p-2 text-emerald-300">
+                        python3 scripts/camera_ros_publisher.py --device /dev/video0 --topic /camera/image_raw --fps 30 --serve-preview --preview-host 0.0.0.0 --preview-port 8091
+                    </code>
+                    <p>Then set <code>camera_topics</code> on the perception node to the same topic (for example <code>/camera/image_raw</code>).</p>
                 </div>
             </div>
 

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -225,7 +225,7 @@ export default function VisionPanel() {
                     captured, return here to start object tracking and monitor lap-count logs.
                 </p>
                 <p className="text-xs text-[var(--color-text-secondary)]">
-                    The preview stream is raw camera video. Use the detection table below to map object IDs to racers; dashboard overlay updates when mapped IDs are seen.
+                    The preview stream is raw camera video. Object IDs are shown as badges (no bounding boxes yet). Use the detection table below to map object IDs to racers; dashboard overlay updates when mapped IDs are seen.
                 </p>
                 <p className="text-xs text-amber-300">
                     Keep the camera stream open in only one viewer at a time. Viewing <code>/stream.mjpg</code> in multiple places can drop the camera connection.
@@ -284,6 +284,7 @@ export default function VisionPanel() {
                                 <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
                                     {item.objectId}
                                     {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
+                                    {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
                                 </p>
                             ))}
                             {!hasRecentVisionObjects ? (

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -383,7 +383,11 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             const position = Number.isFinite(positionX) && Number.isFinite(positionY)
                 ? { x: positionX, y: positionY }
                 : null
-            const cameraTopic = String(data.camera_topic || '').trim()
+            const cameraTopic = String(
+                data.camera_topic
+                || data.camera_id
+                || '',
+            ).trim()
             const detectionSource = String(data.detection_source || '').trim()
             const confidence = Number(data.confidence)
             const normalizedConfidence = Number.isFinite(confidence) ? confidence : null

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -15,7 +15,14 @@ interface RaceContextValue {
     wsRef: React.MutableRefObject<WebSocket | null>
     sendWsMessage: (msg: Record<string, unknown>) => void
     refreshRaceState: (raceId?: string | null) => Promise<void>
-    recentVisionObjects: Array<{ objectId: string, seenAt: number, position: TrackPoint | null }>
+    recentVisionObjects: Array<{
+        objectId: string
+        seenAt: number
+        position: TrackPoint | null
+        cameraTopic: string
+        detectionSource: string
+        confidence: number | null
+    }>
     recentObjectDetections: Array<{ objectId: string, racerProfileId: string, seenAt: number }>
 }
 
@@ -137,7 +144,14 @@ export function RaceProvider({ children }: { children: ReactNode }) {
     const wsRef = useRef<WebSocket | null>(null)
     const liveRaceRef = useRef<LiveRaceState | null>(null)
     const checkpointStateRef = useRef<Map<string, RacerCheckpointState>>(new Map())
-    const [recentVisionObjects, setRecentVisionObjects] = useState<Array<{ objectId: string, seenAt: number, position: TrackPoint | null }>>([])
+    const [recentVisionObjects, setRecentVisionObjects] = useState<Array<{
+        objectId: string
+        seenAt: number
+        position: TrackPoint | null
+        cameraTopic: string
+        detectionSource: string
+        confidence: number | null
+    }>>([])
     const [recentObjectDetections, setRecentObjectDetections] = useState<Array<{ objectId: string, racerProfileId: string, seenAt: number }>>([])
     const checkpointsRef = useRef<Checkpoint[]>([])
     const requiredCheckpointIdsRef = useRef<Set<string>>(new Set())
@@ -369,10 +383,21 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             const position = Number.isFinite(positionX) && Number.isFinite(positionY)
                 ? { x: positionX, y: positionY }
                 : null
+            const cameraTopic = String(data.camera_topic || '').trim()
+            const detectionSource = String(data.detection_source || '').trim()
+            const confidence = Number(data.confidence)
+            const normalizedConfidence = Number.isFinite(confidence) ? confidence : null
             if (incomingObjectId) {
                 setRecentVisionObjects(prev => {
                     const next = [
-                        { objectId: incomingObjectId, seenAt: Date.now(), position },
+                        {
+                            objectId: incomingObjectId,
+                            seenAt: Date.now(),
+                            position,
+                            cameraTopic,
+                            detectionSource,
+                            confidence: normalizedConfidence,
+                        },
                         ...prev.filter(item => item.objectId !== incomingObjectId),
                     ]
                     return next.slice(0, 24)


### PR DESCRIPTION
### Motivation
- Users can start tracking but cannot see which object IDs map to which camera/topic and lack guidance for publishing camera frames or why the Preview step stays red.
- Improve UI diagnostics so operators can confirm which camera topics are producing detections and have a concrete fallback publisher command when `usb_camera` is unavailable.

### Description
- Extended the in-memory vision object model to include `cameraTopic`, `detectionSource`, and `confidence` so panels can show richer context (changes in `raceStore.tsx`).
- Updated the Computer Vision panel to clarify that the preview is a raw MJPEG stream (ID badges only) and to display the detected `cameraTopic` next to object-ID badges (`VisionPanel.tsx`).
- Added an auto-detected camera topics summary derived from live vision payloads and showed `cameraTopic` badges in the Integration panel (`IntegrationCheckPanel.tsx`).
- Added a concrete helper command pointing to `scripts/camera_ros_publisher.py` (with `--serve-preview`) to publish frames when `usb_camera` is unavailable, and clarified why the Settings wizard’s Camera preview stream step can remain red and which endpoints are checked (`IntegrationCheckPanel.tsx` and `SettingsPanel.tsx`).

Files modified: `ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx`, `ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx`, `ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx`, `ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx`.

### Testing
- Ran `pre-commit` on the modified files with `pre-commit run --files <paths>` and hooks passed (no formatting failures).
- Ran `make test`; the environment reported `colcon` is not installed so the ROS test target could not be executed (`colcon not found`).
- No backend API changes required; changes are frontend UX/diagnostics only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc0d8c4c483239fadd65ef032ab0b)