### PR TITLE
Honor configured preview URL in IntegrationCheckPanel

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useRaceContext } from '@/stores/raceStore'
+import { apiFetch } from '@/lib/utils'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
@@ -84,6 +85,24 @@ export default function IntegrationCheckPanel() {
         return () => {
             window.clearInterval(timer)
         }
+    }, [])
+
+    useEffect(() => {
+        const loadPreviewUrl = async () => {
+            try {
+                const response = await apiFetch('/api/setup/wizard')
+                if (!response.ok) return
+                const payload = await response.json() as { config?: { preview_url?: unknown } }
+                const previewUrl = String(payload?.config?.preview_url || '').trim()
+                if (previewUrl) {
+                    setPreviewBaseUrl(previewUrl)
+                }
+            } catch {
+                // keep fallback URL when setup payload cannot be loaded
+            }
+        }
+
+        void loadPreviewUrl()
     }, [])
 
     const topicListCommand = 'ros2 topic list -t | rg -n "Image|CompressedImage|camera|video"'


### PR DESCRIPTION
### Motivation
- The Integration/Computer Vision panel always defaulted the preview URL to `http://<browser-host>:8091`, which caused `ERR_CONNECTION_REFUSED` when the preview server was started on a different host/IP configured in the wizard.
- The goal is to make the IntegrationCheckPanel behave like the Vision panel by loading the saved `preview_url` from the setup wizard so the UI points at the actual preview host.

### Description
- Import `apiFetch` from `@/lib/utils` and add a mount `useEffect` in `IntegrationCheckPanel` to fetch `/api/setup/wizard` and read `config.preview_url`.
- When a non-empty `preview_url` is returned, update `previewBaseUrl` so the embedded stream uses the configured host; otherwise keep the existing fallback of `window.location.hostname:8091`.
- No changes were made to the preview normalization logic or other UI flows; this only sets the initial preview URL from the server-side config.

### Testing
- Ran `pre-commit run --files ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx`, which completed and relevant hooks passed (with a non-blocking deprecation warning reported).
- Ran `make test`, which exited successfully in this environment and printed the expected fallback message `colcon not installed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6e520b0c832394fe889a17dd9591)