### PR TITLE
Improve preview handling in vision panels and add TypeScript parser guard to run script

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/IntegrationCheckPanel.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useRaceContext } from '@/stores/raceStore'
+import { apiFetch } from '@/lib/utils'
 
 function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
         return 'http://localhost:8091'
     }
-    return `${window.location.protocol}//${window.location.hostname}:8091`
+    return ''
 }
 
 function normalizePreviewBaseUrl(value: string): string {
@@ -29,12 +30,33 @@ function extractObjectNumber(objectId: string): string {
     return match ? match[1] : objectId
 }
 
+function connectionClass(ok: boolean): string {
+    return ok ? 'text-emerald-300' : 'text-amber-300'
+}
+
+function resolveWizardPreviewUrl(previewUrl: string): string {
+    const raw = previewUrl.trim()
+    if (!raw) return ''
+    try {
+        const parsed = new URL(raw)
+        const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '')
+        if (host === 'localhost' || host === '127.0.0.1' || host === '::1') {
+            if (typeof window !== 'undefined' && window.location.hostname) {
+                return `${window.location.protocol}//${window.location.hostname}:${parsed.port || '8091'}`
+            }
+        }
+        return `${parsed.protocol}//${parsed.host}`
+    } catch {
+        return raw
+    }
+}
+
 export default function IntegrationCheckPanel() {
     const { connectionStatus, recentVisionObjects, recentObjectDetections, liveRace } = useRaceContext()
     const [previewBaseUrl, setPreviewBaseUrl] = useState(defaultPreviewBaseUrl)
     const [previewEnabled, setPreviewEnabled] = useState(true)
     const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
-    const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
+    const streamUrl = normalizedBaseUrl ? `${normalizedBaseUrl}/stream.mjpg` : ''
     const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
     const lastVisionSeenAt = recentVisionObjects[0]?.seenAt || 0
     const secondsSinceVision = lastVisionSeenAt ? Math.max(0, Math.floor((statusNowMs - lastVisionSeenAt) / 1000)) : null
@@ -76,6 +98,60 @@ export default function IntegrationCheckPanel() {
                 .filter(topic => Boolean(topic)),
         ),
     )
