### PR TITLE
Fix CV capture flow, add bbox overlays, and numeric object-ID assignment

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -69,6 +69,11 @@ function toFullObjectId(prefix: string, numericValue: string): string {
     return `${prefix}${digits}`
 }
 
+function extractPrefixFromObjectId(objectId: string): string | null {
+    const match = objectId.match(/^(.*?)(\d+)$/)
+    return match?.[1] || null
+}
+
 function toNumericObjectId(prefix: string, fullObjectId: string): string {
     if (!fullObjectId) return ''
     if (fullObjectId.startsWith(prefix)) {
@@ -637,7 +642,10 @@ export default function SettingsPanelView() {
                                         className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-white"
                                         value={toNumericObjectId(assignmentPrefix, assignmentDraft[racer.racer_profile_id] || '')}
                                         onChange={event => {
-                                            const fullId = toFullObjectId(assignmentPrefix, event.target.value)
+                                            const existingValue = assignmentDraft[racer.racer_profile_id] || ''
+                                            const existingPrefix = extractPrefixFromObjectId(existingValue)
+                                            const nextPrefix = existingPrefix || assignmentPrefix
+                                            const fullId = toFullObjectId(nextPrefix, event.target.value)
                                             setAssignmentDraft(prev => ({ ...prev, [racer.racer_profile_id]: fullId }))
                                         }}
                                         placeholder="numeric object id (e.g. 403)"

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/settings/SettingsPanel.tsx
@@ -53,6 +53,30 @@ function normalizeBaseUrl(value: string): string {
     }
 }
 
+
+
+function deriveObjectIdPrefix(objectIds: string[]): string {
+    for (const objectId of objectIds) {
+        const match = objectId.match(/^(.*?)(\d+)$/)
+        if (match && match[1]) return match[1]
+    }
+    return 'cv--camera-cam1-image_raw-track-'
+}
+
+function toFullObjectId(prefix: string, numericValue: string): string {
+    const digits = numericValue.replace(/\D+/g, '')
+    if (!digits) return ''
+    return `${prefix}${digits}`
+}
+
+function toNumericObjectId(prefix: string, fullObjectId: string): string {
+    if (!fullObjectId) return ''
+    if (fullObjectId.startsWith(prefix)) {
+        return fullObjectId.slice(prefix.length).replace(/\D+/g, '')
+    }
+    const match = fullObjectId.match(/(\d+)(?!.*\d)/)
+    return match ? match[1] : ''
+}
 function withCacheBust(url: string): string {
     if (!url) return ''
     const separator = url.includes('?') ? '&' : '?'
@@ -97,6 +121,7 @@ export default function SettingsPanelView() {
     const [markerNotice, setMarkerNotice] = useState('')
     const [trackingBackend, setTrackingBackendState] = useState<TrackingBackend>(getTrackingBackend())
     const [assignmentDraft, setAssignmentDraft] = useState<Record<string, string>>({})
+    const [assignmentPrefix, setAssignmentPrefix] = useState('cv--camera-cam1-image_raw-track-')
     const wizardSteps = Array.isArray(wizard?.steps) ? wizard.steps : []
 
     const selectedTrack = useMemo(
@@ -200,6 +225,15 @@ export default function SettingsPanelView() {
         if (!selectedTrackId) return
         setTrackRacerAssignments(selectedTrackId, assignmentDraft)
     }, [assignmentDraft, selectedTrackId])
+
+
+    useEffect(() => {
+        if (safeRecentVisionObjects.length === 0) return
+        const prefix = deriveObjectIdPrefix(safeRecentVisionObjects.map(item => item.objectId))
+        if (prefix) {
+            setAssignmentPrefix(prefix)
+        }
+    }, [safeRecentVisionObjects])
 
     const frontendApiUrl = configuredApiBaseUrl() ?? `same-origin /api → fallback ${backendBaseUrl()}`
     const frontendWsUrl = backendWsUrl('organizer')
@@ -591,48 +625,28 @@ export default function SettingsPanelView() {
                         <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-300 space-y-2">
                             <p><strong>Racer object assignment</strong></p>
                             <p>Assign the tracker object id for each racer. During race tracking, only assigned objects are annotated and lap-checked.</p>
+                            <div className="rounded border border-slate-700 bg-slate-900/60 p-2 text-[11px] text-slate-300">
+                                Object ID prefix: <code>{assignmentPrefix}</code>
+                            </div>
                             {liveRacers.map(racer => (
                                 <label key={racer.racer_profile_id} className="block">
                                     <span className="text-slate-200">{racer.name} (#{racer.number || '?'})</span>
                                     <input
-                                        list={`object-id-options-${racer.racer_profile_id}`}
+                                        inputMode="numeric"
+                                        pattern="[0-9]*"
                                         className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-2 py-1.5 text-xs text-white"
-                                        value={assignmentDraft[racer.racer_profile_id] || ''}
-                                        onChange={event => setAssignmentDraft(prev => ({ ...prev, [racer.racer_profile_id]: event.target.value }))}
-                                        placeholder="tracker object id (e.g. yolo-track-17)"
+                                        value={toNumericObjectId(assignmentPrefix, assignmentDraft[racer.racer_profile_id] || '')}
+                                        onChange={event => {
+                                            const fullId = toFullObjectId(assignmentPrefix, event.target.value)
+                                            setAssignmentDraft(prev => ({ ...prev, [racer.racer_profile_id]: fullId }))
+                                        }}
+                                        placeholder="numeric object id (e.g. 403)"
                                     />
-                                    <datalist id={`object-id-options-${racer.racer_profile_id}`}>
-                                        {safeRecentVisionObjects.map(item => (
-                                            <option key={item.objectId} value={item.objectId} />
-                                        ))}
-                                    </datalist>
                                 </label>
                             ))}
-                            {safeRecentVisionObjects.length > 0 ? (
-                                <div className="rounded border border-slate-700 bg-slate-900/60 p-2 text-[11px] text-slate-300 space-y-1">
-                                    <p className="font-semibold text-slate-200">Live object IDs (from Vision tracking):</p>
-                                    <div className="flex flex-wrap gap-1.5">
-                                        {safeRecentVisionObjects.map(item => (
-                                            <button
-                                                key={item.objectId}
-                                                type="button"
-                                                className="rounded bg-slate-800 px-2 py-0.5 text-[11px] hover:bg-slate-700"
-                                                onClick={() => {
-                                                    const firstUnassigned = liveRacers
-                                                        .find(racer => !(assignmentDraft[racer.racer_profile_id] || '').trim())
-                                                    if (!firstUnassigned) return
-                                                    setAssignmentDraft(prev => ({ ...prev, [firstUnassigned.racer_profile_id]: item.objectId }))
-                                                }}
-                                                title="Click to assign this ID to the first unassigned racer"
-                                            >
-                                                {item.objectId}
-                                            </button>
-                                        ))}
-                                    </div>
-                                </div>
-                            ) : (
+                            {safeRecentVisionObjects.length === 0 ? (
                                 <p className="text-[11px] text-amber-300">No object IDs seen yet. In Computer Vision: enable preview, start tracking, then move cars through frame.</p>
-                            )}
+                            ) : null}
                             <button className="rounded bg-teal-600 px-3 py-2 text-xs font-semibold text-white hover:bg-teal-500" type="button" onClick={saveAssignments}>Save Assignments</button>
                         </div>
                     </div>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -172,6 +172,32 @@ export default function VisionPanel() {
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
     const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
     const hasRecentVisionObjects = recentVisionObjects.length > 0
+    const drawableVisionObjects = recentVisionObjects
+        .slice(0, 12)
+        .map((item) => {
+            const x = parseNumber(item.bbox?.x)
+            const y = parseNumber(item.bbox?.y)
+            const width = parseNumber(item.bbox?.width)
+            const height = parseNumber(item.bbox?.height)
+            const frameWidth = parseNumber(item.frameSize?.width)
+            const frameHeight = parseNumber(item.frameSize?.height)
+            if (x == null || y == null || width == null || height == null || frameWidth == null || frameHeight == null) return null
+            return {
+                item,
+                leftPct: (x / frameWidth) * 100,
+                topPct: (y / frameHeight) * 100,
+                widthPct: (width / frameWidth) * 100,
+                heightPct: (height / frameHeight) * 100,
+            }
+        })
+        .filter((entry): entry is {
+            item: typeof recentVisionObjects[number]
+            leftPct: number
+            topPct: number
+            widthPct: number
+            heightPct: number
+        } => entry !== null)
+    const hasDrawableVisionObjects = drawableVisionObjects.length > 0
     const latestVisionObject = recentVisionObjects[0]
     const visionFresh = Boolean(latestVisionObject && statusNowMs - latestVisionObject.seenAt <= 3000)
 
@@ -302,18 +328,7 @@ export default function VisionPanel() {
                             className="w-full rounded border border-slate-700 bg-black"
                         />
                         <div className="pointer-events-none absolute inset-0">
-                            {recentVisionObjects.slice(0, 12).map((item) => {
-                                const x = parseNumber(item.bbox?.x)
-                                const y = parseNumber(item.bbox?.y)
-                                const width = parseNumber(item.bbox?.width)
-                                const height = parseNumber(item.bbox?.height)
-                                const frameWidth = parseNumber(item.frameSize?.width)
-                                const frameHeight = parseNumber(item.frameSize?.height)
-                                if (x == null || y == null || width == null || height == null || frameWidth == null || frameHeight == null) return null
-                                const leftPct = (x / frameWidth) * 100
-                                const topPct = (y / frameHeight) * 100
-                                const widthPct = (width / frameWidth) * 100
-                                const heightPct = (height / frameHeight) * 100
+                            {drawableVisionObjects.map(({ item, leftPct, topPct, widthPct, heightPct }) => {
                                 return (
                                     <div
                                         key={`${item.objectId}-${item.seenAt}`}
@@ -326,6 +341,16 @@ export default function VisionPanel() {
                                     </div>
                                 )
                             })}
+                            {hasRecentVisionObjects && !hasDrawableVisionObjects ? (
+                                <div className="absolute left-2 top-2 max-w-[65%] space-y-1">
+                                    {recentVisionObjects.slice(0, 8).map((item) => (
+                                        <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
+                                            {extractObjectNumber(item.objectId)}
+                                            {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
+                                        </p>
+                                    ))}
+                                </div>
+                            ) : null}
                             {!hasRecentVisionObjects ? (
                                 <p className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
                                     No tracking objects yet. Start perception node, then click Start Tracking.

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -9,6 +9,16 @@ function defaultPreviewBaseUrl(): string {
     return `http://${window.location.hostname}:8091`
 }
 
+
+function extractObjectNumber(objectId: string): string {
+    const match = objectId.match(/(\d+)(?!.*\d)/)
+    return match ? match[1] : objectId
+}
+
+function parseNumber(value: unknown): number | null {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : null
+}
 function normalizePreviewBaseUrl(value: string): string {
     const raw = value.trim()
     if (!raw) return ''
@@ -81,6 +91,10 @@ export default function VisionPanel() {
             if (!response.ok) return
             const payload = await response.json()
             setRaceContext(payload.race_context || {})
+            const previewUrl = String(payload?.config?.preview_url || '').trim()
+            if (previewUrl) {
+                setPreviewBaseUrl(previewUrl)
+            }
         } catch {
             // ignore for panel resilience
         }
@@ -107,10 +121,18 @@ export default function VisionPanel() {
         setStatusError(false)
 
         try {
+            if (!normalizedBaseUrl) {
+                throw new Error('Set a valid Preview server URL before capturing a track photo.')
+            }
             const response = await fetch(`${normalizedBaseUrl}/capture`, {
                 method: 'POST',
             })
-            const payload = await response.json()
+            let payload: { ok?: boolean, message?: string } = {}
+            try {
+                payload = await response.json() as { ok?: boolean, message?: string }
+            } catch {
+                payload = { ok: response.ok, message: response.ok ? 'Capture request completed.' : 'Capture request failed.' }
+            }
 
             if (!response.ok || !payload.ok) {
                 throw new Error(payload.message || 'Capture failed')
@@ -225,7 +247,7 @@ export default function VisionPanel() {
                     captured, return here to start object tracking and monitor lap-count logs.
                 </p>
                 <p className="text-xs text-[var(--color-text-secondary)]">
-                    The preview stream is raw camera video. Object IDs are shown as badges (no bounding boxes yet). Use the detection table below to map object IDs to racers; dashboard overlay updates when mapped IDs are seen.
+                    The preview stream shows live object bounding boxes when detection payloads include bbox coordinates. Object labels show only the numeric ID so it is easier to match racers.
                 </p>
                 <p className="text-xs text-amber-300">
                     Keep the camera stream open in only one viewer at a time. Viewing <code>/stream.mjpg</code> in multiple places can drop the camera connection.
@@ -279,16 +301,33 @@ export default function VisionPanel() {
                             alt="Live camera preview"
                             className="w-full rounded border border-slate-700 bg-black"
                         />
-                        <div className="pointer-events-none absolute left-2 top-2 max-w-[65%] space-y-1">
-                            {recentVisionObjects.slice(0, 6).map((item) => (
-                                <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
-                                    {item.objectId}
-                                    {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
-                                    {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
-                                </p>
-                            ))}
+                        <div className="pointer-events-none absolute inset-0">
+                            {recentVisionObjects.slice(0, 12).map((item) => {
+                                const x = parseNumber(item.bbox?.x)
+                                const y = parseNumber(item.bbox?.y)
+                                const width = parseNumber(item.bbox?.width)
+                                const height = parseNumber(item.bbox?.height)
+                                const frameWidth = parseNumber(item.frameSize?.width)
+                                const frameHeight = parseNumber(item.frameSize?.height)
+                                if (x == null || y == null || width == null || height == null || frameWidth == null || frameHeight == null) return null
+                                const leftPct = (x / frameWidth) * 100
+                                const topPct = (y / frameHeight) * 100
+                                const widthPct = (width / frameWidth) * 100
+                                const heightPct = (height / frameHeight) * 100
+                                return (
+                                    <div
+                                        key={`${item.objectId}-${item.seenAt}`}
+                                        className="absolute border border-emerald-400/90"
+                                        style={{ left: `${leftPct}%`, top: `${topPct}%`, width: `${widthPct}%`, height: `${heightPct}%` }}
+                                    >
+                                        <span className="absolute -top-4 right-0 rounded bg-black/75 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-200">
+                                            {extractObjectNumber(item.objectId)}
+                                        </span>
+                                    </div>
+                                )
+                            })}
                             {!hasRecentVisionObjects ? (
-                                <p className="rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
+                                <p className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
                                     No tracking objects yet. Start perception node, then click Start Tracking.
                                 </p>
                             ) : null}

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -22,6 +22,8 @@ interface RaceContextValue {
         cameraTopic: string
         detectionSource: string
         confidence: number | null
+        bbox: { x: number, y: number, width: number, height: number } | null
+        frameSize: { width: number, height: number } | null
     }>
     recentObjectDetections: Array<{ objectId: string, racerProfileId: string, seenAt: number }>
 }
@@ -65,6 +67,32 @@ function extractTrackPosition(payload: Record<string, unknown>): TrackPoint | nu
     const positionY = Number(payload.position_y)
     if (!Number.isFinite(positionX) || !Number.isFinite(positionY)) return null
     return { x: positionX, y: positionY }
+}
+
+
+function readFiniteNumber(value: unknown): number | null {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+}
+
+function extractBoundingBox(payload: Record<string, unknown>): { x: number, y: number, width: number, height: number } | null {
+    const bboxX = readFiniteNumber(payload.bbox_x)
+    const bboxY = readFiniteNumber(payload.bbox_y)
+    const bboxWidth = readFiniteNumber(payload.bbox_width ?? payload.bbox_w)
+    const bboxHeight = readFiniteNumber(payload.bbox_height ?? payload.bbox_h)
+    if (bboxX != null && bboxY != null && bboxWidth != null && bboxHeight != null) {
+        return { x: bboxX, y: bboxY, width: bboxWidth, height: bboxHeight }
+    }
+
+    const x1 = readFiniteNumber(payload.bbox_x1)
+    const y1 = readFiniteNumber(payload.bbox_y1)
+    const x2 = readFiniteNumber(payload.bbox_x2)
+    const y2 = readFiniteNumber(payload.bbox_y2)
+    if (x1 != null && y1 != null && x2 != null && y2 != null && x2 > x1 && y2 > y1) {
+        return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
+    }
+
+    return null
 }
 
 function buildLiveRace(statePayload: RuntimeStateResponse, activeRaceId: string, laps: LapRecordResponse[]): LiveRaceState {
@@ -151,6 +179,8 @@ export function RaceProvider({ children }: { children: ReactNode }) {
         cameraTopic: string
         detectionSource: string
         confidence: number | null
+        bbox: { x: number, y: number, width: number, height: number } | null
+        frameSize: { width: number, height: number } | null
     }>>([])
     const [recentObjectDetections, setRecentObjectDetections] = useState<Array<{ objectId: string, racerProfileId: string, seenAt: number }>>([])
     const checkpointsRef = useRef<Checkpoint[]>([])
@@ -391,6 +421,12 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             const detectionSource = String(data.detection_source || '').trim()
             const confidence = Number(data.confidence)
             const normalizedConfidence = Number.isFinite(confidence) ? confidence : null
+            const bbox = extractBoundingBox(data)
+            const frameWidth = readFiniteNumber(data.frame_width)
+            const frameHeight = readFiniteNumber(data.frame_height)
+            const frameSize = frameWidth != null && frameHeight != null
+                ? { width: frameWidth, height: frameHeight }
+                : null
             if (incomingObjectId) {
                 setRecentVisionObjects(prev => {
                     const next = [
@@ -401,6 +437,8 @@ export function RaceProvider({ children }: { children: ReactNode }) {
                             cameraTopic,
                             detectionSource,
                             confidence: normalizedConfidence,
+                            bbox,
+                            frameSize,
                         },
                         ...prev.filter(item => item.objectId !== incomingObjectId),
                     ]

--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
@@ -337,7 +337,7 @@ if ROS2_AVAILABLE:
 
         def _motion_candidates(
             self, frame, subtractor
-        ) -> list[tuple[tuple[float, float], float]]:
+        ) -> list[dict[str, float | tuple[float, float]]]:
             if cv2 is None or np is None:
                 return []
             motion_min_area = float(getattr(self, "motion_min_area", 180.0))
@@ -352,7 +352,7 @@ if ROS2_AVAILABLE:
             contours, _ = cv2.findContours(
                 cleaned, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
             )
-            candidates: list[tuple[tuple[float, float], float]] = []
+            candidates: list[dict[str, float | tuple[float, float]]] = []
             for contour in contours:
                 area = cv2.contourArea(contour)
                 if area < motion_min_area:
@@ -361,10 +361,18 @@ if ROS2_AVAILABLE:
                 if w < motion_min_box_size or h < motion_min_box_size:
                     continue
                 confidence = min(0.99, 0.5 + (float(area) / 5000.0))
-                candidates.append(((x + (w / 2.0), y + (h / 2.0)), confidence))
+                candidates.append(
+                    {
+                        "centroid": (x + (w / 2.0), y + (h / 2.0)),
+                        "confidence": confidence,
+                        "bbox": (float(x), float(y), float(w), float(h)),
+                    }
+                )
             return candidates
 
-        def _yolo_candidates(self, frame) -> list[tuple[tuple[float, float], float]]:
+        def _yolo_candidates(
+            self, frame
+        ) -> list[dict[str, float | tuple[float, float]]]:
             yolo_model = getattr(self, "_yolo_model", None)
             if yolo_model is None:
                 return []
@@ -382,7 +390,7 @@ if ROS2_AVAILABLE:
             boxes = getattr(results[0], "boxes", None)
             if boxes is None:
                 return []
-            candidates: list[tuple[tuple[float, float], float]] = []
+            candidates: list[dict[str, float | tuple[float, float]]] = []
             for box in boxes:
                 conf_values = box.conf.tolist() if box.conf is not None else []
                 if not conf_values:
@@ -393,7 +401,13 @@ if ROS2_AVAILABLE:
                     continue
                 x1, y1, x2, y2 = coords
                 centroid = ((x1 + x2) / 2.0, (y1 + y2) / 2.0)
-                candidates.append((centroid, confidence))
+                candidates.append(
+                    {
+                        "centroid": centroid,
+                        "confidence": confidence,
+                        "bbox": (float(x1), float(y1), float(x2 - x1), float(y2 - y1)),
+                    }
+                )
             return candidates
 
         def image_callback(self, msg: Image, topic: str):
@@ -416,28 +430,35 @@ if ROS2_AVAILABLE:
             if not candidates and self.fallback_to_motion_tracking:
                 candidates = self._motion_candidates(frame, subtractor)
                 detection_source = "motion"
-            centroids = [centroid for centroid, _confidence in candidates]
+            centroids = [candidate["centroid"] for candidate in candidates]
 
             tracked = tracker.update(centroids)
             for object_id, state in tracked.items():
                 if state.disappeared != 0:
                     continue
                 confidence = self.confidence_threshold
+                nearest_idx = -1
                 if candidates:
                     distances = [
                         (
                             idx,
                             np.hypot(
-                                state.centroid[0] - candidate[0][0],
-                                state.centroid[1] - candidate[0][1],
+                                state.centroid[0] - float(candidate["centroid"][0]),
+                                state.centroid[1] - float(candidate["centroid"][1]),
                             ),
                         )
                         for idx, candidate in enumerate(candidates)
                     ]
                     nearest_idx = min(distances, key=lambda item: item[1])[0]
-                    confidence = float(candidates[nearest_idx][1])
+                    confidence = float(candidates[nearest_idx]["confidence"])
                 if confidence < self.confidence_threshold:
                     continue
+                frame_height, frame_width = frame.shape[:2]
+                bbox_x = bbox_y = bbox_w = bbox_h = None
+                if nearest_idx >= 0:
+                    bbox = candidates[nearest_idx].get("bbox")
+                    if bbox is not None:
+                        bbox_x, bbox_y, bbox_w, bbox_h = bbox
                 detection = {
                     "object_id": f"cv-{topic.replace('/', '-')}-track-{object_id}",
                     "camera_topic": topic,
@@ -445,6 +466,16 @@ if ROS2_AVAILABLE:
                     "position_y": round(state.centroid[1], 1),
                     "confidence": round(confidence, 3),
                     "detection_source": detection_source,
+                    "bbox_x": round(float(bbox_x), 1) if bbox_x is not None else None,
+                    "bbox_y": round(float(bbox_y), 1) if bbox_y is not None else None,
+                    "bbox_width": (
+                        round(float(bbox_w), 1) if bbox_w is not None else None
+                    ),
+                    "bbox_height": (
+                        round(float(bbox_h), 1) if bbox_h is not None else None
+                    ),
+                    "frame_width": int(frame_width),
+                    "frame_height": int(frame_height),
                 }
                 try:
                     self._detection_queue.put_nowait(detection)

--- a/ros_ws/src/j5_perception/race-master-pro/perception/standalone/standalone_runner.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/standalone/standalone_runner.py
@@ -248,8 +248,7 @@ class StandaloneRunner:
         contours, _ = cv2.findContours(
             cleaned, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
-        centroids: list[tuple[float, float]] = []
-        bounds: list[tuple[int, int, int, int]] = []
+        candidates: list[tuple[tuple[float, float], tuple[int, int, int, int]]] = []
         for contour in contours:
             area = cv2.contourArea(contour)
             if area < 250:
@@ -257,14 +256,24 @@ class StandaloneRunner:
             x, y, w, h = cv2.boundingRect(contour)
             if w < 10 or h < 10:
                 continue
-            centroids.append((x + (w / 2.0), y + (h / 2.0)))
-            bounds.append((x, y, w, h))
+            candidates.append(((x + (w / 2.0), y + (h / 2.0)), (x, y, w, h)))
 
-        tracked = tracker.update(centroids)
+        tracked = tracker.update([centroid for centroid, _bbox in candidates])
         detections: list[dict] = []
+        frame_height, frame_width = frame.shape[:2]
         for object_id, state in tracked.items():
             if state.disappeared != 0:
                 continue
+            closest_bbox = None
+            if candidates:
+                closest_bbox = min(
+                    candidates,
+                    key=lambda item: (item[0][0] - state.centroid[0]) ** 2
+                    + (item[0][1] - state.centroid[1]) ** 2,
+                )[1]
+            bbox_x, bbox_y, bbox_w, bbox_h = (
+                closest_bbox if closest_bbox else (None, None, None, None)
+            )
             detections.append(
                 {
                     "object_id": f"cv-{cam_id}-track-{object_id}",
@@ -272,7 +281,12 @@ class StandaloneRunner:
                     "position_x": round(state.centroid[0], 1),
                     "position_y": round(state.centroid[1], 1),
                     "confidence": 0.95,
-                    "bbox_count": len(bounds),
+                    "bbox_x": bbox_x,
+                    "bbox_y": bbox_y,
+                    "bbox_width": bbox_w,
+                    "bbox_height": bbox_h,
+                    "frame_width": frame_width,
+                    "frame_height": frame_height,
                 }
             )
         return detections


### PR DESCRIPTION
### Motivation
- The Capture Track Photo button could fail when the preview URL from setup wasn’t used or when the preview server returned non-JSON, preventing reliable photo capture. 
- The Computer Vision preview lacked annotated bounding boxes and numeric labels positioned on each tracked object, making mapping IDs to racers harder. 
- Settings auto-populated full object IDs and offered datalist/button autofill instead of a simpler numeric-only entry that can be prefixed by the app.

### Description
- Vision panel: load the configured preview URL from the setup wizard, validate the preview URL before sending `/capture`, make capture response parsing resilient to non-JSON responses, and show bounding-box overlays with numeric-only object labels positioned at the upper-right of each box (`ros_ws/src/.../frontend/src/components/vision/VisionPanel.tsx`).
- Frontend store: extend `recentVisionObjects` shape and add helpers to read bounding-box/frame metadata from websocket detection payloads so overlays can be placed and scaled correctly (`ros_ws/src/.../frontend/src/stores/raceStore.tsx`).
- Settings UX: derive an object-id prefix from observed IDs, expose that prefix, accept numeric-only inputs for racer assignments, and automatically compose the full object id by prepending the prefix (removing the previous datalist/autofill click-assignment behavior) (`ros_ws/src/.../frontend/src/components/settings/SettingsPanel.tsx`).
- Perception producers: update both the standalone runner and ROS2 perception node to include bounding-box coordinates and frame dimensions in each `visionDetection` payload and to carry bbox candidates through centroid-tracker matching so the UI receives bbox/frame metadata (`ros_ws/src/.../perception/standalone/standalone_runner.py` and `ros_ws/src/.../perception/ros2_node/racetracker_perception/perception_node.py`).
- Formatting: Python files updated by the code changes were auto-formatted by the project `pre-commit` hooks (Black).

### Testing
- Ran `pre-commit run --files <changed-files>` which initially reformatted two Python files via `black` and then completed successfully. 
- Ran `make test`, which executed the Makefile test target; the environment reported `colcon not installed` (Makefile fallback executed), so full ROS test execution was not performed in this environment but the Makefile command completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc93de8188323baa82bf39ddc865a)