### PR TITLE
Require explicit preview URL and load configured preview_url for vision panels

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useRaceContext } from '@/stores/raceStore'
+import { apiFetch } from '@/lib/utils'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
         return 'http://localhost:8091'
     }
-    return `${window.location.protocol}//${window.location.hostname}:8091`
+    return ''
 }
 
 function normalizePreviewBaseUrl(value: string): string {
@@ -34,7 +35,7 @@ export default function IntegrationCheckPanel() {
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const [previewEnabled, setPreviewEnabled] = useState(true)
     const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
-    const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
+    const streamUrl = normalizedBaseUrl ? `${normalizedBaseUrl}/stream.mjpg` : ''
     const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
     const lastVisionSeenAt = recentVisionObjects[0]?.seenAt || 0
     const secondsSinceVision = lastVisionSeenAt ? Math.max(0, Math.floor((statusNowMs - lastVisionSeenAt) / 1000)) : null
@@ -84,6 +85,24 @@ export default function IntegrationCheckPanel() {
         return () => {
             window.clearInterval(timer)
         }
+    }, [])
+
+    useEffect(() => {
+        const loadPreviewUrl = async () => {
+            try {
+                const response = await apiFetch('/api/setup/wizard')
+                if (!response.ok) return
+                const payload = await response.json() as { config?: { preview_url?: unknown } }
+                const previewUrl = String(payload?.config?.preview_url || '').trim()
+                if (previewUrl) {
+                    setPreviewBaseUrl(previewUrl)
+                }
+            } catch {
+                // keep fallback URL when setup payload cannot be loaded
+            }
+        }
+
+        void loadPreviewUrl()
     }, [])
 
     const topicListCommand = 'ros2 topic list -t | rg -n "Image|CompressedImage|camera|video"'
@@ -225,7 +244,8 @@ export default function IntegrationCheckPanel() {
                     />
                 </label>
                 {previewEnabled ? (
-                    <div className="relative">
+                    normalizedBaseUrl ? (
+                        <div className="relative">
                         <img
                             src={streamUrl}
                             alt="Embedded camera stream"
@@ -260,7 +280,12 @@ export default function IntegrationCheckPanel() {
                                 </p>
                             ) : null}
                         </div>
-                    </div>
+                        </div>
+                    ) : (
+                        <div className="rounded border border-dashed border-amber-700 bg-amber-950/20 p-4 text-xs text-amber-200">
+                            Set Preview server URL first, then show embedded camera.
+                        </div>
+                    )
                 ) : (
                     <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
                         Embedded camera preview is paused.

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -6,7 +6,7 @@ function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
         return 'http://localhost:8091'
     }
-    return `http://${window.location.hostname}:8091`
+    return ''
 }
 
 
@@ -42,7 +42,7 @@ export default function VisionPanel() {
     const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
 
     const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
-    const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
+    const streamUrl = normalizedBaseUrl ? `${normalizedBaseUrl}/stream.mjpg` : ''
 
     const ensureSelectedTrack = async () => {
         const existingTrackId = getSelectedTrackId()
@@ -305,7 +305,12 @@ export default function VisionPanel() {
                     <button
                         type="button"
                         className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
-                        onClick={() => setPreviewEnabled(prev => !prev)}
+                        onClick={async () => {
+                            if (!previewEnabled) {
+                                await refreshWizardContext()
+                            }
+                            setPreviewEnabled(prev => !prev)
+                        }}
                     >
                         {previewEnabled ? 'Hide Live Preview' : 'Show Live Preview'}
                     </button>
@@ -322,7 +327,8 @@ export default function VisionPanel() {
                     </p>
                 </div>
                 {previewEnabled ? (
-                    <div className="relative">
+                    normalizedBaseUrl ? (
+                        <div className="relative">
                         <img
                             src={streamUrl}
                             alt="Live camera preview"
@@ -360,7 +366,12 @@ export default function VisionPanel() {
                                 </p>
                             ) : null}
                         </div>
-                    </div>
+                        </div>
+                    ) : (
+                        <div className="rounded border border-dashed border-amber-700 bg-amber-950/20 p-4 text-xs text-amber-200">
+                            Set Preview server URL first (for example <code>http://100.90.148.71:8091</code>), then click Show Live Preview.
+                        </div>
+                    )
                 ) : (
                     <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
                         Live preview is paused to avoid multiple stream consumers.


### PR DESCRIPTION
### Motivation

- Avoid auto-constructing a preview host from the client `window` and prevent invalid stream requests when no preview URL is configured.
- Surface a server-provided `preview_url` from the setup wizard so users don’t have to manually paste it every time.
- Provide clearer UI messaging when the preview URL is not set and avoid multiple stream consumers.

### Description

- IntegrationCheckPanel: import `apiFetch`, stop auto-generating a host-based default in the browser, add an effect to fetch `/api/setup/wizard` and populate the preview URL from `config.preview_url` when available, and only build `stream.mjpg` URL when a normalized base URL exists; update rendering to show an instructional placeholder if no preview URL is set.
- VisionPanel: stop auto-generating a host-based default in the browser, make the `stream.mjpg` URL conditional on a normalized base URL, update the Show/Hide Live Preview toggle to call `refreshWizardContext` before enabling the preview, and show an instructional placeholder with an example URL when the preview is unset.
- Shared behavior: add `normalizePreviewBaseUrl` handling and defensive `streamUrl` construction in both panels, and improved UX for embedded camera preview state (paused/disabled/no-URL messages).

### Testing

- Ran TypeScript typecheck and built the frontend locally; the project compiled successfully with the changes.
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6e520b0c832394fe889a17dd9591)