### PR TITLE
Update preview vs tracking docs and UI to use camera_ros_publisher + perception_node

### DIFF
--- a/ros_ws/src/j5_perception/race-master-pro/README.md
+++ b/ros_ws/src/j5_perception/race-master-pro/README.md
@@ -374,8 +374,9 @@ python3 scripts/pi_preflight.py \
 Then open `http://<pi-ip>:8091/` from another device. Use **Capture Track Photo**
 to write the snapshot to `track_snapshot.jpg` on the Pi.
 
-If you need a lightweight ROS image publisher that also serves `/stream.mjpg`
-for the Integration/Computer Vision tabs, run:
+If you need preview + tracking at the same time, use a single camera owner (`camera_ros_publisher.py`) and let the perception node subscribe to `/camera/cam1/image_raw`.
+
+Run the publisher + preview stream:
 
 ```bash
 python3 scripts/camera_ros_publisher.py \
@@ -386,8 +387,20 @@ python3 scripts/camera_ros_publisher.py \
   --serve-preview --preview-host 0.0.0.0 --preview-port 8091
 ```
 
-This is useful when `usb_cam` is unavailable in the current source-built
-environment.
+Then start the perception node in another shell (same host):
+
+```bash
+python -m racetracker_perception.perception_node   --ros-args   -p camera_topics:=[/camera/cam1/image_raw]   -p auto_discover_camera_topics:=true   -p confidence_threshold:=0.25
+```
+
+Calibration/tuning notes:
+- `scripts/pi_preflight.py` is **preview + capture only**. It does not run object tracking.
+- For race tracking and lap counting, run `camera_ros_publisher.py` + `racetracker_perception.perception_node`.
+- Start at `--width 960 --height 540 --fps 15` to reduce motion blur + ID switching.
+- Keep `confidence_threshold` around `0.25-0.35` and tune upward only if false positives are excessive.
+- Use only one camera owner process for `/dev/video0` at a time to avoid blank preview or camera-open failures.
+
+This is useful when `usb_cam` is unavailable in the current source-built environment.
 
 You can also use Race Manager Pro UI from another machine at
 `http://<pi-ip>:5173` -> **Computer Vision** tab:

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -351,17 +351,18 @@ export default function VisionPanel() {
                 <div className="rounded border border-cyan-900/70 bg-cyan-950/30 p-3 text-xs text-cyan-100 space-y-2">
                     <p className="font-semibold text-cyan-200">Tracking bring-up quick start</p>
                     <p>Run these commands on the Pi / perception host before pressing <strong>Start Tracking</strong>:</p>
-                    <p><strong>1) Camera preview server</strong></p>
+                    <p><strong>1) Preview-only setup/capture (no tracking)</strong></p>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
                         python3 scripts/pi_preflight.py --camera-source /dev/video0 --capture-file track_snapshot.jpg --serve-preview --preview-host 0.0.0.0 --preview-port 8091 --preview-fps 15
                     </code>
-                    <p><strong>2) Perception node (choose one)</strong></p>
+                    <p><strong>2) Tracking + preview during race (recommended)</strong></p>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
-                        python -m perception.standalone.standalone_runner --camera-source /dev/video0 --camera-id cam1
+                        python3 scripts/camera_ros_publisher.py --device /dev/video0 --topic /camera/cam1/image_raw --width 960 --height 540 --fps 15 --pixel-format MJPG --serve-preview --preview-host 0.0.0.0 --preview-port 8091
                     </code>
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
-                        ros2 run racetracker_perception perception_node
+                        python -m racetracker_perception.perception_node --ros-args -p camera_topics:=[/camera/cam1/image_raw] -p auto_discover_camera_topics:=true -p confidence_threshold:=0.25
                     </code>
+                    <p className="text-xs text-cyan-100/90">Use <code>--confidence-threshold</code> around <strong>0.25-0.35</strong>. Lower values reduce missed moving cars but can add false positives.</p>
                     <p>Then in this tab: <strong>Show Live Preview</strong> → <strong>Capture Track Photo</strong> → <strong>Start Tracking</strong>.</p>
                 </div>
                 <label className="block text-sm text-[var(--color-text-secondary)]">

--- a/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
+++ b/ros_ws/src/j5_perception/race-master-pro/frontend/src/components/vision/VisionPanel.tsx
@@ -362,7 +362,7 @@ export default function VisionPanel() {
                     <code className="block overflow-x-auto rounded bg-black/40 p-2 text-xs text-emerald-300">
                         python -m racetracker_perception.perception_node --ros-args -p camera_topics:=[/camera/cam1/image_raw] -p auto_discover_camera_topics:=true -p confidence_threshold:=0.25
                     </code>
-                    <p className="text-xs text-cyan-100/90">Use <code>--confidence-threshold</code> around <strong>0.25-0.35</strong>. Lower values reduce missed moving cars but can add false positives.</p>
+                    <p className="text-xs text-cyan-100/90">Use ROS param <code>-p confidence_threshold:=...</code> around <strong>0.25-0.35</strong>. Lower values reduce missed moving cars but can add false positives.</p>
                     <p>Then in this tab: <strong>Show Live Preview</strong> → <strong>Capture Track Photo</strong> → <strong>Start Tracking</strong>.</p>
                 </div>
                 <label className="block text-sm text-[var(--color-text-secondary)]">


### PR DESCRIPTION
### Motivation

- Clarify the distinction between preview-only capture and full tracking so operators run the correct processes on the Pi or perception host.
- Recommend a single camera owner process to avoid camera-open conflicts and reduce user confusion when `usb_cam` is unavailable.
- Provide practical calibration/tuning guidance (resolution/fps and confidence threshold) to improve tracking quality and reduce ID switching.

### Description

- Rewrote README sections to separate `pi_preflight.py` (preview + capture only) from the full tracking flow and added calibration/tuning notes; added recommendation to use one camera owner process for `/dev/video0` at a time.
- Replaced the previous lightweight ROS publisher guidance with an example using `python3 scripts/camera_ros_publisher.py` to serve a preview stream and recommended parameters `--width 960 --height 540 --fps 15` and `--pixel-format MJPG`.
- Added the recommended perception invocation using `python -m racetracker_perception.perception_node --ros-args -p camera_topics:=[/camera/cam1/image_raw] -p auto_discover_camera_topics:=true -p confidence_threshold:=0.25` and notes to tune `confidence_threshold` around `0.25-0.35`.
- Updated the frontend `VisionPanel.tsx` UI text and code snippets to reflect the new preview vs tracking workflow, updated commands to `camera_ros_publisher.py` and the `racetracker_perception.perception_node`, and added a short hint about the `--confidence-threshold` recommendation.

### Testing

- No automated tests were run for this documentation and UI text update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109306e0c08323af404e2927d4d96b)