+    const previewContent = (() => {
+        if (!previewEnabled) {
+            return (
+                <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
+                    Embedded camera preview is paused.
+                </div>
+            )
+        }
+        if (!normalizedBaseUrl) {
+            return (
+                <div className="rounded border border-dashed border-amber-700 bg-amber-950/20 p-4 text-xs text-amber-200">
+                    Set Preview server URL first, then show embedded camera.
+                </div>
+            )
+        }
+        return (
+            <div className="relative">
+                    <img
+                        src={streamUrl}
+                        alt="Embedded camera stream"
+                        className="w-full rounded border border-slate-700 bg-black"
+                    />
+                    <div className="pointer-events-none absolute inset-0">
+                        {drawableVisionObjects.map(({ item, leftPct, topPct, widthPct, heightPct }) => (
+                            <div
+                                key={`${item.objectId}-${item.seenAt}`}
+                                className="absolute border border-emerald-400/90"
+                                style={{ left: `${leftPct}%`, top: `${topPct}%`, width: `${widthPct}%`, height: `${heightPct}%` }}
+                            >
+                                <span className="absolute -top-4 right-0 rounded bg-black/75 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-200">
+                                    {extractObjectNumber(item.objectId)}
+                                </span>
+                            </div>
+                        ))}
+                        {hasRecentVisionObjects && !hasDrawableVisionObjects ? (
+                            <div className="absolute left-2 top-2 max-w-[70%] space-y-1">
+                                {recentVisionObjects.slice(0, 6).map((item) => (
+                                    <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
+                                        {extractObjectNumber(item.objectId)}
+                                        {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
+                                        {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
+                                    </p>
+                                ))}
+                            </div>
+                        ) : null}
+                        {!hasRecentVisionObjects ? (
+                            <p className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
+                                No object IDs yet. Move an object through frame and verify ROS2 topics below.
+                            </p>
+                        ) : null}
+                    </div>
+            </div>
+        )
+    })()
 
     useEffect(() => {
         const timer = window.setInterval(() => {
@@ -84,6 +160,24 @@ export default function IntegrationCheckPanel() {
         return () => {
             window.clearInterval(timer)
         }
+    }, [])
+
+    useEffect(() => {
+        const loadPreviewUrl = async () => {
+            try {
+                const response = await apiFetch('/api/setup/wizard')
+                if (!response.ok) return
+                const payload = await response.json() as { config?: { preview_url?: unknown } }
+                const previewUrl = resolveWizardPreviewUrl(String(payload?.config?.preview_url || ''))
+                if (previewUrl) {
+                    setPreviewBaseUrl(previewUrl)
+                }
+            } catch {
+                // keep fallback URL when setup payload cannot be loaded
+            }
+        }
+
+        void loadPreviewUrl()
     }, [])
 
     const topicListCommand = 'ros2 topic list -t | rg -n "Image|CompressedImage|camera|video"'
@@ -169,31 +263,31 @@ export default function IntegrationCheckPanel() {
                 <ul className="space-y-2 text-sm">
                     <li>
                         UI websocket:{' '}
-                        <span className={connectionStatus === 'connected' ? 'text-emerald-300' : 'text-amber-300'}>
+                        <span className={connectionClass(connectionStatus === 'connected')}>
                             {connectionStatus}
                         </span>
                     </li>
                     <li>
                         Vision object stream:{' '}
-                        <span className={secondsSinceVision !== null && secondsSinceVision <= 3 ? 'text-emerald-300' : 'text-amber-300'}>
+                        <span className={connectionClass(secondsSinceVision !== null && secondsSinceVision <= 3)}>
                             {secondsSinceVision === null ? 'waiting for objects' : `${secondsSinceVision}s since last object`}
                         </span>
                     </li>
                     <li>
                         Auto-detected camera topics:{' '}
-                        <span className={autoDetectedTopics.length > 0 ? 'text-emerald-300' : 'text-amber-300'}>
+                        <span className={connectionClass(autoDetectedTopics.length > 0)}>
                             {autoDetectedTopics.length > 0 ? autoDetectedTopics.join(', ') : 'none detected yet'}
                         </span>
                     </li>
                     <li>
                         Detection events in memory:{' '}
-                        <span className={recentObjectDetections.length > 0 ? 'text-emerald-300' : 'text-amber-300'}>
+                        <span className={connectionClass(recentObjectDetections.length > 0)}>
                             {recentObjectDetections.length}
                         </span>
                     </li>
                     <li>
                         Tracking health:{' '}
-                        <span className={visionIsFresh && recentObjectDetections.length > 0 ? 'text-emerald-300' : 'text-amber-300'}>
+                        <span className={connectionClass(visionIsFresh && recentObjectDetections.length > 0)}>
                             {visionIsFresh && recentObjectDetections.length > 0 ? 'active detections' : 'camera up but no confirmed detections yet'}
                         </span>
                     </li>
@@ -224,48 +318,7 @@ export default function IntegrationCheckPanel() {
                         placeholder="http://192.168.1.134:8091"
                     />
                 </label>
-                {previewEnabled ? (
-                    <div className="relative">
-                        <img
-                            src={streamUrl}
-                            alt="Embedded camera stream"
-                            className="w-full rounded border border-slate-700 bg-black"
-                        />
-                        <div className="pointer-events-none absolute inset-0">
-                            {drawableVisionObjects.map(({ item, leftPct, topPct, widthPct, heightPct }) => (
-                                <div
-                                    key={`${item.objectId}-${item.seenAt}`}
-                                    className="absolute border border-emerald-400/90"
-                                    style={{ left: `${leftPct}%`, top: `${topPct}%`, width: `${widthPct}%`, height: `${heightPct}%` }}
-                                >
-                                    <span className="absolute -top-4 right-0 rounded bg-black/75 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-200">
-                                        {extractObjectNumber(item.objectId)}
-                                    </span>
-                                </div>
-                            ))}
-                            {hasRecentVisionObjects && !hasDrawableVisionObjects ? (
-                                <div className="absolute left-2 top-2 max-w-[70%] space-y-1">
-                                    {recentVisionObjects.slice(0, 6).map((item) => (
-                                        <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
-                                            {extractObjectNumber(item.objectId)}
-                                            {item.position ? ` (${item.position.x.toFixed(1)}, ${item.position.y.toFixed(1)})` : ''}
-                                            {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
-                                        </p>
-                                    ))}
-                                </div>
-                            ) : null}
-                            {!hasRecentVisionObjects ? (
-                                <p className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
-                                    No object IDs yet. Move an object through frame and verify ROS2 topics below.
-                                </p>
-                            ) : null}
-                        </div>
-                    </div>
-                ) : (
-                    <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
-                        Embedded camera preview is paused.
-                    </div>
-                )}
+                {previewContent}
                 <div className="rounded border border-slate-700 bg-slate-950/60 p-3 text-xs text-slate-200 space-y-1">
                     <p className="font-semibold text-slate-100">If tracking still does not start, check this in order:</p>
                     <p>• Camera stream loads in this panel and updates continuously.</p>

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -6,7 +6,7 @@ function defaultPreviewBaseUrl(): string {
     if (typeof window === 'undefined') {
         return 'http://localhost:8091'
     }
-    return `http://${window.location.hostname}:8091`
+    return ''
 }
 
 
@@ -18,6 +18,14 @@ function extractObjectNumber(objectId: string): string {
 function parseNumber(value: unknown): number | null {
     const n = Number(value)
     return Number.isFinite(n) ? n : null
+}
+
+function objectIdClass(mapped: boolean): string {
+    return mapped ? 'text-emerald-300' : 'text-amber-300'
+}
+
+function trackingStatusClass(enabled: boolean): string {
+    return enabled ? 'text-emerald-400' : 'text-amber-300'
 }
 function normalizePreviewBaseUrl(value: string): string {
     const raw = value.trim()
@@ -42,7 +50,7 @@ export default function VisionPanel() {
     const [statusNowMs, setStatusNowMs] = useState(() => Date.now())
 
     const normalizedBaseUrl = useMemo(() => normalizePreviewBaseUrl(previewBaseUrl), [previewBaseUrl])
-    const streamUrl = `${normalizedBaseUrl}/stream.mjpg`
+    const streamUrl = normalizedBaseUrl ? `${normalizedBaseUrl}/stream.mjpg` : ''
 
     const ensureSelectedTrack = async () => {
         const existingTrackId = getSelectedTrackId()
@@ -170,6 +178,11 @@ export default function VisionPanel() {
 
     const trackingEnabled = Boolean(raceContext.tracking_enabled)
     const logs = Array.isArray(raceContext.log_stream) ? raceContext.log_stream : []
+    const detectionEmptyMessage = trackingEnabled
+        ? 'No detections yet. Start tracking and assign object IDs in Settings.'
+        : 'Start tracking to show object IDs and annotation events.'
+    const trackingStatusText = trackingEnabled ? 'Enabled' : 'Disabled'
+    const statusClassName = statusError ? 'text-red-400' : 'text-emerald-400'
     const racerAssignments = getSelectedTrackId() ? getTrackRacerAssignments(getSelectedTrackId()) : {}
     const visibleVisionObjects = trackingEnabled ? recentVisionObjects : []
     const hasRecentVisionObjects = visibleVisionObjects.length > 0
@@ -201,6 +214,63 @@ export default function VisionPanel() {
     const hasDrawableVisionObjects = drawableVisionObjects.length > 0
     const latestVisionObject = visibleVisionObjects[0]
     const visionFresh = Boolean(latestVisionObject && statusNowMs - latestVisionObject.seenAt <= 3000)
+    const previewContent = (() => {
+        if (!previewEnabled) {
+            return (
+                <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
+                    Live preview is paused to avoid multiple stream consumers.
+                </div>
+            )
+        }
+        if (!normalizedBaseUrl) {
+            return (
+                <div className="rounded border border-dashed border-amber-700 bg-amber-950/20 p-4 text-xs text-amber-200">
+                    Set Preview server URL first (for example <code>http://100.90.148.71:8091</code>), then click Show Live Preview.
+                </div>
+            )
+        }
+        return (
+            <div className="relative">
+                    <img
+                        src={streamUrl}
+                        alt="Live camera preview"
+                        className="w-full rounded border border-slate-700 bg-black"
+                    />
+                    <div className="pointer-events-none absolute inset-0">
+                        {drawableVisionObjects.map(({ item, leftPct, topPct, widthPct, heightPct }) => {
+                            return (
+                                <div
+                                    key={`${item.objectId}-${item.seenAt}`}
+                                    className="absolute border border-emerald-400/90"
+                                    style={{ left: `${leftPct}%`, top: `${topPct}%`, width: `${widthPct}%`, height: `${heightPct}%` }}
+                                >
+                                    <span className="absolute -top-4 right-0 rounded bg-black/75 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-200">
+                                        {extractObjectNumber(item.objectId)}
+                                    </span>
+                                </div>
+                            )
+                        })}
+                        {hasRecentVisionObjects && !hasDrawableVisionObjects ? (
+                            <div className="absolute left-2 top-2 max-w-[65%] space-y-1">
+                                {visibleVisionObjects.slice(0, 8).map((item) => (
+                                    <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
+                                        {extractObjectNumber(item.objectId)}
+                                        {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
+                                    </p>
+                                ))}
+                            </div>
+                        ) : null}
+                        {!hasRecentVisionObjects ? (
+                            <p className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
+                                {trackingEnabled
+                                    ? 'No tracking objects yet. Move racers through the frame.'
+                                    : 'Tracking overlay is hidden until Start Tracking is pressed.'}
+                            </p>
+                        ) : null}
+                    </div>
+            </div>
+        )
+    })()
 
     const toggleTracking = async (start: boolean) => {
         const raceId = String(raceContext.race_id || '')
@@ -305,7 +375,12 @@ export default function VisionPanel() {
                     <button
                         type="button"
                         className="rounded bg-slate-700 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-600"
-                        onClick={() => setPreviewEnabled(prev => !prev)}
+                        onClick={() => {
+                            if (!previewEnabled && !previewBaseUrl.trim()) {
+                                void refreshWizardContext()
+                            }
+                            setPreviewEnabled(prev => !prev)
+                        }}
                     >
                         {previewEnabled ? 'Hide Live Preview' : 'Show Live Preview'}
                     </button>
@@ -321,51 +396,7 @@ export default function VisionPanel() {
                         If your ROS2 node is running, this can still show waiting when camera frames are not on the expected topic, no objects are visible yet, or confidence filtering drops detections.
                     </p>
                 </div>
-                {previewEnabled ? (
-                    <div className="relative">
-                        <img
-                            src={streamUrl}
-                            alt="Live camera preview"
-                            className="w-full rounded border border-slate-700 bg-black"
-                        />
-                        <div className="pointer-events-none absolute inset-0">
-                            {drawableVisionObjects.map(({ item, leftPct, topPct, widthPct, heightPct }) => {
-                                return (
-                                    <div
-                                        key={`${item.objectId}-${item.seenAt}`}
-                                        className="absolute border border-emerald-400/90"
-                                        style={{ left: `${leftPct}%`, top: `${topPct}%`, width: `${widthPct}%`, height: `${heightPct}%` }}
-                                    >
-                                        <span className="absolute -top-4 right-0 rounded bg-black/75 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-200">
-                                            {extractObjectNumber(item.objectId)}
-                                        </span>
-                                    </div>
-                                )
-                            })}
-                            {hasRecentVisionObjects && !hasDrawableVisionObjects ? (
-                                <div className="absolute left-2 top-2 max-w-[65%] space-y-1">
-                                    {visibleVisionObjects.slice(0, 8).map((item) => (
-                                        <p key={`${item.objectId}-${item.seenAt}`} className="rounded bg-black/70 px-2 py-1 text-[11px] text-emerald-200">
-                                            {extractObjectNumber(item.objectId)}
-                                            {item.cameraTopic ? ` · ${item.cameraTopic}` : ''}
-                                        </p>
-                                    ))}
-                                </div>
-                            ) : null}
-                            {!hasRecentVisionObjects ? (
-                                <p className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[11px] text-amber-200">
-                                    {trackingEnabled
-                                        ? 'No tracking objects yet. Move racers through the frame.'
-                                        : 'Tracking overlay is hidden until Start Tracking is pressed.'}
-                                </p>
-                            ) : null}
-                        </div>
-                    </div>
-                ) : (
-                    <div className="rounded border border-dashed border-slate-700 bg-black/30 p-4 text-xs text-[var(--color-text-secondary)]">
-                        Live preview is paused to avoid multiple stream consumers.
-                    </div>
-                )}
+                {previewContent}
 
                 <form onSubmit={onCapture} className="flex flex-wrap items-center gap-2">
                     <button
@@ -392,17 +423,15 @@ export default function VisionPanel() {
                 </form>
 
                 <p className="text-xs text-[var(--color-text-secondary)]">
-                    Tracking status: <span className={trackingEnabled ? 'text-emerald-400' : 'text-amber-300'}>{trackingEnabled ? 'Enabled' : 'Disabled'}</span>
+                    Tracking status: <span className={trackingStatusClass(trackingEnabled)}>{trackingStatusText}</span>
                 </p>
 
-                {statusMessage ? (
-                    <p className={`text-sm ${statusError ? 'text-red-400' : 'text-emerald-400'}`}>{statusMessage}</p>
-                ) : null}
+                {statusMessage && <p className={`text-sm ${statusClassName}`}>{statusMessage}</p>}
             </div>
 
             <div className="race-card p-4 space-y-2">
                 <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Recent object detections</h3>
-                {(!trackingEnabled || recentObjectDetections.length === 0) ? <p className="text-xs text-[var(--color-text-secondary)]">{trackingEnabled ? 'No detections yet. Start tracking and assign object IDs in Settings.' : 'Start tracking to show object IDs and annotation events.'}</p> : null}
+                {(!trackingEnabled || recentObjectDetections.length === 0) && <p className="text-xs text-[var(--color-text-secondary)]">{detectionEmptyMessage}</p>}
                 {trackingEnabled && recentObjectDetections.length > 0 ? (
                     <div className="max-h-52 overflow-auto rounded border border-slate-700 bg-slate-950 p-2 text-xs text-slate-200 space-y-1">
                         {recentObjectDetections.map(item => {
@@ -411,7 +440,7 @@ export default function VisionPanel() {
                             const mapped = Boolean(racer && assignedId && assignedId === item.objectId)
                             return (
                                 <p key={`${item.objectId}-${item.seenAt}`}>
-                                    <span className={mapped ? 'text-emerald-300' : 'text-amber-300'}>{item.objectId}</span>
+                                    <span className={objectIdClass(mapped)}>{item.objectId}</span>
                                     {' → '}
                                     <span>{racer?.name || 'unmapped racer'}</span>
                                 </p>
@@ -423,7 +452,7 @@ export default function VisionPanel() {
 
             <div className="race-card p-4 space-y-2">
                 <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">Lap / Tracking Logs</h3>
-                {logs.length === 0 ? <p className="text-xs text-[var(--color-text-secondary)]">No logs yet. Start tracking to populate this feed.</p> : null}
+                {logs.length === 0 && <p className="text-xs text-[var(--color-text-secondary)]">No logs yet. Start tracking to populate this feed.</p>}
                 <div className="max-h-56 overflow-auto rounded border border-slate-700 bg-slate-950 p-2 text-xs text-slate-200">
                     {logs.map((line, index) => (
                         <p key={`${line}-${index}`}>{String(line)}</p>

--- a/scripts/run_race_master_pro.sh
+++ b/scripts/run_race_master_pro.sh
@@ -149,7 +149,88 @@ fi
 
 apply_defaults
 
+print_source_revision_info() {
+  echo "[run_race_master_pro] guard_version=2026-05-21b"
+  echo "[run_race_master_pro] script_path=$SCRIPT_DIR/run_race_master_pro.sh"
+  echo "[run_race_master_pro] repo_root=$REPO_ROOT"
+  if command -v git >/dev/null 2>&1; then
+    local head_sha
+    head_sha="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    if [[ -n "$head_sha" ]]; then
+      echo "[run_race_master_pro] git_head=$head_sha"
+    fi
+  fi
+}
+
+frontend_parser_guard() {
+  local integration_file="$FRONTEND_ROOT/src/components/vision/IntegrationCheckPanel.tsx"
+  local vision_file="$FRONTEND_ROOT/src/components/vision/VisionPanel.tsx"
+  local ts_parser="$FRONTEND_ROOT/node_modules/typescript/lib/typescript.js"
+
+  if [[ ! -f "$integration_file" || ! -f "$vision_file" ]]; then
+    return 0
+  fi
+
+  if [[ ! -f "$ts_parser" ]]; then
+    echo "[run_race_master_pro] warning: TypeScript parser not found at $ts_parser"
+    echo "[run_race_master_pro] warning: skipping frontend parser guard (run 'npm install' in $FRONTEND_ROOT to enable it)"
+    return 0
+  fi
+
+  if ! node - "$ts_parser" "$integration_file" "$vision_file" <<'JS'
+const fs = require('fs')
+const ts = require(process.argv[2])
+const files = process.argv.slice(3)
+let failed = false
+
+for (const file of files) {
+  const source = fs.readFileSync(file, 'utf8')
+  const result = ts.transpileModule(source, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: file,
+    reportDiagnostics: true,
+  })
+  const diagnostics = result.diagnostics || []
+  const parseDiagnostics = diagnostics.filter((d) =>
+    d.category === ts.DiagnosticCategory.Error,
+  )
+
+  if (parseDiagnostics.length > 0) {
+    failed = true
+    console.error(`[run_race_master_pro] parser errors in ${file}:`)
+    const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.ES2020, true, ts.ScriptKind.TSX)
+    for (const diagnostic of parseDiagnostics) {
+      const text = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+      const start = typeof diagnostic.start === 'number' ? diagnostic.start : 0
+      const pos = sourceFile.getLineAndCharacterOfPosition(start)
+      const lineNo = pos.line + 1
+      const colNo = pos.character + 1
+      const lineText = source.split('\n')[pos.line] || ''
+      console.error(`  TS${diagnostic.code} (${lineNo}:${colNo}): ${text}`)
+      if (lineText.trim().length > 0) {
+        console.error(`    ${lineText}`)
+      }
+    }
+  }
+}
+
+process.exit(failed ? 1 : 0)
+JS
+  then
+    echo "Aborting startup due to frontend parser errors in vision panels."
+    echo "Tip: if output does not include 'guard_version=' and 'TS#### (line:col)', your run script is stale."
+    echo "      Refresh this checkout (git fetch && git pull) and rerun: ./scripts/run_race_master_pro.sh --doctor"
+    echo "      Expected current signature: guard_version=2026-05-21b"
+    exit 1
+  fi
+}
+
 if [[ "$DOCTOR_MODE" == "true" ]]; then
+  print_source_revision_info
+  frontend_parser_guard
   echo "[run_race_master_pro] doctor: app_root=$APP_ROOT"
   echo "[run_race_master_pro] doctor: python=$PYTHON_BIN"
   echo "[run_race_master_pro] doctor: npm=$(command -v npm || echo missing)"
@@ -157,6 +238,9 @@ if [[ "$DOCTOR_MODE" == "true" ]]; then
   echo "[run_race_master_pro] doctor: api_port=$API_PORT ui_port=$UI_PORT host=$HOST"
   exit 0
 fi
+
+print_source_revision_info
+frontend_parser_guard
 
 if [[ "$MODE" == "ros2" ]]; then
   if [[ -z "$ROS_SETUP" ]]; then


### PR DESCRIPTION
### Motivation
- Make embedded/live camera preview more robust and user-friendly by normalizing/auto-resolving preview URLs and showing clearer UI states when the preview is disabled or unavailable.
- Centralize small view helpers (CSS class helpers and ID extraction) to reduce duplication and improve readability.
- Fail early on startup if key frontend TSX files contain parse errors to avoid confusing runtime failures.

### Description
- IntegrationCheckPanel: import `apiFetch`, add `connectionClass` and `resolveWizardPreviewUrl`, change `defaultPreviewBaseUrl` for browser to an empty default, use `normalizePreviewBaseUrl` defensively, auto-load preview URL from `/api/setup/wizard` in an effect, and consolidate the preview JSX into a `previewContent` renderer that overlays object badges and status messages.
- VisionPanel: change `defaultPreviewBaseUrl` to return empty in browser, add `objectIdClass` and `trackingStatusClass`, render preview via `previewContent`, avoid creating `streamUrl` when base URL is empty, refresh wizard context before enabling preview when no URL is set, and simplify status/detection message rendering.
- Scripts: extend `scripts/run_race_master_pro.sh` with `print_source_revision_info` and `frontend_parser_guard` that invokes the TypeScript parser to transpile/diagnose `IntegrationCheckPanel.tsx` and `VisionPanel.tsx`, integrate the guard into `--doctor` and normal startup flows, and abort startup with helpful hints if parse errors are detected.

### Testing
- Ran the script doctor check with `./scripts/run_race_master_pro.sh --doctor`, which printed revision info and executed the frontend parser guard successfully (exited 0).
- Exercised the parser guard path (Node + TypeScript transpile) against the modified `IntegrationCheckPanel.tsx` and `VisionPanel.tsx`, which reported no parse errors during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6e520b0c832394fe889a17dd9591)