### PR TITLE
Improve tracker stability and toggleable vision overlays

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -19,6 +19,16 @@ function normalizePreviewBaseUrl(value: string): string {
     }
 }
 
+function parseNumber(value: unknown): number | null {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+}
+
+function extractObjectNumber(objectId: string): string {
+    const match = objectId.match(/(\d+)(?!.*\d)/)
+    return match ? match[1] : objectId
+}
+
 export default function IntegrationCheckPanel() {
     const { connectionStatus, recentVisionObjects, recentObjectDetections, liveRace } = useRaceContext()
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
@@ -32,6 +42,32 @@ export default function IntegrationCheckPanel() {
     const secondsSinceDetection = lastDetectionSeenAt ? Math.max(0, Math.floor((statusNowMs - lastDetectionSeenAt) / 1000)) : null
     const raceStatus = liveRace?.status || 'setup'
     const hasRecentVisionObjects = recentVisionObjects.length > 0
+    const drawableVisionObjects = recentVisionObjects
+        .slice(0, 12)
+        .map((item) => {
+            const x = parseNumber(item.bbox?.x)
+            const y = parseNumber(item.bbox?.y)
+            const width = parseNumber(item.bbox?.width)
+            const height = parseNumber(item.bbox?.height)
+            const frameWidth = parseNumber(item.frameSize?.width)
+            const frameHeight = parseNumber(item.frameSize?.height)
+            if (x == null || y == null || width == null || height == null || frameWidth == null || frameHeight == null) return null
+            return {
+                item,
+                leftPct: (x / frameWidth) * 100,
+                topPct: (y / frameHeight) * 100,
+                widthPct: (width / frameWidth) * 100,
+                heightPct: (height / frameHeight) * 100,
+            }
+        })
+        .filter((entry): entry is {
+            item: typeof recentVisionObjects[number]
+            leftPct: number
+            topPct: number
+            widthPct: number
+            heightPct: number
+        } => entry !== null)
+    const hasDrawableVisionObjects = drawableVisionObjects.length > 0
     const visionIsFresh = secondsSinceVision !== null && secondsSinceVision <= 3
     const autoDetectedTopics = Array.from(
         new Set(
@@ -195,16 +231,31 @@ export default function IntegrationCheckPanel() {
                             alt="Embedded camera stream"
                             className="w-full rounded border border-slate-700 bg-black"
                         />
-                        <div className="pointer-events-none absolute left-2 top-2 max-w-[70%] space-y-1">
-                            {recentVisionObjects.slice(0, 6).map((item) => (
-                                <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
-                                    {item.objectId}
-                                    {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
-                                    {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
-                                </p>
+                        <div className="pointer-events-none absolute inset-0">
+                            {drawableVisionObjects.map(({ item, leftPct, topPct, widthPct, heightPct }) => (
+                                <div
+                                    key={`${item.objectId}-${item.seenAt}`}
+                                    className="absolute border border-emerald-400/90"
+                                    style={{ left: `${leftPct}%`, top: `${topPct}%`, width: `${widthPct}%`, height: `${heightPct}%` }}
+                                >
+                                    <span className="absolute -top-4 right-0 rounded bg-black/75 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-200">
+                                        {extractObjectNumber(item.objectId)}
+                                    </span>
+                                </div>
                             ))}
+                            {hasRecentVisionObjects && !hasDrawableVisionObjects ? (
+                                <div className="absolute left-2 top-2 max-w-[70%] space-y-1">
+                                    {recentVisionObjects.slice(0, 6).map((item) => (
+                                        <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
+                                            {extractObjectNumber(item.objectId)}
+                                            {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
+                                            {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
+                                        </p>
+                                    ))}
+                                </div>
+                            ) : null}
                             {!hasRecentVisionObjects ? (
-                                <p className="rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
+                                <p className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
                                     No object IDs yet. Move an object through frame and verify ROS2 topics below.
                                 </p>
                             ) : null}

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -171,8 +171,9 @@ export default function VisionPanel() {
     const trackingEnabled = Boolean(raceContext.tracking_enabled)
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
     const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
-    const hasRecentVisionObjects = recentVisionObjects.length > 0
-    const drawableVisionObjects = recentVisionObjects
+    const visibleVisionObjects = trackingEnabled ? recentVisionObjects : []
+    const hasRecentVisionObjects = visibleVisionObjects.length > 0
+    const drawableVisionObjects = visibleVisionObjects
         .slice(0, 12)
         .map((item) => {
             const x = parseNumber(item.bbox?.x)
@@ -198,7 +199,7 @@ export default function VisionPanel() {
             heightPct: number
         } => entry !== null)
     const hasDrawableVisionObjects = drawableVisionObjects.length > 0
-    const latestVisionObject = recentVisionObjects[0]
+    const latestVisionObject = visibleVisionObjects[0]
     const visionFresh = Boolean(latestVisionObject && statusNowMs - latestVisionObject.seenAt <= 3000)
 
     const toggleTracking = async (start: boolean) => {
@@ -343,7 +344,7 @@ export default function VisionPanel() {
                             })}
                             {hasRecentVisionObjects && !hasDrawableVisionObjects ? (
                                 <div className="absolute left-2 top-2 max-w-[65%] space-y-1">
-                                    {recentVisionObjects.slice(0, 8).map((item) => (
+                                    {visibleVisionObjects.slice(0, 8).map((item) => (
                                         <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
                                             {extractObjectNumber(item.objectId)}
                                             {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
@@ -353,7 +354,9 @@ export default function VisionPanel() {
                             ) : null}
                             {!hasRecentVisionObjects ? (
                                 <p className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
-                                    No tracking objects yet. Start perception node, then click Start Tracking.
+                                    {trackingEnabled
+                                        ? 'No tracking objects yet. Move racers through the frame.'
+                                        : 'Tracking overlay is hidden until Start Tracking is pressed.'}
                                 </p>
                             ) : null}
                         </div>
@@ -399,8 +402,8 @@ export default function VisionPanel() {
 
             <div className="race-card p-4 space-y-2">
                 <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Recent object detections</h3>
-                {recentObjectDetections.length === 0 ? <p className="text-xs text-[var(--color-text-secondary)]">No detections yet. Start tracking and assign object IDs in Settings.</p> : null}
-                {recentObjectDetections.length > 0 ? (
+                {(!trackingEnabled || recentObjectDetections.length === 0) ? <p className="text-xs text-[var(--color-text-secondary)]">{trackingEnabled ? 'No detections yet. Start tracking and assign object IDs in Settings.' : 'Start tracking to show object IDs and annotation events.'}</p> : null}
+                {trackingEnabled && recentObjectDetections.length > 0 ? (
                     <div className="max-h-52 overflow-auto rounded border border-slate-700 bg-slate-950 p-2 text-xs text-slate-200 space-y-1">
                         {recentObjectDetections.map(item => {
                             const racer = (liveRace?.racers || []).find(entry => entry.racer_profile_id === item.racerProfileId)

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -94,6 +94,21 @@ function objectIdsLikelyMatch(assignedId: string, incomingId: string): boolean {
     return Boolean(assignedNumber && incomingNumber && assignedNumber === incomingNumber)
 }
 
+function findAssignedRacerIdForObject(assignments: Record<string, string>, incomingObjectId: string): string {
+    const normalizedIncoming = normalizeObjectIdToken(incomingObjectId)
+    if (!normalizedIncoming) return ''
+
+    const exactMatch = Object.entries(assignments).find(([, objectId]) => (
+        normalizeObjectIdToken(String(objectId || '')) === normalizedIncoming
+    ))
+    if (exactMatch) return exactMatch[0]
+
+    const fallbackMatch = Object.entries(assignments).find(([, objectId]) => (
+        objectIdsLikelyMatch(String(objectId || ''), incomingObjectId)
+    ))
+    return fallbackMatch?.[0] || ''
+}
+
 function extractBoundingBox(payload: Record<string, unknown>): { x: number, y: number, width: number, height: number } | null {
     const bboxX = readFiniteNumber(payload.bbox_x)
     const bboxY = readFiniteNumber(payload.bbox_y)
@@ -466,8 +481,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             }
             let racerId = String(data.racer_profile_id || '').trim()
             if (incomingObjectId) {
-                const match = Object.entries(assignments).find(([, objectId]) => objectIdsLikelyMatch(String(objectId || ''), incomingObjectId))
-                racerId = match?.[0] || ''
+                racerId = findAssignedRacerIdForObject(assignments, incomingObjectId)
             }
             if (!racerId) return
             if (Object.keys(assignments).length > 0 && !assignments[racerId]) {

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/stores/raceStore.tsx
@@ -75,6 +75,25 @@ function readFiniteNumber(value: unknown): number | null {
     return Number.isFinite(parsed) ? parsed : null
 }
 
+function normalizeObjectIdToken(value: string): string {
+    return value.trim().toLowerCase()
+}
+
+function extractObjectIdNumber(value: string): string {
+    const match = value.match(/(\d+)(?!.*\d)/)
+    return match ? match[1] : ''
+}
+
+function objectIdsLikelyMatch(assignedId: string, incomingId: string): boolean {
+    const assigned = normalizeObjectIdToken(assignedId)
+    const incoming = normalizeObjectIdToken(incomingId)
+    if (!assigned || !incoming) return false
+    if (assigned === incoming) return true
+    const assignedNumber = extractObjectIdNumber(assigned)
+    const incomingNumber = extractObjectIdNumber(incoming)
+    return Boolean(assignedNumber && incomingNumber && assignedNumber === incomingNumber)
+}
+
 function extractBoundingBox(payload: Record<string, unknown>): { x: number, y: number, width: number, height: number } | null {
     const bboxX = readFiniteNumber(payload.bbox_x)
     const bboxY = readFiniteNumber(payload.bbox_y)
@@ -447,7 +466,7 @@ export function RaceProvider({ children }: { children: ReactNode }) {
             }
             let racerId = String(data.racer_profile_id || '').trim()
             if (incomingObjectId) {
-                const match = Object.entries(assignments).find(([, objectId]) => objectId === incomingObjectId)
+                const match = Object.entries(assignments).find(([, objectId]) => objectIdsLikelyMatch(String(objectId || ''), incomingObjectId))
                 racerId = match?.[0] || ''
             }
             if (!racerId) return

--- a/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/ros2_node/racetracker_perception/perception_node.py
@@ -52,12 +52,13 @@ if ROS2_AVAILABLE:
     @dataclass
     class TrackerState:
         centroid: tuple[float, float]
+        velocity: tuple[float, float] = (0.0, 0.0)
         disappeared: int = 0
 
     class SimpleCentroidTracker:
         """Lightweight centroid tracker for moving objects."""
 
-        def __init__(self, max_disappeared: int = 8, max_distance: float = 90.0):
+        def __init__(self, max_disappeared: int = 20, max_distance: float = 140.0):
             self.max_disappeared = max_disappeared
             self.max_distance = max_distance
             self.next_object_id = 1
@@ -93,7 +94,14 @@ if ROS2_AVAILABLE:
             object_items = list(self.objects.items())
             object_ids = [item[0] for item in object_items]
             existing = np.array(
-                [item[1].centroid for item in object_items], dtype=float
+                [
+                    (
+                        item[1].centroid[0] + item[1].velocity[0],
+                        item[1].centroid[1] + item[1].velocity[1],
+                    )
+                    for item in object_items
+                ],
+                dtype=float,
             )
             incoming = np.array(centroids, dtype=float)
             distances = np.linalg.norm(existing[:, None] - incoming[None, :], axis=2)
@@ -112,6 +120,15 @@ if ROS2_AVAILABLE:
                     if float(distances[row, col]) > self.max_distance:
                         continue
                     object_id = object_ids[row]
+                    prev_x, prev_y = self.objects[object_id].centroid
+                    next_x, next_y = centroids[col]
+                    velocity = (next_x - prev_x, next_y - prev_y)
+                    self.objects[object_id].velocity = (
+                        (self.objects[object_id].velocity[0] * 0.4)
+                        + (velocity[0] * 0.6),
+                        (self.objects[object_id].velocity[1] * 0.4)
+                        + (velocity[1] * 0.6),
+                    )
                     self.objects[object_id].centroid = centroids[col]
                     self.objects[object_id].disappeared = 0
                     used_rows.add(row)
@@ -129,6 +146,37 @@ if ROS2_AVAILABLE:
                 if col not in used_cols:
                     self._register(centroid)
             return self.objects
+
+    def merge_nearby_boxes(
+        boxes: list[tuple[int, int, int, int]], merge_distance: int = 24
+    ) -> list[tuple[int, int, int, int]]:
+        """Merge nearby or overlapping boxes so one racer doesn't split into fragments."""
+        if not boxes:
+            return []
+        merged = boxes[:]
+        changed = True
+        while changed:
+            changed = False
+            next_boxes: list[tuple[int, int, int, int]] = []
+            while merged:
+                x, y, w, h = merged.pop(0)
+                x1, y1, x2, y2 = x, y, x + w, y + h
+                idx = 0
+                while idx < len(merged):
+                    ox, oy, ow, oh = merged[idx]
+                    ox1, oy1, ox2, oy2 = ox, oy, ox + ow, oy + oh
+                    close_x = ox1 <= x2 + merge_distance and ox2 >= x1 - merge_distance
+                    close_y = oy1 <= y2 + merge_distance and oy2 >= y1 - merge_distance
+                    if close_x and close_y:
+                        x1, y1 = min(x1, ox1), min(y1, oy1)
+                        x2, y2 = max(x2, ox2), max(y2, oy2)
+                        merged.pop(idx)
+                        changed = True
+                    else:
+                        idx += 1
+                next_boxes.append((x1, y1, x2 - x1, y2 - y1))
+            merged = next_boxes
+        return merged
 
     class RaceMasterPerceptionNode(Node):
         """ROS2 node that subscribes to camera image topics and publishes racer detections."""
@@ -173,8 +221,8 @@ if ROS2_AVAILABLE:
             self.ws_url = (
                 self.get_parameter("ws_url").get_parameter_value().string_value
             )
-            self.motion_min_area = 180.0
-            self.motion_min_box_size = 10
+            self.motion_min_area = 550.0
+            self.motion_min_box_size = 16
             self.yolo_target_classes: set[int] = set()
             self._yolo_model = None
             if YOLO is not None:
@@ -250,7 +298,7 @@ if ROS2_AVAILABLE:
             if cv2 is not None:
                 self._background_models[clean_topic] = (
                     cv2.createBackgroundSubtractorMOG2(
-                        history=500, varThreshold=24, detectShadows=False
+                        history=700, varThreshold=32, detectShadows=False
                     )
                 )
             self.get_logger().info(
@@ -347,12 +395,13 @@ if ROS2_AVAILABLE:
             _, thresh = cv2.threshold(mask, 200, 255, cv2.THRESH_BINARY)
             kernel = np.ones((3, 3), dtype=np.uint8)
             cleaned = cv2.morphologyEx(thresh, cv2.MORPH_OPEN, kernel, iterations=2)
+            cleaned = cv2.morphologyEx(cleaned, cv2.MORPH_CLOSE, kernel, iterations=3)
             cleaned = cv2.dilate(cleaned, kernel, iterations=2)
 
             contours, _ = cv2.findContours(
                 cleaned, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
             )
-            candidates: list[dict[str, float | tuple[float, float]]] = []
+            raw_boxes: list[tuple[int, int, int, int]] = []
             for contour in contours:
                 area = cv2.contourArea(contour)
                 if area < motion_min_area:
@@ -360,7 +409,14 @@ if ROS2_AVAILABLE:
                 x, y, w, h = cv2.boundingRect(contour)
                 if w < motion_min_box_size or h < motion_min_box_size:
                     continue
-                confidence = min(0.99, 0.5 + (float(area) / 5000.0))
+                aspect = w / float(h)
+                if aspect < 0.25 or aspect > 4.0:
+                    continue
+                raw_boxes.append((x, y, w, h))
+
+            candidates: list[dict[str, float | tuple[float, float]]] = []
+            for x, y, w, h in merge_nearby_boxes(raw_boxes):
+                confidence = min(0.99, 0.5 + (float(w * h) / 9000.0))
                 candidates.append(
                     {
                         "centroid": (x + (w / 2.0), y + (h / 2.0)),

--- a/ros_ws/src/j5_perception/race-master-pro/perception/standalone/standalone_runner.py
+++ b/ros_ws/src/j5_perception/race-master-pro/perception/standalone/standalone_runner.py
@@ -28,13 +28,14 @@ except ImportError:
 @dataclass
 class TrackerState:
     centroid: tuple[float, float]
+    velocity: tuple[float, float] = (0.0, 0.0)
     disappeared: int = 0
 
 
 class SimpleCentroidTracker:
     """Lightweight centroid tracker for moving objects."""
 
-    def __init__(self, max_disappeared: int = 10, max_distance: float = 80.0):
+    def __init__(self, max_disappeared: int = 20, max_distance: float = 140.0):
         self.max_disappeared = max_disappeared
         self.max_distance = max_distance
         self.next_object_id = 1
@@ -67,7 +68,16 @@ class SimpleCentroidTracker:
 
         object_items = list(self.objects.items())
         object_ids = [item[0] for item in object_items]
-        existing = np.array([item[1].centroid for item in object_items], dtype=float)
+        existing = np.array(
+            [
+                (
+                    item[1].centroid[0] + item[1].velocity[0],
+                    item[1].centroid[1] + item[1].velocity[1],
+                )
+                for item in object_items
+            ],
+            dtype=float,
+        )
         incoming = np.array(centroids, dtype=float)
         distances = np.linalg.norm(existing[:, None] - incoming[None, :], axis=2)
 
@@ -85,6 +95,13 @@ class SimpleCentroidTracker:
                 if float(distances[row, col]) > self.max_distance:
                     continue
                 object_id = object_ids[row]
+                prev_x, prev_y = self.objects[object_id].centroid
+                next_x, next_y = centroids[col]
+                velocity = (next_x - prev_x, next_y - prev_y)
+                self.objects[object_id].velocity = (
+                    (self.objects[object_id].velocity[0] * 0.4) + (velocity[0] * 0.6),
+                    (self.objects[object_id].velocity[1] * 0.4) + (velocity[1] * 0.6),
+                )
                 self.objects[object_id].centroid = centroids[col]
                 self.objects[object_id].disappeared = 0
                 used_rows.add(row)
@@ -103,6 +120,38 @@ class SimpleCentroidTracker:
                 self._register(centroid)
 
         return self.objects
+
+
+def merge_nearby_boxes(
+    boxes: list[tuple[int, int, int, int]], merge_distance: int = 24
+) -> list[tuple[int, int, int, int]]:
+    """Merge nearby or overlapping bounding boxes to reduce fragment detections."""
+    if not boxes:
+        return []
+    merged = boxes[:]
+    changed = True
+    while changed:
+        changed = False
+        next_boxes: list[tuple[int, int, int, int]] = []
+        while merged:
+            x, y, w, h = merged.pop(0)
+            x1, y1, x2, y2 = x, y, x + w, y + h
+            idx = 0
+            while idx < len(merged):
+                ox, oy, ow, oh = merged[idx]
+                ox1, oy1, ox2, oy2 = ox, oy, ox + ow, oy + oh
+                close_x = ox1 <= x2 + merge_distance and ox2 >= x1 - merge_distance
+                close_y = oy1 <= y2 + merge_distance and oy2 >= y1 - merge_distance
+                if close_x and close_y:
+                    x1, y1 = min(x1, ox1), min(y1, oy1)
+                    x2, y2 = max(x2, ox2), max(y2, oy2)
+                    merged.pop(idx)
+                    changed = True
+                else:
+                    idx += 1
+            next_boxes.append((x1, y1, x2 - x1, y2 - y1))
+        merged = next_boxes
+    return merged
 
 
 class StandaloneRunner:
@@ -180,7 +229,7 @@ class StandaloneRunner:
                     if cv2 is not None:
                         self._background_models[cam["id"]] = (
                             cv2.createBackgroundSubtractorMOG2(
-                                history=500, varThreshold=24, detectShadows=False
+                                history=700, varThreshold=32, detectShadows=False
                             )
                         )
                     print(f"Opened camera: {cam['name']} ({cam['source']})")
@@ -243,20 +292,30 @@ class StandaloneRunner:
         _, thresh = cv2.threshold(mask, 200, 255, cv2.THRESH_BINARY)
         kernel = np.ones((3, 3), dtype=np.uint8)
         cleaned = cv2.morphologyEx(thresh, cv2.MORPH_OPEN, kernel, iterations=2)
+        cleaned = cv2.morphologyEx(cleaned, cv2.MORPH_CLOSE, kernel, iterations=3)
         cleaned = cv2.dilate(cleaned, kernel, iterations=2)
 
         contours, _ = cv2.findContours(
             cleaned, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
-        candidates: list[tuple[tuple[float, float], tuple[int, int, int, int]]] = []
+        raw_boxes: list[tuple[int, int, int, int]] = []
         for contour in contours:
             area = cv2.contourArea(contour)
-            if area < 250:
+            if area < 550:
                 continue
             x, y, w, h = cv2.boundingRect(contour)
-            if w < 10 or h < 10:
+            if w < 16 or h < 16:
                 continue
-            candidates.append(((x + (w / 2.0), y + (h / 2.0)), (x, y, w, h)))
+            aspect = w / float(h)
+            if aspect < 0.25 or aspect > 4.0:
+                continue
+            raw_boxes.append((x, y, w, h))
+
+        merged_boxes = merge_nearby_boxes(raw_boxes)
+        candidates: list[tuple[tuple[float, float], tuple[int, int, int, int]]] = [
+            ((x + (w / 2.0), y + (h / 2.0)), (x, y, w, h))
+            for x, y, w, h in merged_boxes
+        ]
 
         tracked = tracker.update([centroid for centroid, _bbox in candidates])
         detections: list[dict] = []


### PR DESCRIPTION
### Motivation
- Object tracking was too sensitive: moving objects were getting new IDs and object parts were detected as separate objects, making lap counting unreliable.
- The UI showed annotations and IDs even when tracking was not active, and Integration preview lacked bounding-box annotations, reducing usefulness during integration checks.
- Need robust mapping from incoming object IDs to assigned racer IDs even when prefixes differ, so racers remain matched during a race.

### Description
- Made centroid tracking velocity-aware by adding a `velocity` field to `TrackerState`, using predicted positions for association, and increasing `max_disappeared` and `max_distance` to improve ID persistence in both standalone and ROS2 perception runners (`standalone_runner.py` and `perception_node.py`).
- Reduced fragmented detections by tightening motion filters (raised `motion_min_area` and `motion_min_box_size`), added aspect-ratio filtering, applied morphological close, and introduced `merge_nearby_boxes` to merge nearby/overlapping motion boxes before tracking (both perception paths).
- Tuned background subtractor parameters (`history`/`varThreshold`) and adjusted confidence heuristics for merged motion boxes to reduce noise and false positives.
- Frontend: made object annotation overlays in the Computer Vision panel visible only while tracking is enabled, and updated the Integration panel to render bounding-box annotations with numeric object ID badges while preserving calibration and integration instructions (`VisionPanel.tsx` and `IntegrationCheckPanel.tsx`).
- Frontend: improved assignment matching logic to consider numeric suffix equality when comparing assigned object IDs to incoming IDs to tolerate prefix differences (`raceStore.tsx`).

### Testing
- Ran `pre-commit run --files <changed files>` which passed after auto-formatting adjustments by `black`.
- Ran `make test`, which completed in this environment but printed `colcon not installed` indicating ROS package tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff3d0cc1c8323bba081ef535a2229)